### PR TITLE
Fix mobile map popup dismissal

### DIFF
--- a/apps/web/gmanhole_map.html
+++ b/apps/web/gmanhole_map.html
@@ -123,13 +123,16 @@
   </footer>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
   <script>
-    const map = L.map('map', { closePopupOnClick: false }).setView([36.0, 138.0], 6);
+    const isTouchMapPointer = window.matchMedia
+      ? window.matchMedia('(pointer: coarse)').matches
+      : L.Browser.mobile && L.Browser.touch;
+    const map = L.map('map', { closePopupOnClick: !isTouchMapPointer }).setView([36.0, 138.0], 6);
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', { maxZoom: 19, attribution: '&copy; OpenStreetMap contributors' }).addTo(map);
     const POPUP_SIDE_PADDING = 16;
     const POPUP_TOP_PADDING = 24;
     const POPUP_BOTTOM_CONTROLS_PADDING = 220;
     const franchisePopupOptions = {
-      closeOnClick: false,
+      closeOnClick: !isTouchMapPointer,
       autoPan: true,
       // Keep popups clear of viewport edges and the bottom controls panel on mobile.
       autoPanPaddingTopLeft: L.point(POPUP_SIDE_PADDING, POPUP_TOP_PADDING),

--- a/apps/web/gmanhole_map.html
+++ b/apps/web/gmanhole_map.html
@@ -125,11 +125,15 @@
   <script>
     const map = L.map('map', { closePopupOnClick: false }).setView([36.0, 138.0], 6);
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', { maxZoom: 19, attribution: '&copy; OpenStreetMap contributors' }).addTo(map);
+    const POPUP_SIDE_PADDING = 16;
+    const POPUP_TOP_PADDING = 24;
+    const POPUP_BOTTOM_CONTROLS_PADDING = 220;
     const franchisePopupOptions = {
       closeOnClick: false,
       autoPan: true,
-      autoPanPaddingTopLeft: L.point(16, 24),
-      autoPanPaddingBottomRight: L.point(16, 220)
+      // Keep popups clear of viewport edges and the bottom controls panel on mobile.
+      autoPanPaddingTopLeft: L.point(POPUP_SIDE_PADDING, POPUP_TOP_PADDING),
+      autoPanPaddingBottomRight: L.point(POPUP_SIDE_PADDING, POPUP_BOTTOM_CONTROLS_PADDING)
     };
 
     function franchiseIcon(franchise, overlap=false) {

--- a/apps/web/gmanhole_map.html
+++ b/apps/web/gmanhole_map.html
@@ -123,8 +123,14 @@
   </footer>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
   <script>
-    const map = L.map('map').setView([36.0, 138.0], 6);
+    const map = L.map('map', { closePopupOnClick: false }).setView([36.0, 138.0], 6);
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', { maxZoom: 19, attribution: '&copy; OpenStreetMap contributors' }).addTo(map);
+    const franchisePopupOptions = {
+      closeOnClick: false,
+      autoPan: true,
+      autoPanPaddingTopLeft: L.point(16, 24),
+      autoPanPaddingBottomRight: L.point(16, 220)
+    };
 
     function franchiseIcon(franchise, overlap=false) {
       let cls = 'fr-marker ';
@@ -400,7 +406,7 @@
         if (d.lat == null || d.lng == null) return; // skip unless geocoded
         const overlap = overlapLocs.has(locKey(d));
         const popup = buildGundamPopup(d, overlap);
-        const marker = L.marker([d.lat, d.lng], { icon: franchiseIcon('gundam', overlap) }).bindPopup(popup);
+        const marker = L.marker([d.lat, d.lng], { icon: franchiseIcon('gundam', overlap) }).bindPopup(popup, franchisePopupOptions);
         marker._data = { ...d, prefecture: normalizePrefecture(d.prefecture), franchise:'gundam', overlap };
         marker.addTo(map); allMarkers.push(marker);
       });
@@ -408,7 +414,7 @@
         if (d.lat == null || d.lng == null) return;
         const overlap = overlapLocs.has(locKey(d));
         const popup = buildPokemonPopup(d, overlap);
-        const marker = L.marker([d.lat, d.lng], { icon: franchiseIcon('pokefuta', overlap) }).bindPopup(popup);
+        const marker = L.marker([d.lat, d.lng], { icon: franchiseIcon('pokefuta', overlap) }).bindPopup(popup, franchisePopupOptions);
         marker._data = { ...d, prefecture: normalizePrefecture(d.prefecture), franchise:'pokefuta', overlap };
         marker.addTo(map); allMarkers.push(marker);
       });

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -263,13 +263,19 @@
   iconAnchor: [17, 38],
   popupAnchor: [0, -34]
 });
