### PR TITLE
Improve Pokefuta SEO for summary and prefecture lists

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -35,6 +35,8 @@ jobs:
           python3 apps/scraper/generate_sitemap.py
           echo "[dist] Copy HTML sources"
           cp apps/web/index.html dist/index.html
+          mkdir -p dist/summary
+          cp apps/web/summary.html dist/summary/index.html
           cp apps/web/nearby_manholes.html dist/nearby.html
           cp apps/web/gmanhole_map.html dist/gmanhole_map.html
           cp apps/web/sitemap.xml dist/sitemap.xml

--- a/apps/scraper/generate_sitemap.py
+++ b/apps/scraper/generate_sitemap.py
@@ -109,6 +109,7 @@ def url_entry(loc: str, changefreq: str, priority: str) -> str:
 def build_sitemap(photo_ids: list[str]) -> str:
     entries = [
         url_entry(BASE_URL, "daily", "1.0"),
+        url_entry(f"{BASE_URL}summary", "weekly", "0.8"),
         url_entry(f"{BASE_URL}nearby.html", "weekly", "0.6"),
         url_entry(f"{BASE_URL}gmanhole_map.html", "weekly", "0.6"),
     ]

--- a/apps/web/assets/pokefuta-map.css
+++ b/apps/web/assets/pokefuta-map.css
@@ -292,6 +292,14 @@ body.pokefuta-map-page {
   letter-spacing: 0;
 }
 
