### PR TITLE
Improve pokefuta map discovery panels

### DIFF
--- a/apps/web/assets/pokefuta-map.css
+++ b/apps/web/assets/pokefuta-map.css
@@ -32,6 +32,10 @@ body.pokefuta-map-page {
   color: #2b2722;
 }
 
+.pokefuta-map-page .leaflet-top.leaflet-left {
+  top: 124px;
+}
+
 .pokefuta-map-page .map-hero-card {
   position: absolute;
   z-index: 800;
@@ -50,7 +54,6 @@ body.pokefuta-map-page {
 
 .pokefuta-map-page .map-hero-card h1 {
   margin: 0;
-  max-width: 12em;
   font-size: 1.72rem;
   line-height: 1.2;
   letter-spacing: 0;
@@ -61,84 +64,19 @@ body.pokefuta-map-page {
   color: #1f1b18;
 }
 
-.pokefuta-map-page .map-hero-card h1::after {
-  content: "";
-  display: inline-block;
-  width: 52px;
-  height: 52px;
-  margin-left: 8px;
-  vertical-align: -14px;
-  border-radius: 50%;
-  background: url("./icon-pin.svg") center / 36px 36px no-repeat rgba(126, 107, 169, .12);
-  box-shadow: inset 0 0 0 1px rgba(126, 107, 169, .18);
-}
-
 .pokefuta-map-page .map-hero-card p {
-  margin: 12px 0 0;
-  max-width: 18.5em;
+  margin: 10px 0 0;
   color: #3f3730;
   font-size: .94rem;
-  line-height: 1.65;
+  line-height: 1.55;
   font-weight: 650;
 }
 
-.pokefuta-map-page .locate-cta {
-  position: absolute;
-  z-index: 850;
-  right: 16px;
-  bottom: calc(26px + env(safe-area-inset-bottom));
-  min-height: 50px;
-  padding: 0 18px;
-  border: 0;
-  border-radius: 999px;
-  background: linear-gradient(135deg, #7e5bb8, #6b4aa2);
-  color: #fff;
-  box-shadow: 0 12px 26px rgba(76, 45, 130, .32);
-  font: inherit;
-  font-size: .9rem;
+.pokefuta-map-page .map-hero-card .map-hero-meta {
+  margin-top: 8px;
+  color: #2b213a;
+  font-size: .86rem;
   font-weight: 900;
-  cursor: pointer;
-}
-
-.pokefuta-map-page .locate-cta::before {
-  content: "";
-  display: inline-block;
-  width: 22px;
-  height: 22px;
-  margin-right: 8px;
-  vertical-align: -5px;
-  background: url("./icon-current-location.svg") center / contain no-repeat;
-  filter: brightness(0) invert(1);
-}
-
-.pokefuta-map-page .locate-cta:disabled {
-  opacity: .72;
-  cursor: progress;
-}
-
-.pokefuta-map-page .locate-status {
-  position: absolute;
-  z-index: 840;
-  right: 16px;
-  bottom: calc(84px + env(safe-area-inset-bottom));
-  max-width: min(320px, calc(100vw - 32px));
-  min-height: 0;
-  padding: 8px 11px;
-  border-radius: 12px;
-  background: rgba(255, 250, 238, .9);
-  color: #4d3f35;
-  box-shadow: 0 8px 22px rgba(56, 39, 17, .12);
-  font-size: .75rem;
-  font-weight: 700;
-  opacity: 0;
-  transform: translateY(6px);
-  transition: opacity .16s ease, transform .16s ease;
-  pointer-events: none;
-}
-
-.pokefuta-map-page .locate-status:not(:empty) {
-  opacity: 1;
-  transform: translateY(0);
 }
 
 .pokefuta-map-page #controls {
@@ -237,7 +175,7 @@ body.pokefuta-map-page {
 
 .pokefuta-map-page .sheet-action-grid {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 10px;
 }
 
@@ -281,6 +219,15 @@ body.pokefuta-map-page {
 .pokefuta-map-page .sheet-action-btn.active {
   background: #7654aa;
   color: #fff;
+}
+
+.pokefuta-map-page .sheet-action-btn.active img {
+  filter: brightness(0) invert(1);
+}
+
+.pokefuta-map-page .sheet-action-btn:disabled {
+  opacity: .72;
+  cursor: progress;
 }
 
 .pokefuta-map-page .selected-prefecture-badge {
@@ -518,32 +465,20 @@ body.pokefuta-map-page {
 }
 
 .pokefuta-map-page .nearby-results {
-  margin-top: 14px;
-  padding: 12px;
-  border-radius: 14px;
-  background: rgba(126, 107, 169, .1);
+  margin-top: 2px;
 }
 
-.pokefuta-map-page .nearby-results h4 {
-  margin: 0 0 10px;
-  color: #2b213a;
-  font-size: .9rem;
-  font-weight: 900;
+.pokefuta-map-page .nearby-results .section-title-row {
+  margin-top: 16px;
 }
 
 .pokefuta-map-page .nearby-list,
+.pokefuta-map-page .recent-added-list,
 .pokefuta-map-page .prefecture-spots-list {
   display: grid;
   gap: 8px;
 }
 
-.pokefuta-map-page .recent-added-list {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 7px;
-}
-
-.pokefuta-map-page .nearby-item,
 .pokefuta-map-page .prefecture-spot-item {
   display: flex;
   align-items: center;
@@ -559,43 +494,6 @@ body.pokefuta-map-page {
   cursor: pointer;
 }
 
-.pokefuta-map-page .recent-added-chip {
-  display: grid;
-  align-content: start;
-  gap: 4px;
-  min-width: 0;
-  min-height: 82px;
-  padding: 6px;
-  border: 1px solid rgba(116, 82, 38, .16);
-  border-radius: 13px;
-  background: #fffaf0;
-  color: #241f1a;
-  font: inherit;
-  text-align: left;
-  cursor: pointer;
-}
-
-.pokefuta-map-page .recent-added-code {
-  display: grid;
-  width: 30px;
-  min-height: 24px;
-  place-items: center;
-  border-radius: 7px;
-  background: linear-gradient(135deg, #7e6ba9, #6d55a3);
-  color: #fff;
-  font-size: .6rem;
-  font-weight: 950;
-}
-
-.pokefuta-map-page .recent-added-pref {
-  overflow: hidden;
-  color: #75685c;
-  font-size: .64rem;
-  font-weight: 850;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 .pokefuta-map-page .recent-added-empty {
   grid-column: 1 / -1;
   margin: 0;
@@ -609,7 +507,6 @@ body.pokefuta-map-page {
   text-align: center;
 }
 
-.pokefuta-map-page .nearby-item span,
 .pokefuta-map-page .prefecture-spot-copy {
   display: grid;
   min-width: 0;
@@ -656,12 +553,24 @@ body.pokefuta-map-page {
   line-height: 1;
 }
 
+.pokefuta-map-page .prefecture-spot-distance {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  padding: 5px 8px;
+  border-radius: 999px;
+  background: rgba(126, 107, 169, .12);
+  color: #6b4aa2;
+  font-size: .72rem;
+  font-weight: 950;
+  line-height: 1;
+}
+
 .pokefuta-map-page .prefecture-spot-new img {
   width: 12px;
   height: 12px;
 }
 
-.pokefuta-map-page .nearby-item strong,
 .pokefuta-map-page .prefecture-spot-item strong {
   overflow: hidden;
   font-size: .86rem;
@@ -670,27 +579,10 @@ body.pokefuta-map-page {
   white-space: nowrap;
 }
 
-.pokefuta-map-page .recent-added-chip strong {
-  overflow: hidden;
-  font-size: .66rem;
-  font-weight: 950;
-  line-height: 1.25;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.pokefuta-map-page .nearby-item small,
 .pokefuta-map-page .prefecture-spot-item small {
   color: #75685c;
   font-size: .74rem;
   font-weight: 750;
-}
-
-.pokefuta-map-page .nearby-item b {
-  flex: 0 0 auto;
-  color: #6b4aa2;
-  font-size: .9rem;
-  font-weight: 900;
 }
 
 .pokefuta-map-page .recent-added-panel {
@@ -699,14 +591,6 @@ body.pokefuta-map-page {
 
 .pokefuta-map-page .prefecture-spots-panel {
   margin-top: 2px;
-}
-
-.pokefuta-map-page .stats {
-  margin-top: 14px;
-  padding-top: 10px;
-  border-top: 1px solid rgba(81, 60, 32, .14);
-  color: #6e6258;
-  font-size: .72rem;
 }
 
 .pokefuta-map-page .data-links {
@@ -842,15 +726,18 @@ body.pokefuta-map-page {
   justify-content: center;
   min-height: 40px;
   padding: 0 10px;
+  border: 0;
   border-radius: 11px;
   background: #fff;
   color: #5b5046;
   text-decoration: none;
+  font: inherit;
   font-size: .76rem;
   font-weight: 950;
   line-height: 1.2;
   text-align: center;
   box-shadow: inset 0 0 0 1px rgba(116, 82, 38, .16);
+  cursor: pointer;
 }
 
 .pokefuta-map-page .travel-popup-action--primary {
@@ -915,22 +802,16 @@ body.pokefuta-map-page {
     padding: 20px 22px;
   }
 
+  .pokefuta-map-page .leaflet-top.leaflet-left {
+    top: 180px;
+  }
+
   .pokefuta-map-page .map-hero-card h1 {
     font-size: 1.46rem;
   }
 
   .pokefuta-map-page .map-hero-card p {
     font-size: .86rem;
-  }
-
-  .pokefuta-map-page .locate-cta {
-    right: 450px;
-    bottom: 30px;
-  }
-
-  .pokefuta-map-page .locate-status {
-    right: 450px;
-    bottom: 92px;
   }
 
   .pokefuta-map-page #controls {
@@ -963,10 +844,6 @@ body.pokefuta-map-page {
   .pokefuta-map-page .controls-content {
     max-height: calc(100dvh - 126px);
     padding-bottom: 18px;
-  }
-
-  .pokefuta-map-page .recent-added-list {
-    grid-template-columns: repeat(6, minmax(0, 1fr));
   }
 
   .pokefuta-map-page #prefecture-table-body {
@@ -1022,12 +899,8 @@ body.pokefuta-map-page {
     line-height: 1.32;
   }
 
-  .pokefuta-map-page .map-hero-card h1::after {
-    width: 34px;
-    height: 34px;
-    margin-left: 6px;
-    vertical-align: -10px;
-    background-size: 24px 24px;
+  .pokefuta-map-page .leaflet-top.leaflet-left {
+    top: 154px;
   }
 
   .pokefuta-map-page .map-hero-card p {
@@ -1047,14 +920,6 @@ body.pokefuta-map-page {
     width: min(92vw, 390px) !important;
   }
 
-  .pokefuta-map-page .locate-cta {
-    right: 14px;
-    bottom: calc(22px + env(safe-area-inset-bottom));
-    min-height: 48px;
-    padding: 0 15px;
-    font-size: .84rem;
-  }
-
   .pokefuta-map-page #controls {
     width: 100vw;
     max-width: none;
@@ -1072,23 +937,40 @@ body.pokefuta-map-page {
   }
 
   .pokefuta-map-page .prefecture-card-main {
-    grid-template-columns: 36px minmax(0, 1fr) auto;
-    gap: 8px;
-    padding: 10px;
+    grid-template-columns: 36px minmax(0, 1fr) minmax(0, auto) auto;
+    gap: 7px;
+    min-height: 48px;
+    padding: 8px 10px 6px;
   }
 
   .pokefuta-map-page .prefecture-card-meta {
-    grid-column: 2 / 4;
-    grid-row: 2;
-    justify-content: flex-start;
+    justify-content: flex-end;
+    gap: 5px;
+    font-size: .66rem;
+  }
+
+  .pokefuta-map-page .prefecture-new-badge {
+    min-height: 22px;
+    padding: 0 6px;
+    font-size: .62rem;
+  }
+
+  .pokefuta-map-page .prefecture-new-badge img {
+    width: 12px;
+    height: 12px;
+  }
+
+  .pokefuta-map-page .prefecture-site-link {
+    max-width: 7.8em;
   }
 
   .pokefuta-map-page .prefecture-card-thumb {
-    width: 48px;
-    height: 48px;
+    width: 42px;
+    height: 42px;
   }
 
   .pokefuta-map-page .prefecture-card-gallery {
-    padding: 0 10px 10px 54px;
+    gap: 6px;
+    padding: 0 10px 8px 54px;
   }
 }

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -175,10 +175,9 @@
     <div id="map"></div>
     <section class="map-hero-card" aria-labelledby="hero-title">
       <h1 id="hero-title">全国470枚のポケふたを探そう</h1>
-      <p>旅先や現在地の近くにあるポケふたを地図でチェック</p>
+      <p>旅行やお出かけのついでに、ご当地マンホール「ポケふた」を見つけよう</p>
+      <p class="map-hero-meta">📍 全国<span id="hero-city-count">0</span>の自治体に設置</p>
     </section>
-    <button type="button" id="locate-button" class="locate-cta" aria-describedby="locate-status">近くのポケふたを探す</button>
-    <div id="locate-status" class="locate-status" role="status" aria-live="polite"></div>
   </main>
 
   <div id="controls" class="bottom-sheet" role="complementary" aria-labelledby="page-title">
@@ -198,13 +197,25 @@
           <label class="sheet-action-btn sheet-action-btn--toggle" for="recent-toggle">
             <input type="checkbox" id="recent-toggle" />
             <img src="./assets/icon-fire.svg" alt="" aria-hidden="true">
-            最近追加を見る
+            新着ポケふた
           </label>
+          <button type="button" id="locate-button" class="sheet-action-btn">
+            <img src="./assets/icon-current-location.svg" alt="" aria-hidden="true">
+            近くのポケふた
+          </button>
         </div>
       </div>
       <section id="nearby-results" class="nearby-results" aria-live="polite" hidden>
-        <h4>近くのポケふた</h4>
+        <div class="section-title-row">
+          <h4>近くのポケふた</h4>
+        </div>
         <div id="nearby-list" class="nearby-list"></div>
+      </section>
+      <section id="recent-added-panel" class="recent-added-panel" aria-labelledby="recent-added-heading" hidden>
+        <div class="section-title-row">
+          <h4 id="recent-added-heading">新着ポケふた</h4>
+        </div>
+        <div id="recent-added-list" class="recent-added-list"></div>
       </section>
       <div id="prefecture-tab" class="tab-content active">
         <div id="selected-prefecture-badge" class="selected-prefecture-badge" style="display:none;">
@@ -217,28 +228,12 @@
           </div>
           <div id="prefecture-spots-list" class="prefecture-spots-list"></div>
         </section>
-        <section id="recent-added-panel" class="recent-added-panel" aria-labelledby="recent-added-heading" hidden>
-          <div class="section-title-row">
-            <h4 id="recent-added-heading">最近追加されたポケふた</h4>
-            <span>横並び</span>
-          </div>
-          <div id="recent-added-list" class="recent-added-list"></div>
-        </section>
-        <div id="prefecture-section-heading" class="section-title-row">
-          <h4 id="heading-pref-count">都道府県から探す</h4>
-          <span id="prefecture-total-label">470枚</span>
-        </div>
         <div id="prefecture-table-wrapper" class="prefecture-card-list" aria-describedby="pref-table-desc">
           <p id="pref-table-desc" class="sr-only">都道府県ごとのポケふた数と公式サイトリンク</p>
           <div id="prefecture-table-body"></div>
         </div>
       </div>
-      <div class="stats" role="status" aria-live="polite">
-        <div id="total-count">総数: <span>0</span></div>
-        <div id="visible-count">表示: <span>0</span></div>
-        <div id="city-count">市町村: <span>0</span></div>
-        <span id="recent-summary" class="sr-only"></span>
-      </div>
+      <span id="recent-summary" class="sr-only"></span>
     </div>
   </div>
   <!-- バナーを地図上オーバーレイとして配置 -->
@@ -309,6 +304,7 @@
     var currentTab = 'prefecture';
     var filterRecent = false; // recent 30 days filter
     var showPrefectureCards = true;
+    var showNearbyResults = false;
     var hasAddedAtField = false; // whether dataset has any date field
     var prefectureBounds = {};  // 都道府県ごとのbounding box（グローバルスコープ）
     var prefectureMarkerCounts = {};  // 都道府県ごとのマンホール数（グローバルスコープ）
@@ -415,6 +411,42 @@
       return safeId ? window.buildManholeCanonicalPath(safeId) : '';
     }
 
+    function getAbsoluteManholePageUrl(id) {
+      const path = getManholePageUrl(id);
+      return path ? new URL(path, window.location.origin).href : '';
+    }
+
+    async function shareManholeUrl(button) {
+      const url = button?.dataset.shareUrl;
+      if (!url) return;
+      const title = button.dataset.shareTitle || 'ポケふた';
+      if (navigator.share) {
+        try {
+          await navigator.share({ title, url });
+          return;
+        } catch (error) {
+          if (error?.name === 'AbortError') return;
+        }
+      }
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(url);
+        const originalText = button.textContent;
+        button.textContent = 'コピー済み';
+        window.setTimeout(() => {
+          button.textContent = originalText || '共有';
+        }, 1400);
+      }
+    }
+
+    document.addEventListener('click', event => {
+      const shareButton = event.target.closest('[data-share-url]');
+      if (!shareButton) return;
+      event.preventDefault();
+      shareManholeUrl(shareButton).catch(error => {
+        console.warn('URLの共有に失敗しました', error);
+      });
+    });
+
     function formatPhotoDate(rawDate) {
       if (!rawDate) return '';
       const date = new Date(rawDate);
@@ -448,6 +480,8 @@
       const imageUrl = getLocalManholeImageUrl(d.id);
       const photoAlt = `${d.title || 'ポケふた'}の写真`;
       const photoDate = getPhotoTakenDate(d.id);
+      const shareUrl = getAbsoluteManholePageUrl(d.id);
+      const shareTitle = `${d.title || 'ポケふた'} | ポケふたマップ`;
       const photoBlock = imageUrl ? `
         <div class="popup-photo travel-popup-photo" aria-label="マンホール写真">
           <img src="${imageUrl}" alt="${escapeHtml(photoAlt)}" loading="lazy" decoding="async" onerror="handlePopupImageError(this)">
@@ -488,7 +522,7 @@
       const links = [
         officialDetailLink,
         prefectureSiteLink,
-        `<a href="${getManholePageUrl(d.id)}" class="travel-popup-action travel-popup-action--secondary">このURLを開く</a>`,
+        shareUrl ? `<button type="button" class="travel-popup-action travel-popup-action--secondary" data-share-url="${escapeHtml(shareUrl)}" data-share-title="${escapeHtml(shareTitle)}">共有</button>` : '',
         `<a href="https://pokefuta.com/" target="_blank" rel="noopener noreferrer" class="travel-popup-action travel-popup-action--secondary travel-popup-action--upload">写真を投稿</a>`
       ].filter(Boolean).join('');
 
@@ -684,8 +718,6 @@
         updateRecentSummary();
         renderRecentAdded();
         syncExploreSections();
-        document.getElementById('prefecture-total-label').textContent = `${allData.length}枚`;
-        
         // URL パラメータから初期表示を選択
         const initialManholeId = getInitialManholeIdFromURL();
         if (initialManholeId) {
@@ -765,6 +797,7 @@
         filterRecent = e.target.checked;
         if (filterRecent) {
           showPrefectureCards = false;
+          showNearbyResults = false;
         }
         syncExploreSections();
         recomputeVisibility();
@@ -779,16 +812,19 @@
     function syncExploreSections() {
       const prefButton = document.getElementById('prefecture-open-button');
       const recentButton = document.querySelector('.sheet-action-btn--toggle');
-      const prefectureHeading = document.getElementById('prefecture-section-heading');
+      const nearbyButton = document.getElementById('locate-button');
       const prefectureList = document.getElementById('prefecture-table-wrapper');
       const recentPanel = document.getElementById('recent-added-panel');
+      const nearbyPanel = document.getElementById('nearby-results');
 
       prefButton?.classList.toggle('active', showPrefectureCards);
       prefButton?.setAttribute('aria-pressed', String(showPrefectureCards));
       recentButton?.classList.toggle('active', filterRecent);
-      if (prefectureHeading) prefectureHeading.hidden = !showPrefectureCards;
+      nearbyButton?.classList.toggle('active', showNearbyResults);
+      nearbyButton?.setAttribute('aria-pressed', String(showNearbyResults));
       if (prefectureList) prefectureList.hidden = !showPrefectureCards;
       if (recentPanel) recentPanel.hidden = !filterRecent;
+      if (nearbyPanel) nearbyPanel.hidden = !showNearbyResults || !nearbyPanel.dataset.hasResults;
     }
 
     function zoomToRecentMarkers() {
@@ -822,6 +858,7 @@
       document.getElementById('prefecture-open-button')?.addEventListener('click', () => {
         expandBottomSheet();
         showPrefectureCards = true;
+        showNearbyResults = false;
         filterRecent = false;
         const recentToggle = document.getElementById('recent-toggle');
         if (recentToggle) recentToggle.checked = false;
@@ -926,6 +963,17 @@
       }
     }
 
+    function focusSelectedPrefecturePanel() {
+      const controlsContent = document.getElementById('controls-content');
+      const badge = document.getElementById('selected-prefecture-badge');
+      if (!controlsContent || !badge || !selectedPrefecture) return;
+      expandBottomSheet();
+      requestAnimationFrame(() => {
+        const top = Math.max(0, badge.offsetTop - controlsContent.offsetTop - 8);
+        controlsContent.scrollTo({ top, behavior: 'smooth' });
+      });
+    }
+
     function clearPrefectureSelection() {
       selectedPrefecture = '';
       filterByPrefectureFromTable('');
@@ -946,14 +994,7 @@
     // ↑ ドロップダウン関連は不要になったため後で削除予定
 
     function updateStats(visibleOverride) {
-      const totalEl = document.querySelector('#total-count span');
-      const visibleEl = document.querySelector('#visible-count span');
-      const cityEl = document.querySelector('#city-count span');
-      if (totalEl) totalEl.textContent = String(allMarkers.length);
-      if (visibleEl) {
-        const visibleCount = typeof visibleOverride === 'number' ? visibleOverride : allMarkers.filter(marker => markerLayer?.hasLayer(marker)).length;
-        visibleEl.textContent = String(visibleCount);
-      }
+      const cityEl = document.getElementById('hero-city-count');
       if (cityEl) cityEl.textContent = String(Object.keys(cityCounts).length);
     }
 
@@ -1051,7 +1092,7 @@
             filterByPrefectureFromTable(prefecture);
             showSelectedPrefectureBadge();
             zoomToPrefecture(prefecture);
-            collapseBottomSheet();
+            focusSelectedPrefecturePanel();
           };
           button.addEventListener('click', selectPrefecture);
           button.addEventListener('keydown', event => {
@@ -1079,22 +1120,45 @@
       const recentItems = [...allData]
         .filter(d => isWithinLastDays(d._addedDate, 30))
         .sort((a, b) => b._addedDate - a._addedDate);
-      if (!recentItems.length) {
-        list.innerHTML = '<p class="recent-added-empty">直近30日の追加はありません。</p>';
+      renderSpotResults(list, recentItems, {
+        emptyMessage: '直近30日の追加はありません。',
+        meta: d => [d.prefecture || '不明', d.title || 'ポケふた'].join(' / '),
+        badge: () => '<img src="./assets/icon-fire.svg" alt="" aria-hidden="true">NEW'
+      });
+    }
+
+    function renderSpotResults(list, spots, options = {}) {
+      const {
+        emptyMessage = '',
+        meta,
+        badge,
+        badgeClass = 'prefecture-spot-new',
+        limit = spots.length
+      } = options;
+      const visibleSpots = spots.slice(0, limit);
+      if (!visibleSpots.length) {
+        list.innerHTML = emptyMessage ? `<p class="recent-added-empty">${escapeHtml(emptyMessage)}</p>` : '';
         return;
       }
-      const items = recentItems;
-      list.innerHTML = items.map(d => `
-        <button type="button" class="recent-added-chip" data-manhole-id="${escapeHtml(d.id)}">
-          <span class="recent-added-code">${escapeHtml(window.PREFECTURE_CODE_MAP[d.prefecture] || '--')}</span>
-          <span class="recent-added-pref">${escapeHtml(d.prefecture || '不明')}</span>
-          <strong>${escapeHtml(d.city || 'スポット')}</strong>
-        </button>
-      `).join('');
-      list.querySelectorAll('.recent-added-chip').forEach(button => {
+      list.innerHTML = visibleSpots.map(d => {
+        const metaText = meta ? meta(d) : (d.title || 'ポケふた');
+        const badgeText = badge ? badge(d) : '';
+        return `
+          <button type="button" class="prefecture-spot-item" data-manhole-id="${escapeHtml(d.id)}">
+            <span class="prefecture-spot-thumb" aria-hidden="true">
+              <img src="${getLocalManholeImageUrl(d.id)}" alt="" loading="lazy" decoding="async" onerror="this.closest('.prefecture-spot-thumb').classList.add('is-missing'); this.remove();">
+            </span>
+            <span class="prefecture-spot-copy">
+              <strong>${escapeHtml(d.city || '自治体未設定')}</strong>
+              <small>${escapeHtml(metaText)}</small>
+            </span>
+            ${badgeText ? `<span class="${badgeClass}">${badgeText}</span>` : ''}
+          </button>
+        `;
+      }).join('');
+      list.querySelectorAll('.prefecture-spot-item').forEach(button => {
         button.addEventListener('click', () => {
-          const id = button.dataset.manholeId;
-          openManholePopup(id);
+          openManholePopup(button.dataset.manholeId);
           collapseBottomSheet();
         });
       });
@@ -1112,26 +1176,11 @@
       }
       const spots = allData
         .filter(d => d.prefecture === prefecture)
-        .sort((a, b) => String(a.city || '').localeCompare(String(b.city || ''), 'ja'))
-        .slice(0, 24);
+        .sort((a, b) => String(a.city || '').localeCompare(String(b.city || ''), 'ja'));
       heading.textContent = `${prefecture}のポケふた`;
-      list.innerHTML = spots.map(d => `
-        <button type="button" class="prefecture-spot-item" data-manhole-id="${escapeHtml(d.id)}">
-          <span class="prefecture-spot-thumb" aria-hidden="true">
-            <img src="${getLocalManholeImageUrl(d.id)}" alt="" loading="lazy" decoding="async" onerror="this.closest('.prefecture-spot-thumb').classList.add('is-missing'); this.remove();">
-          </span>
-          <span class="prefecture-spot-copy">
-            <strong>${escapeHtml(d.city || '自治体未設定')}</strong>
-            <small>${escapeHtml(d.title || 'ポケふた')}</small>
-          </span>
-          ${isWithinLastDays(d._addedDate, 30) ? '<span class="prefecture-spot-new"><img src="./assets/icon-fire.svg" alt="" aria-hidden="true">NEW</span>' : ''}
-        </button>
-      `).join('');
-      list.querySelectorAll('.prefecture-spot-item').forEach(button => {
-        button.addEventListener('click', () => {
-          openManholePopup(button.dataset.manholeId);
-          collapseBottomSheet();
-        });
+      renderSpotResults(list, spots, {
+        limit: 24,
+        badge: d => isWithinLastDays(d._addedDate, 30) ? '<img src="./assets/icon-fire.svg" alt="" aria-hidden="true">NEW' : ''
       });
       panel.hidden = spots.length === 0;
     }
@@ -1156,43 +1205,37 @@
         .slice(0, 5);
       if (!nearest.length) {
         list.innerHTML = '';
-        section.hidden = true;
+        section.dataset.hasResults = '';
+        showNearbyResults = false;
+        syncExploreSections();
         return;
       }
-      list.innerHTML = nearest.map(d => `
-        <button type="button" class="nearby-item" data-manhole-id="${escapeHtml(d.id)}">
-          <span>
-            <strong>${escapeHtml(d.city || d.title || 'ポケふた')}</strong>
-            <small>${escapeHtml(d.prefecture || '不明')}</small>
-          </span>
-          <b>${d.distance.toFixed(1)}km</b>
-        </button>
-      `).join('');
-      list.querySelectorAll('.nearby-item').forEach(button => {
-        button.addEventListener('click', () => {
-          openManholePopup(button.dataset.manholeId);
-          collapseBottomSheet();
-        });
+      renderSpotResults(list, nearest, {
+        meta: d => [d.prefecture || '不明', d.title || 'ポケふた'].join(' / '),
+        badge: d => `${d.distance.toFixed(1)}km`,
+        badgeClass: 'prefecture-spot-distance'
       });
-      section.hidden = false;
+      section.dataset.hasResults = 'true';
+      showNearbyResults = true;
+      showPrefectureCards = false;
+      filterRecent = false;
+      const recentToggle = document.getElementById('recent-toggle');
+      if (recentToggle) recentToggle.checked = false;
+      syncExploreSections();
     }
 
     function initLocationSearch() {
       const button = document.getElementById('locate-button');
-      const status = document.getElementById('locate-status');
       if (!button) return;
       button.addEventListener('click', () => {
         if (!navigator.geolocation) {
-          if (status) status.textContent = '現在地を使えないため、都道府県から探してください。';
           expandBottomSheet();
           return;
         }
         button.disabled = true;
-        if (status) status.textContent = '現在地を確認しています...';
         navigator.geolocation.getCurrentPosition(position => {
           const { latitude, longitude } = position.coords;
           button.disabled = false;
-          if (status) status.textContent = '近くのポケふたを距離順に表示しました。';
           if (userLocationMarker) map.removeLayer(userLocationMarker);
           userLocationMarker = L.circleMarker([latitude, longitude], {
             radius: 8,
@@ -1212,7 +1255,6 @@
           expandBottomSheet();
         }, () => {
           button.disabled = false;
-          if (status) status.textContent = '現在地を使えませんでした。都道府県から探してください。';
           expandBottomSheet();
         }, { enableHighAccuracy: false, timeout: 10000, maximumAge: 300000 });
       });

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -201,7 +201,7 @@
           </label>
           <button type="button" id="locate-button" class="sheet-action-btn">
             <img src="./assets/icon-current-location.svg" alt="" aria-hidden="true">
-            近くのポケふた
+            <span id="locate-button-label">近くのポケふた</span>
           </button>
         </div>
       </div>
@@ -429,13 +429,19 @@
         }
       }
       if (navigator.clipboard?.writeText) {
-        await navigator.clipboard.writeText(url);
-        const originalText = button.textContent;
-        button.textContent = 'コピー済み';
-        window.setTimeout(() => {
-          button.textContent = originalText || '共有';
-        }, 1400);
+        try {
+          await navigator.clipboard.writeText(url);
+          const originalText = button.textContent;
+          button.textContent = 'コピー済み';
+          window.setTimeout(() => {
+            button.textContent = originalText || '共有';
+          }, 1400);
+          return;
+        } catch (error) {
+          console.warn('クリップボードへのコピーに失敗しました', error);
+        }
       }
+      window.prompt('共有URLをコピーしてください', url);
     }
 
     document.addEventListener('click', event => {
@@ -1123,17 +1129,30 @@
       renderSpotResults(list, recentItems, {
         emptyMessage: '直近30日の追加はありません。',
         meta: d => [d.prefecture || '不明', d.title || 'ポケふた'].join(' / '),
-        badge: () => '<img src="./assets/icon-fire.svg" alt="" aria-hidden="true">NEW'
+        badge: () => '<img src="./assets/icon-fire.svg" alt="" aria-hidden="true">NEW',
+        limit: 24
+      });
+    }
+
+    function bindSpotResultList(list) {
+      if (!list || list.dataset.boundSpotResults) return;
+      list.dataset.boundSpotResults = 'true';
+      list.addEventListener('click', event => {
+        const button = event.target.closest('.prefecture-spot-item[data-manhole-id]');
+        if (!button || !list.contains(button)) return;
+        openManholePopup(button.dataset.manholeId);
+        collapseBottomSheet();
       });
     }
 
     function renderSpotResults(list, spots, options = {}) {
+      bindSpotResultList(list);
       const {
         emptyMessage = '',
         meta,
         badge,
         badgeClass = 'prefecture-spot-new',
-        limit = spots.length
+        limit = 24
       } = options;
       const visibleSpots = spots.slice(0, limit);
       if (!visibleSpots.length) {
@@ -1156,12 +1175,6 @@
           </button>
         `;
       }).join('');
-      list.querySelectorAll('.prefecture-spot-item').forEach(button => {
-        button.addEventListener('click', () => {
-          openManholePopup(button.dataset.manholeId);
-          collapseBottomSheet();
-        });
-      });
     }
 
     function renderPrefectureSpots(prefecture) {
@@ -1226,16 +1239,31 @@
 
     function initLocationSearch() {
       const button = document.getElementById('locate-button');
+      const label = document.getElementById('locate-button-label');
       if (!button) return;
+      const defaultLabel = label?.textContent || '近くのポケふた';
+      const setButtonState = (text, options = {}) => {
+        const { busy = false, resetAfter = 0 } = options;
+        button.disabled = busy;
+        button.setAttribute('aria-busy', String(busy));
+        if (label) label.textContent = text;
+        if (resetAfter) {
+          window.setTimeout(() => {
+            if (label) label.textContent = defaultLabel;
+            button.removeAttribute('aria-busy');
+          }, resetAfter);
+        }
+      };
       button.addEventListener('click', () => {
         if (!navigator.geolocation) {
+          setButtonState('現在地を使えません', { resetAfter: 1800 });
           expandBottomSheet();
           return;
         }
-        button.disabled = true;
+        setButtonState('確認中...', { busy: true });
         navigator.geolocation.getCurrentPosition(position => {
           const { latitude, longitude } = position.coords;
-          button.disabled = false;
+          setButtonState(defaultLabel);
           if (userLocationMarker) map.removeLayer(userLocationMarker);
           userLocationMarker = L.circleMarker([latitude, longitude], {
             radius: 8,
@@ -1254,7 +1282,7 @@
           map.fitBounds(group.getBounds(), { padding: [48, 48], maxZoom: 13 });
           expandBottomSheet();
         }, () => {
-          button.disabled = false;
+          setButtonState('取得できませんでした', { resetAfter: 1800 });
           expandBottomSheet();
         }, { enableHighAccuracy: false, timeout: 10000, maximumAge: 300000 });
       });


### PR DESCRIPTION
## Summary
- Move nearby search into the shared discovery controls and remove the floating location CTA/status tooltip.
- Keep new and nearby result panels above the prefecture list, including when a prefecture is selected.
- Reuse one manhole card renderer for prefecture, new, and nearby result lists.
- Simplify the hero/stat copy, tighten mobile prefecture cards, and replace the popup URL action with share/copy behavior.

## Follow-up Fixes
- Added a manual URL prompt fallback when Web Share and Clipboard are unavailable.
- Added current-location progress/failure feedback via the locate button label and `aria-busy`.
- Capped shared result rendering at 24 items by default, with explicit limits for new/prefecture lists.
- Switched shared spot card clicks to event delegation.

## Verification
- Inline script syntax check passed.
- `python3 test_noise_filter.py`
- `git diff --check`
- Verified `recent-added-panel` appears before `prefecture-tab` in the DOM.
- Served `apps/web` locally with `python3 -m http.server 8765` and confirmed `/index.html` returns `200 OK`.

## Review Notes
- Addressed and resolved all 4 Copilot review threads.