### PR TITLE
Fix intermittent mobile popup close

### DIFF
--- a/apps/web/gmanhole_map.html
+++ b/apps/web/gmanhole_map.html
@@ -123,9 +123,14 @@
   </footer>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
   <script>
-    const isTouchMapPointer = window.matchMedia
-      ? window.matchMedia('(pointer: coarse)').matches
-      : L.Browser.mobile && L.Browser.touch;
+    function hasTouchMapPointer() {
+      const matchesMedia = query => typeof window.matchMedia === 'function' && window.matchMedia(query).matches;
+      return matchesMedia('(pointer: coarse)')
+        || matchesMedia('(any-pointer: coarse)')
+        || Number(navigator.maxTouchPoints || 0) > 0
+        || (L.Browser.mobile && L.Browser.touch);
+    }
+    const isTouchMapPointer = hasTouchMapPointer();
     const map = L.map('map', { closePopupOnClick: !isTouchMapPointer }).setView([36.0, 138.0], 6);
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', { maxZoom: 19, attribution: '&copy; OpenStreetMap contributors' }).addTo(map);
     const POPUP_SIDE_PADDING = 16;

--- a/apps/web/gmanhole_map.html
+++ b/apps/web/gmanhole_map.html
@@ -125,6 +125,7 @@
   <script>
     function hasTouchMapPointer() {
       const matchesMedia = query => typeof window.matchMedia === 'function' && window.matchMedia(query).matches;
+      if (matchesMedia('(pointer: fine)')) return false;
       return matchesMedia('(pointer: coarse)')
         || matchesMedia('(any-pointer: coarse)')
         || Number(navigator.maxTouchPoints || 0) > 0

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -805,6 +805,7 @@
       if (L.markerClusterGroup) {
         markerLayer = L.markerClusterGroup({
           showCoverageOnHover: false,
+          removeOutsideVisibleBounds: false,
           disableClusteringAtZoom: 8,
           maxClusterRadius: 48,
           iconCreateFunction(cluster) {

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -265,6 +265,7 @@
     });
     function hasTouchMapPointer() {
       const matchesMedia = query => typeof window.matchMedia === 'function' && window.matchMedia(query).matches;
+      if (matchesMedia('(pointer: fine)')) return false;
       return matchesMedia('(pointer: coarse)')
         || matchesMedia('(any-pointer: coarse)')
         || Number(navigator.maxTouchPoints || 0) > 0

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -263,9 +263,14 @@
       iconAnchor: [17, 38],
       popupAnchor: [0, -34]
     });
-    const isTouchMapPointer = window.matchMedia
-      ? window.matchMedia('(pointer: coarse)').matches
-      : L.Browser.mobile && L.Browser.touch;
+    function hasTouchMapPointer() {
+      const matchesMedia = query => typeof window.matchMedia === 'function' && window.matchMedia(query).matches;
+      return matchesMedia('(pointer: coarse)')
+        || matchesMedia('(any-pointer: coarse)')
+        || Number(navigator.maxTouchPoints || 0) > 0
+        || (L.Browser.mobile && L.Browser.touch);
+    }
+    const isTouchMapPointer = hasTouchMapPointer();
     const map = L.map('map', { zoomControl: true, closePopupOnClick: !isTouchMapPointer }).setView([36.0, 138.0], 6);
     L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
       maxZoom: 19,


### PR DESCRIPTION
## Summary
- Broaden touch-device detection so popup click guards cover browsers that expose coarse input via `any-pointer` or `maxTouchPoints`.
- Keep MarkerCluster from pruning visible markers during popup auto-pan, which was closing popups when the opened marker was removed from the cluster layer.
- Preserve desktop/fine-pointer behavior where map clicks close popups.

## Root Cause
The remaining intermittent close was not caused by the map click guard. A popup could auto-pan the map after opening; MarkerCluster then pruned layers outside the visible bounds, removed the marker that owned the popup, and Leaflet closed the popup as part of that marker removal.

## Verification
- Inline script syntax check for apps/web/index.html and apps/web/gmanhole_map.html.
- `python3 test_noise_filter.py`
- `git diff --check`
- Playwright against http://127.0.0.1:8000/index.html: mobile keeps popup open after Leaflet preclick; desktop closes popup on preclick.
- Popup event trace confirmed `popupopen -> moveend` with the marker and popup still mounted after disabling MarkerCluster outside-bounds pruning.