+.pokefuta-map-page .section-title-row h2 {
+  margin: 0;
+  color: #1f1b18;
+  font-size: .98rem;
+  font-weight: 900;
+  letter-spacing: 0;
+}
+
 .pokefuta-map-page .section-title-row span {
   color: #6b4aa2;
   font-size: .82rem;
@@ -301,6 +309,55 @@ body.pokefuta-map-page {
 .pokefuta-map-page .prefecture-card-list {
   max-height: none;
   overflow: visible;
+}
+
+.pokefuta-map-page .prefecture-directory {
+  margin: 14px 0 2px;
+  padding: 12px;
+  border: 1px solid rgba(116, 82, 38, .15);
+  border-radius: 14px;
+  background: rgba(255, 253, 246, .76);
+}
+
+.pokefuta-map-page .prefecture-directory .section-title-row {
+  margin: 0 0 6px;
+}
+
+.pokefuta-map-page .prefecture-directory p {
+  margin: 0 0 10px;
+  color: #5f5146;
+  font-size: .84rem;
+  font-weight: 700;
+  line-height: 1.5;
+}
+
+.pokefuta-map-page .prefecture-directory-links {
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+  padding-bottom: 2px;
+  scrollbar-width: thin;
+}
+
+.pokefuta-map-page .prefecture-directory-links a {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 6px;
+  min-height: 34px;
+  padding: 0 10px;
+  border: 1px solid rgba(126, 107, 169, .22);
+  border-radius: 999px;
+  background: #fffaf0;
+  color: #342b45;
+  font-size: .82rem;
+  font-weight: 900;
+  text-decoration: none;
+}
+
+.pokefuta-map-page .prefecture-directory-links a span {
+  color: #6b4aa2;
+  font-size: .74rem;
 }
 
 .pokefuta-map-page #prefecture-table-body {

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -3,14 +3,14 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>ポケふた マップ | 全国ポケモンマンホール一覧</title>
-  <meta name="description" content="全国のポケモンマンホール（ポケふた）を地図で探索。都道府県・ポケモン名・最近追加フィルタで絞り込み可能。">
+  <title>ポケふたマップ｜全国のポケモンマンホール一覧・地図</title>
+  <meta name="description" content="全国のポケふた・ポケモンマンホールを地図で探せるマップサービスです。都道府県別の一覧、設置場所、近くのポケふた探しに対応しています。">
   <meta name="keywords" content="ポケふた,ポケモンマンホール,マンホール,ポケモン,聖地巡礼,地図">
   <meta name="robots" content="index,follow">
   <meta property="og:type" content="website">
   <meta property="og:locale" content="ja_JP">
-  <meta property="og:title" content="ポケふた マップ | 全国ポケモンマンホール一覧">
-  <meta property="og:description" content="全国のポケモンマンホール（ポケふた）を地図で探索。都道府県・ポケモン名・最近追加フィルタで絞り込み可能。">
+  <meta property="og:title" content="ポケふたマップ｜全国のポケモンマンホール一覧・地図">
+  <meta property="og:description" content="全国のポケふた・ポケモンマンホールを地図で探せるマップサービスです。都道府県別の一覧、設置場所、近くのポケふた探しに対応しています。">
   <meta property="og:url" content="https://data.pokefuta.com/">
   <meta property="og:image" content="https://data.pokefuta.com/assets/pokefuta_icon_32.png">
   <link rel="canonical" href="https://data.pokefuta.com/">
@@ -40,10 +40,10 @@
     window.buildPrefecturePageMeta = function(prefecture) {
       const title = prefecture
         ? `${prefecture}のポケふた マップ | ポケモンマンホール一覧`
-        : 'ポケふた マップ | 全国ポケモンマンホール一覧';
+        : 'ポケふたマップ｜全国のポケモンマンホール一覧・地図';
       const description = prefecture
         ? `${prefecture}のポケモンマンホール（ポケふた）を地図で確認。設置場所、市町村、登場ポケモンを一覧できます。`
-        : '全国のポケモンマンホール（ポケふた）を地図で探索。都道府県・ポケモン名・最近追加フィルタで絞り込み可能。';
+        : '全国のポケふた・ポケモンマンホールを地図で探せるマップサービスです。都道府県別の一覧、設置場所、近くのポケふた探しに対応しています。';
       const canonicalUrl = prefecture
         ? `${window.SITE_BASE_URL}?pref=${encodeURIComponent(prefecture)}`
         : window.SITE_BASE_URL;
@@ -174,7 +174,7 @@
   <main class="map-stage" aria-label="ポケふた探索マップ">
     <div id="map"></div>
     <section class="map-hero-card" aria-labelledby="hero-title">
-      <h1 id="hero-title">全国470枚のポケふたを探そう</h1>
+      <h1 id="hero-title">全国のポケふた・ポケモンマンホールマップ</h1>
       <p>旅行やお出かけのついでに、ご当地マンホール「ポケふた」を見つけよう</p>
       <p class="map-hero-meta">📍 全国<span id="hero-city-count">0</span>の自治体に設置</p>
     </section>
@@ -192,7 +192,7 @@
         <div class="sheet-action-grid" aria-label="探索メニュー">
           <button type="button" id="prefecture-open-button" class="sheet-action-btn">
             <img src="./assets/icon-map.svg" alt="" aria-hidden="true">
-            都道府県から探す
+            地図で探す
           </button>
           <label class="sheet-action-btn sheet-action-btn--toggle" for="recent-toggle">
             <input type="checkbox" id="recent-toggle" />
@@ -201,10 +201,17 @@
           </label>
           <button type="button" id="locate-button" class="sheet-action-btn">
             <img src="./assets/icon-current-location.svg" alt="" aria-hidden="true">
-            <span id="locate-button-label">近くのポケふた</span>
+            <span id="locate-button-label">近くのポケふたを探す</span>
           </button>
         </div>
       </div>
+      <section class="prefecture-directory" aria-labelledby="prefecture-directory-heading">
+        <div class="section-title-row">
+          <h2 id="prefecture-directory-heading">都道府県別のポケふた一覧</h2>
+        </div>
+        <p>旅行先やお出かけ先の近くにあるポケふたを、都道府県別に探せます。</p>
+        <div id="prefecture-directory-links" class="prefecture-directory-links" aria-label="ポケふたがある都道府県"></div>
+      </section>
       <section id="nearby-results" class="nearby-results" aria-live="polite" hidden>
         <div class="section-title-row">
           <h4>近くのポケふた</h4>
@@ -764,6 +771,7 @@
         }
         
         populatePrefectureTable();
+        renderPrefectureDirectory();
         updateStats();
         initRecentFilter();
         updateRecentSummary();
@@ -1194,6 +1202,19 @@
           });
         });
       });