-    const map = L.map('map', { zoomControl: true }).setView([36.0, 138.0], 6);
+    const map = L.map('map', { zoomControl: true, closePopupOnClick: false }).setView([36.0, 138.0], 6);
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
       maxZoom: 19,
       attribution: '&copy; OpenStreetMap contributors'
     }).addTo(map);
     map.on('popupopen', () => document.body.classList.add('popup-open'));
     map.on('popupclose', () => document.body.classList.remove('popup-open'));
+    const pokefutaPopupOptions = {
+      closeOnClick: false,
+      autoPan: true,
+      autoPanPaddingTopLeft: L.point(16, 176),
+      autoPanPaddingBottomRight: L.point(16, 250)
+    };
 
     // 都道府県中心座標マッピング（クリック時の移動用）
     const prefectureCenterCoords = {
@@ -676,7 +682,8 @@
             d.pokemons.forEach(p => { if (p) pokemonCounts[p] = (pokemonCounts[p] || 0) + 1; });
           }
           const popupContent = buildPokefutaPopup(d);
-          const marker = L.marker([d.lat, d.lng], { icon: pokefutaIcon }).bindPopup(popupContent);
+          const marker = L.marker([d.lat, d.lng], { icon: pokefutaIcon }).bindPopup(popupContent, pokefutaPopupOptions);
+          marker.on('click', collapseBottomSheet);
           marker.pokefutaData = d; marker.pokefutaData.prefectureCode = prefectureCode;
           allMarkers.push(marker);
           markerLayer.addLayer(marker);

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -270,11 +270,15 @@
     }).addTo(map);
     map.on('popupopen', () => document.body.classList.add('popup-open'));
     map.on('popupclose', () => document.body.classList.remove('popup-open'));
+    const POPUP_SIDE_PADDING = 16;
+    const POPUP_TOP_PADDING = 176;
+    const POPUP_BOTTOM_SHEET_PADDING = 250;
     const pokefutaPopupOptions = {
       closeOnClick: false,
       autoPan: true,
-      autoPanPaddingTopLeft: L.point(16, 176),
-      autoPanPaddingBottomRight: L.point(16, 250)
+      // Keep popups clear of the hero card at the top and collapsed bottom sheet on mobile.
+      autoPanPaddingTopLeft: L.point(POPUP_SIDE_PADDING, POPUP_TOP_PADDING),
+      autoPanPaddingBottomRight: L.point(POPUP_SIDE_PADDING, POPUP_BOTTOM_SHEET_PADDING)
     };
 
     // 都道府県中心座標マッピング（クリック時の移動用）

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -258,12 +258,15 @@
     integrity="sha384-eXVCORTRlv4FUUgS/xmOyr66XBVraen8ATNLMESp92FKXLAMiKkerixTiBvXriZr" crossorigin=""></script>
   <script>
     const pokefutaIcon = L.icon({
-  iconUrl: './assets/pokefuta-marker.svg',
-  iconSize: [34, 40],
-  iconAnchor: [17, 38],
-  popupAnchor: [0, -34]
-});
-    const map = L.map('map', { zoomControl: true, closePopupOnClick: false }).setView([36.0, 138.0], 6);
+      iconUrl: './assets/pokefuta-marker.svg',
+      iconSize: [34, 40],
+      iconAnchor: [17, 38],
+      popupAnchor: [0, -34]
+    });
+    const isTouchMapPointer = window.matchMedia
+      ? window.matchMedia('(pointer: coarse)').matches
+      : L.Browser.mobile && L.Browser.touch;
+    const map = L.map('map', { zoomControl: true, closePopupOnClick: !isTouchMapPointer }).setView([36.0, 138.0], 6);
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
       maxZoom: 19,
       attribution: '&copy; OpenStreetMap contributors'
@@ -274,7 +277,7 @@
     const POPUP_TOP_PADDING = 176;
     const POPUP_BOTTOM_SHEET_PADDING = 250;
     const pokefutaPopupOptions = {
-      closeOnClick: false,
+      closeOnClick: !isTouchMapPointer,
       autoPan: true,
       // Keep popups clear of the hero card at the top and collapsed bottom sheet on mobile.
       autoPanPaddingTopLeft: L.point(POPUP_SIDE_PADDING, POPUP_TOP_PADDING),


### PR DESCRIPTION
## Summary
- Prevent Leaflet map clicks from closing freshly opened popups on touch devices.
- Share popup options across marker bindings and add mobile-friendly auto-pan padding.
- Collapse the bottom sheet when a Pokefuta marker is tapped so the popup has room to stay visible.

## Verification
- Inline script syntax check for apps/web/index.html and apps/web/gmanhole_map.html.
- python3 test_noise_filter.py
- git diff --check
- Playwright mobile viewport check: popup remains open after a map click.