### PR TITLE
Improve map panel interactions

### DIFF
--- a/apps/web/assets/pokefuta-map.css
+++ b/apps/web/assets/pokefuta-map.css
@@ -10,7 +10,9 @@ body.pokefuta-map-page {
 
 .pokefuta-map-page .map-stage {
   position: relative;
+  height: 100vh;
   height: 100dvh;
+  min-height: 100vh;
   min-height: 100dvh;
   overflow: hidden;
   background: #cfe8ef;
@@ -945,7 +947,9 @@ body.pokefuta-map-page {
 @media (max-width: 600px) {
   .pokefuta-map-page .map-stage {
     width: 100vw;
+    height: 100vh;
     height: 100dvh;
+    min-height: 100vh;
     min-height: 100dvh;
   }
 

--- a/apps/web/assets/pokefuta-map.css
+++ b/apps/web/assets/pokefuta-map.css
@@ -10,8 +10,8 @@ body.pokefuta-map-page {
 
 .pokefuta-map-page .map-stage {
   position: relative;
-  height: 72vh;
-  min-height: 520px;
+  height: 100dvh;
+  min-height: 100dvh;
   overflow: hidden;
   background: #cfe8ef;
 }
@@ -98,7 +98,7 @@ body.pokefuta-map-page {
   background: rgba(255, 248, 232, .96);
   box-shadow: 0 -14px 40px rgba(52, 35, 16, .18);
   overflow: hidden;
-  transform: translateY(calc(100% - 228px - env(safe-area-inset-bottom)));
+  transform: translateY(calc(100% - 44px - env(safe-area-inset-bottom)));
   transition: transform .22s cubic-bezier(.2,.8,.2,1), max-height .22s cubic-bezier(.2,.8,.2,1);
 }
 
@@ -108,11 +108,33 @@ body.pokefuta-map-page {
 }
 
 .pokefuta-map-page .controls-header {
-  min-height: 0;
-  padding: 8px 18px 0;
+  position: relative;
+  z-index: 2;
+  min-height: 44px;
+  padding: 0 18px;
+  border: 0;
+  background: rgba(255, 248, 232, .96);
+  color: #1f1b18;
+}
+
+.pokefuta-map-page .controls-toggle-btn {
+  display: grid;
+  width: 100%;
+  min-height: 44px;
+  place-items: center;
+  padding: 0;
   border: 0;
   background: transparent;
-  color: #1f1b18;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.pokefuta-map-page .controls-toggle-btn:focus-visible {
+  border-radius: 14px;
+  outline: 3px solid rgba(118, 84, 170, .32);
+  outline-offset: 4px;
 }
 
 .pokefuta-map-page .sheet-grip {
@@ -120,7 +142,7 @@ body.pokefuta-map-page {
   width: 58px;
   height: 28px;
   min-width: 58px;
-  margin: 0 auto 3px;
+  margin: 0 auto;
   padding: 0;
   border: 0;
   border-radius: 999px;
@@ -151,7 +173,12 @@ body.pokefuta-map-page {
   gap: 12px;
 }
 
+.pokefuta-map-page .bottom-sheet-title-row {
+  min-height: 36px;
+}
+
 .pokefuta-map-page .controls-header h3 {
+  display: block;
   margin: 0;
   font-size: 1.08rem;
   font-weight: 900;
@@ -362,12 +389,21 @@ body.pokefuta-map-page {
   height: 54px;
   place-items: center;
   overflow: hidden;
+  padding: 0;
   border: 2px solid rgba(255, 255, 255, .95);
   border-radius: 50%;
   background:
     url("./icon-pin.svg") center / 24px 24px no-repeat,
     linear-gradient(135deg, rgba(126, 107, 169, .14), rgba(255, 250, 239, .92));
   box-shadow: 0 4px 10px rgba(67, 38, 111, .16);
+  cursor: pointer;
+}
+
+.pokefuta-map-page button.prefecture-card-thumb:hover,
+.pokefuta-map-page button.prefecture-card-thumb:focus-visible {
+  border-color: #7654aa;
+  box-shadow: 0 6px 14px rgba(67, 38, 111, .24), 0 0 0 3px rgba(118, 84, 170, .18);
+  outline: 0;
 }
 
 .pokefuta-map-page .prefecture-card-thumb img {
@@ -858,20 +894,18 @@ body.pokefuta-map-page {
     transform: none;
   }
 
+  .pokefuta-map-page:not(.sheet-expanded) #controls,
   .pokefuta-map-page.sheet-expanded #controls {
+    max-height: calc(100dvh - 64px);
     transform: none;
   }
 
-  .pokefuta-map-page .sheet-grip {
+  .pokefuta-map-page .controls-header {
     display: none;
   }
 
-  .pokefuta-map-page .controls-header {
-    padding: 16px 18px 0;
-  }
-
   .pokefuta-map-page .controls-content {
-    max-height: calc(100dvh - 126px);
+    max-height: calc(100dvh - 64px);
     padding-bottom: 18px;
   }
 
@@ -911,8 +945,8 @@ body.pokefuta-map-page {
 @media (max-width: 600px) {
   .pokefuta-map-page .map-stage {
     width: 100vw;
-    height: 71vh;
-    min-height: 500px;
+    height: 100dvh;
+    min-height: 100dvh;
   }
 
   .pokefuta-map-page .map-hero-card {
@@ -952,7 +986,7 @@ body.pokefuta-map-page {
   .pokefuta-map-page #controls {
     width: 100vw;
     max-width: none;
-    transform: translateY(calc(100% - 218px - env(safe-area-inset-bottom)));
+    transform: translateY(calc(100% - 44px - env(safe-area-inset-bottom)));
   }
 
   .pokefuta-map-page .sheet-action-grid {

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -181,13 +181,13 @@
   </main>
 
   <div id="controls" class="bottom-sheet" role="complementary" aria-labelledby="page-title">
+    <span id="page-title" class="sr-only">全体パネル</span>
     <div class="controls-header">
-      <button type="button" id="controls-toggle" class="controls-toggle-btn sheet-grip" aria-label="都道府県リストを開く" title="開く/閉じる" aria-expanded="false" aria-controls="controls-content"></button>
-      <div class="bottom-sheet-title-row">
-        <h3 id="page-title">ポケふたマップ</h3>
-      </div>
+      <button type="button" id="controls-toggle" class="controls-toggle-btn" aria-label="全体パネルを開く" title="全体パネルを開く/閉じる" aria-expanded="false" aria-controls="controls-content">
+        <span class="sheet-grip" aria-hidden="true"></span>
+      </button>
     </div>
-    <div id="controls-content" class="controls-content" role="region" aria-label="Filters and statistics">
+    <div id="controls-content" class="controls-content" role="region" aria-label="全体パネルの内容">
       <div class="sheet-summary-card">
         <div class="sheet-action-grid" aria-label="探索メニュー">
           <button type="button" id="prefecture-open-button" class="sheet-action-btn">
@@ -890,8 +890,14 @@
       const toggleBtn = document.getElementById('controls-toggle');
       const controlsContent = document.getElementById('controls-content');
       if (!toggleBtn || !controlsContent) return;
-      collapseBottomSheet();
+      const canTogglePanel = () => window.matchMedia('(max-width: 759px)').matches;
+      if (canTogglePanel()) {
+        collapseBottomSheet();
+      } else {
+        expandBottomSheet();
+      }
       toggleBtn.addEventListener('click', () => {
+        if (!canTogglePanel()) return;
         const expanded = document.body.classList.contains('sheet-expanded');
         expanded ? collapseBottomSheet() : expandBottomSheet();
       });
@@ -908,17 +914,22 @@
       let startY = 0;
       toggleBtn.addEventListener('touchstart', e => { startY = e.touches[0].clientY; }, { passive: true });
       toggleBtn.addEventListener('touchend', e => {
+        if (!canTogglePanel()) return;
         const dy = e.changedTouches[0].clientY - startY;
         if (dy < -20) expandBottomSheet();
         if (dy > 20) collapseBottomSheet();
       }, { passive: true });
+      window.matchMedia('(max-width: 759px)').addEventListener('change', event => {
+        event.matches ? collapseBottomSheet() : expandBottomSheet();
+      });
     }
 
     function expandBottomSheet() {
       document.body.classList.add('sheet-expanded');
       const toggleBtn = document.getElementById('controls-toggle');
       toggleBtn?.setAttribute('aria-expanded', 'true');
-      toggleBtn?.setAttribute('aria-label', '都道府県リストを閉じる');
+      toggleBtn?.setAttribute('aria-label', '全体パネルを閉じる');
+      toggleBtn?.setAttribute('title', '全体パネルを閉じる');
       setTimeout(() => map.invalidateSize(), 160);
     }
 
@@ -926,7 +937,8 @@
       document.body.classList.remove('sheet-expanded');
       const toggleBtn = document.getElementById('controls-toggle');
       toggleBtn?.setAttribute('aria-expanded', 'false');
-      toggleBtn?.setAttribute('aria-label', '都道府県リストを開く');
+      toggleBtn?.setAttribute('aria-label', '全体パネルを開く');
+      toggleBtn?.setAttribute('title', '全体パネルを開く');
       setTimeout(() => map.invalidateSize(), 160);
     }
 
@@ -1078,7 +1090,11 @@
           prefectureThumbnails[pref] = [];
         }
         if (d.id && prefectureThumbnails[pref] && prefectureThumbnails[pref].length < 4) {
-          prefectureThumbnails[pref].push(getLocalManholeImageUrl(d.id));
+          prefectureThumbnails[pref].push({
+            id: d.id,
+            title: d.title || 'ポケふた',
+            imageUrl: getLocalManholeImageUrl(d.id)
+          });
         }
         if (isWithinLastDays(d._addedDate, 30)) {
           prefectureRecentCounts[pref] = (prefectureRecentCounts[pref] || 0) + 1;
@@ -1118,11 +1134,11 @@
             </span>
             <span class="${countBadgeClass}">${count}枚</span>
           </div>
-          <div class="prefecture-card-gallery" aria-hidden="true">
-            ${thumbnailUrls.length ? thumbnailUrls.map(url => `
-              <span class="prefecture-card-thumb">
-                <img src="${url}" alt="" loading="lazy" decoding="async" onerror="this.closest('.prefecture-card-thumb').classList.add('is-missing'); this.remove();">
-              </span>
+          <div class="prefecture-card-gallery" aria-label="${escapeHtml(prefecture)}のマンホール写真">
+            ${thumbnailUrls.length ? thumbnailUrls.map(item => `
+              <button type="button" class="prefecture-card-thumb" data-manhole-id="${escapeHtml(item.id)}" aria-label="${escapeHtml(item.title)}の詳細を開く" title="${escapeHtml(item.title)}の詳細を開く">
+                <img src="${item.imageUrl}" alt="" loading="lazy" decoding="async" onerror="this.closest('.prefecture-card-thumb').classList.add('is-missing'); this.remove();">
+              </button>
             `).join('') : '<span class="prefecture-card-thumb is-missing"></span>'}
           </div>
         `;
@@ -1151,6 +1167,13 @@
           linkEl.addEventListener('click', stopRowPropagation);
           linkEl.addEventListener('dblclick', stopRowPropagation);
         }
+        row.querySelectorAll('.prefecture-card-thumb[data-manhole-id]').forEach(thumb => {
+          thumb.addEventListener('click', event => {
+            event.stopPropagation();
+            openManholePopup(thumb.dataset.manholeId);
+            collapseBottomSheet();
+          });
+        });
       });
     }
 

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -328,6 +328,18 @@
     var prefectureBounds = {};  // 都道府県ごとのbounding box（グローバルスコープ）
     var prefectureMarkerCounts = {};  // 都道府県ごとのマンホール数（グローバルスコープ）
     const PREFECTURE_BOUNDS_OFFSET = 0.5;  // 都道府県 bounding box のオフセット（度）
+    const OVERALL_PANEL_MEDIA_QUERY = '(max-width: 759px)';
+
+    function getOverallPanelMediaQuery() {
+      return typeof window.matchMedia === 'function'
+        ? window.matchMedia(OVERALL_PANEL_MEDIA_QUERY)
+        : null;
+    }
+
+    function isOverallPanelToggleable() {
+      const mediaQuery = getOverallPanelMediaQuery();
+      return mediaQuery ? mediaQuery.matches : true;
+    }
 
     // URL パラメータから初期都道府県を取得する関数
     function getInitialPrefectureFromURL() {
@@ -890,9 +902,10 @@
       const toggleBtn = document.getElementById('controls-toggle');
       const controlsContent = document.getElementById('controls-content');
       if (!toggleBtn || !controlsContent) return;
-      const canTogglePanel = () => window.matchMedia('(max-width: 759px)').matches;
+      const panelMediaQuery = getOverallPanelMediaQuery();
+      const canTogglePanel = () => panelMediaQuery ? panelMediaQuery.matches : true;
       if (canTogglePanel()) {
-        collapseBottomSheet();
+        collapseBottomSheet(true);
       } else {
         expandBottomSheet();
       }
@@ -919,9 +932,14 @@
         if (dy < -20) expandBottomSheet();
         if (dy > 20) collapseBottomSheet();
       }, { passive: true });
-      window.matchMedia('(max-width: 759px)').addEventListener('change', event => {
-        event.matches ? collapseBottomSheet() : expandBottomSheet();
-      });
+      const handlePanelQueryChange = event => {
+        event.matches ? collapseBottomSheet(true) : expandBottomSheet();
+      };
+      if (panelMediaQuery?.addEventListener) {
+        panelMediaQuery.addEventListener('change', handlePanelQueryChange);
+      } else if (panelMediaQuery?.addListener) {
+        panelMediaQuery.addListener(handlePanelQueryChange);
+      }
     }
 
     function expandBottomSheet() {
@@ -933,7 +951,8 @@
       setTimeout(() => map.invalidateSize(), 160);
     }
 
-    function collapseBottomSheet() {
+    function collapseBottomSheet(force = false) {
+      if (!force && !isOverallPanelToggleable()) return;
       document.body.classList.remove('sheet-expanded');
       const toggleBtn = document.getElementById('controls-toggle');
       toggleBtn?.setAttribute('aria-expanded', 'false');
@@ -1105,7 +1124,7 @@
         const row = document.createElement('article');
         const code = window.PREFECTURE_CODE_MAP[prefecture] || '--';
         const siteUrl = prefectureSiteUrls[prefecture];
-        const thumbnailUrls = prefectureThumbnails[prefecture] || [];
+        const thumbnailItems = prefectureThumbnails[prefecture] || [];
         const recentCount = prefectureRecentCounts[prefecture] || 0;
         let siteCell = '<span class="prefecture-site-link prefecture-site-link--empty">公式サイトなし</span>';
         if (siteUrl) {
@@ -1135,7 +1154,7 @@
             <span class="${countBadgeClass}">${count}枚</span>
           </div>
           <div class="prefecture-card-gallery" aria-label="${escapeHtml(prefecture)}のマンホール写真">
-            ${thumbnailUrls.length ? thumbnailUrls.map(item => `
+            ${thumbnailItems.length ? thumbnailItems.map(item => `
               <button type="button" class="prefecture-card-thumb" data-manhole-id="${escapeHtml(item.id)}" aria-label="${escapeHtml(item.title)}の詳細を開く" title="${escapeHtml(item.title)}の詳細を開く">
                 <img src="${item.imageUrl}" alt="" loading="lazy" decoding="async" onerror="this.closest('.prefecture-card-thumb').classList.add('is-missing'); this.remove();">
               </button>


### PR DESCRIPTION
## Summary
- Make prefecture card thumbnails open the existing manhole popup directly.
- Define the controls area as the overall panel for accessibility without showing extra UI text.
- Keep the overall panel always open on desktop, while mobile uses a 44px handle with tap/swipe open-close behavior.
- Expand the map stage to the full mobile viewport height.

## Verification
- git diff --check
- Inline script syntax check passed.
- python3 test_noise_filter.py
- Playwright smoke checks for mobile panel behavior, desktop panel visibility, thumbnail popup behavior, and full-height mobile map.