+    }
+
+    function renderPrefectureDirectory() {
+      const links = document.getElementById('prefecture-directory-links');
+      if (!links) return;
+      const prefectures = Object.keys(window.PREFECTURE_CODE_MAP)
+        .filter(prefecture => (prefectureCounts[prefecture] || 0) > 0)
+        .sort((a, b) => window.PREFECTURE_CODE_MAP[a].localeCompare(window.PREFECTURE_CODE_MAP[b]));
+      links.innerHTML = prefectures.map(prefecture => {
+        const count = prefectureCounts[prefecture] || 0;
+        const href = window.buildCanonicalPath(prefecture);
+        return `<a href="${href}" data-prefecture="${escapeHtml(prefecture)}">${escapeHtml(prefecture)}<span>${count}枚</span></a>`;
+      }).join('');
     }
 
     function renderRecentAdded() {

--- a/apps/web/sitemap.xml
+++ b/apps/web/sitemap.xml
@@ -6,6 +6,11 @@
     <priority>1.0</priority>
   </url>
   <url>
+    <loc>https://data.pokefuta.com/summary</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://data.pokefuta.com/nearby.html</loc>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>

--- a/apps/web/summary.html
+++ b/apps/web/summary.html
@@ -1,0 +1,348 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>ポケふたは全国に何個ある？都道府県別の数・多い県ランキング</title>
+  <meta name="description" content="全国のポケふた・ポケモンマンホールの総数、都道府県別の設置数、多い県、まだ設置されていない県をまとめています。">
+  <meta name="robots" content="index,follow">
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="ja_JP">
+  <meta property="og:title" content="ポケふたは全国に何個ある？都道府県別の数・多い県ランキング">
+  <meta property="og:description" content="全国のポケふた・ポケモンマンホールの総数、都道府県別の設置数、多い県、まだ設置されていない県をまとめています。">
+  <meta property="og:url" content="https://data.pokefuta.com/summary">
+  <meta property="og:image" content="https://data.pokefuta.com/assets/pokefuta_icon_32.png">
+  <link rel="canonical" href="https://data.pokefuta.com/summary">
+  <link rel="stylesheet" href="../assets/theme.css">
+  <link rel="icon" href="../assets/pokefuta-marker.svg" type="image/svg+xml">
+  <style>
+    body {
+      margin: 0;
+      background: #f7f0df;
+      color: #201b16;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.7;
+    }
+
+    .summary-page {
+      max-width: 1040px;
+      margin: 0 auto;
+      padding: 24px 16px 48px;
+    }
+
+    .summary-hero {
+      padding: 28px 0 18px;
+    }
+
+    .summary-hero a,
+    .summary-link {
+      color: #176f68;
+      font-weight: 850;
+      text-decoration: none;
+    }
+
+    .summary-hero h1 {
+      margin: 8px 0 10px;
+      font-size: clamp(2rem, 7vw, 3.4rem);
+      line-height: 1.12;
+      letter-spacing: 0;
+    }
+
+    .summary-hero p {
+      max-width: 720px;
+      margin: 0;
+      color: #574b41;
+      font-size: 1rem;
+      font-weight: 650;
+    }
+
+    .summary-stats {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 12px;
+      margin: 20px 0 24px;
+    }
+
+    .summary-stat {
+      padding: 16px;
+      border: 1px solid rgba(93, 67, 35, .16);
+      border-radius: 8px;
+      background: #fffaf0;
+    }
+
+    .summary-stat span {
+      display: block;
+      color: #716154;
+      font-size: .84rem;
+      font-weight: 800;
+    }
+
+    .summary-stat strong {
+      display: block;
+      margin-top: 4px;
+      font-size: 2rem;
+      line-height: 1.1;
+    }
+
+    .summary-section {
+      margin-top: 28px;
+    }
+
+    .summary-section h2 {
+      margin: 0 0 10px;
+      font-size: 1.35rem;
+      letter-spacing: 0;
+    }
+
+    .summary-table-wrap {
+      overflow-x: auto;
+      border: 1px solid rgba(93, 67, 35, .16);
+      border-radius: 8px;
+      background: #fffdf7;
+    }
+
+    table {
+      width: 100%;
+      min-width: 520px;
+      border-collapse: collapse;
+    }
+
+    th,
+    td {
+      padding: 11px 12px;
+      border-bottom: 1px solid rgba(93, 67, 35, .11);
+      text-align: left;
+    }
+
+    th {
+      background: #fff6e6;
+      font-size: .84rem;
+      font-weight: 900;
+    }
+
+    tr:last-child td {
+      border-bottom: 0;
+    }
+
+    .summary-list {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 10px;
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .summary-list li,
+    .summary-empty {
+      padding: 12px;
+      border: 1px solid rgba(93, 67, 35, .14);
+      border-radius: 8px;
+      background: #fffaf0;
+      font-weight: 800;
+    }
+
+    .summary-list small {
+      display: block;
+      color: #6d5f55;
+      font-weight: 750;
+    }
+
+    .summary-cta {
+      display: inline-flex;
+      align-items: center;
+      min-height: 44px;
+      margin-top: 10px;
+      padding: 0 16px;
+      border-radius: 8px;
+      background: #176f68;
+      color: #fff;
+      font-weight: 900;
+      text-decoration: none;
+    }
+
+    @media (max-width: 700px) {
+      .summary-stats {
+        grid-template-columns: 1fr;
+      }
+
+      .summary-hero h1 {
+        font-size: 2rem;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main class="summary-page">
+    <nav class="summary-hero" aria-label="パンくず">
+      <a href="/">全国マップ</a>
+      <h1>ポケふたは全国に何個ある？</h1>
+      <p>全国のポケふた・ポケモンマンホールを、既存データから都道府県別に集計しています。</p>
+    </nav>
+
+    <section class="summary-stats" aria-label="全国集計">
+      <div class="summary-stat">
+        <span>全国の総数</span>
+        <strong id="total-count">読み込み中</strong>
+      </div>
+      <div class="summary-stat">
+        <span>設置済み都道府県</span>
+        <strong id="installed-prefecture-count">-</strong>
+      </div>
+      <div class="summary-stat">
+        <span>未設置県</span>
+        <strong id="empty-prefecture-count">-</strong>
+      </div>
+    </section>
+
+    <section class="summary-section" aria-labelledby="prefecture-count-heading">
+      <h2 id="prefecture-count-heading">都道府県別の設置数一覧</h2>
+      <div class="summary-table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">都道府県</th>
+              <th scope="col">ポケふた数</th>
+              <th scope="col">地図</th>
+            </tr>
+          </thead>
+          <tbody id="prefecture-count-table">
+            <tr><td colspan="3">読み込み中です。</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section class="summary-section" aria-labelledby="ranking-heading">
+      <h2 id="ranking-heading">ポケふたが多い県ランキング</h2>
+      <ol id="ranking-list" class="summary-list"></ol>
+    </section>
+
+    <section class="summary-section" aria-labelledby="empty-prefecture-heading">
+      <h2 id="empty-prefecture-heading">ポケふたがない県</h2>
+      <ul id="empty-prefecture-list" class="summary-list"></ul>
+    </section>
+
+    <section class="summary-section" aria-labelledby="map-link-heading">
+      <h2 id="map-link-heading">全国マップで探す</h2>
+      <p>設置場所や近くのポケふたは、地図上で確認できます。</p>
+      <a class="summary-cta" href="/">地図で全国のポケふたを探す</a>
+    </section>
+  </main>
+
+  <script>
+    const PREFECTURE_CODE_MAP = Object.freeze({
+      '北海道': '01', '青森県': '02', '岩手県': '03', '宮城県': '04', '秋田県': '05',
+      '山形県': '06', '福島県': '07', '茨城県': '08', '栃木県': '09', '群馬県': '10',
+      '埼玉県': '11', '千葉県': '12', '東京都': '13', '神奈川県': '14', '新潟県': '15',
+      '富山県': '16', '石川県': '17', '福井県': '18', '山梨県': '19', '長野県': '20',
+      '岐阜県': '21', '静岡県': '22', '愛知県': '23', '三重県': '24', '滋賀県': '25',
+      '京都府': '26', '大阪府': '27', '兵庫県': '28', '奈良県': '29', '和歌山県': '30',
+      '鳥取県': '31', '島根県': '32', '岡山県': '33', '広島県': '34', '山口県': '35',
+      '徳島県': '36', '香川県': '37', '愛媛県': '38', '高知県': '39', '福岡県': '40',
+      '佐賀県': '41', '長崎県': '42', '熊本県': '43', '大分県': '44', '宮崎県': '45',
+      '鹿児島県': '46', '沖縄県': '47'
+    });
+
+    function escapeHtml(value) {
+      return String(value ?? '').replace(/[&<>"']/g, ch => ({
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;'
+      }[ch]));
+    }
+
+    async function fetchPokefutaData() {
+      const paths = ['../pokefuta.ndjson', '/pokefuta.ndjson', './pokefuta.ndjson'];
+      for (const path of paths) {
+        try {
+          const response = await fetch(path, { cache: 'no-store' });
+          if (response.ok) return response.text();
+        } catch (error) {
+          console.warn(`Failed to load ${path}`, error);
+        }
+      }
+      throw new Error('pokefuta.ndjson could not be loaded');
+    }
+
+    function parseRecords(text) {
+      const byId = new Map();
+      text.split('\n').forEach(line => {
+        if (!line.trim()) return;
+        let record;
+        try {
+          record = JSON.parse(line);
+        } catch {
+          return;
+        }
+        const id = String(record.id || '').trim();
+        if (!id) return;
+        byId.set(id, { ...byId.get(id), ...record });
+      });
+      return [...byId.values()];
+    }
+
+    function buildSummary(records) {
+      const counts = {};
+      records.forEach(record => {
+        const prefecture = record.prefecture;
+        if (!PREFECTURE_CODE_MAP[prefecture]) return;
+        counts[prefecture] = (counts[prefecture] || 0) + 1;
+      });
+      return Object.keys(PREFECTURE_CODE_MAP)
+        .map(prefecture => ({
+          prefecture,
+          code: PREFECTURE_CODE_MAP[prefecture],
+          count: counts[prefecture] || 0
+        }))
+        .sort((a, b) => a.code.localeCompare(b.code));
+    }
+
+    function render(summary) {
+      const total = summary.reduce((sum, item) => sum + item.count, 0);
+      const installed = summary.filter(item => item.count > 0);
+      const empty = summary.filter(item => item.count === 0);
+      const ranking = [...installed].sort((a, b) => b.count - a.count || a.code.localeCompare(b.code)).slice(0, 10);
+
+      document.getElementById('total-count').textContent = `${total}枚`;
+      document.getElementById('installed-prefecture-count').textContent = `${installed.length}都道府県`;
+      document.getElementById('empty-prefecture-count').textContent = `${empty.length}県`;
+
+      document.getElementById('prefecture-count-table').innerHTML = summary.map(item => {
+        const href = `/?pref=${encodeURIComponent(item.prefecture)}`;
+        const link = item.count > 0 ? `<a class="summary-link" href="${href}">地図で見る</a>` : '-';
+        return `
+          <tr>
+            <td>${escapeHtml(item.prefecture)}</td>
+            <td>${item.count}枚</td>
+            <td>${link}</td>
+          </tr>
+        `;
+      }).join('');
+
+      document.getElementById('ranking-list').innerHTML = ranking.map(item => `
+        <li>
+          ${escapeHtml(item.prefecture)}
+          <small>${item.count}枚</small>
+        </li>
+      `).join('');
+
+      document.getElementById('empty-prefecture-list').innerHTML = empty.length
+        ? empty.map(item => `<li>${escapeHtml(item.prefecture)}</li>`).join('')
+        : '<li class="summary-empty">現在、未設置県はありません。</li>';
+    }
+
+    fetchPokefutaData()
+      .then(parseRecords)
+      .then(buildSummary)
+      .then(render)
+      .catch(error => {
+        console.error(error);
+        document.getElementById('total-count').textContent = '取得失敗';
+        document.getElementById('prefecture-count-table').innerHTML = '<tr><td colspan="3">データを読み込めませんでした。</td></tr>';
+      });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Update the top page title, description, OGP title, H1, and primary CTA labels for map/list search intent.
- Add a prefecture directory block on the map page using existing Pokefuta data and `/?pref=...` links.
- Add `/summary` with data-driven totals, prefecture counts, ranking, empty prefectures, and a link back to the national map.
- Add `/summary` to sitemap generation and deploy it as `summary/index.html`.

## Verification
- `python3 apps/scraper/generate_sitemap.py`
- Parsed `apps/web/sitemap.xml` with Python XML parser; confirmed `/summary` appears once and existing root/nearby/gmanhole/pref/manhole URLs remain.
- `git diff --check`
- Playwright mobile smoke check on local dist: top and `/summary` rendered without horizontal overflow; summary showed 469 total, 41 installed prefectures, and 6 empty prefectures.

## Notes
- Existing uncommitted workflow edits in `.github/workflows/pages-deploy.yml` and `.github/workflows/update-pokefuta.yml` were left out of this commit except the two lines needed to deploy `/summary`.