### PR TITLE
Fix false positive diffs by tracking is_prefecture_site field

### DIFF
--- a/apps/scraper/scrape_pokefuta.py
+++ b/apps/scraper/scrape_pokefuta.py
@@ -267,6 +267,18 @@ def parse_detail(detail_url: str, html: str, logger: logging.Logger) -> Optional
             if not address:
                 break
 
+    # Detect prefecture_site_url from link text
+    prefecture_site_url = ""
+    is_prefecture_site = False
+    for a in soup.select("a[href]"):
+        txt = a.get_text(strip=True)
+        if "ローカルActs" in txt and "ページへ" in txt:
+            href = a.get("href", "")
+            if href and "/municipality/" in href:
+                prefecture_site_url = href
+                is_prefecture_site = True
+                break
+
     # Use second precision UTC format compatible with JS Date parsing
     now_iso = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
     return {
@@ -275,18 +287,19 @@ def parse_detail(detail_url: str, html: str, logger: logging.Logger) -> Optional
         "prefecture": prefecture,
         "city": city,
         "address": address,
+        "building": "",
         "city_url": "",
         "lat": lat,
         "lng": lng,
         "pokemons": pokemons,
-        "pokemons": pokemons,
         "detail_url": detail_url,
-        "prefecture_site_url": "",
+        "prefecture_site_url": prefecture_site_url,
         # extended schema (for consistency with incremental updater)
         "first_seen": now_iso,
         "added_at": now_iso,  # alias for first_seen used by web UI
         "last_updated": now_iso,  # unified update timestamp
-        "status": "active"
+        "status": "active",
+        "is_prefecture_site": is_prefecture_site
     }
 
 
@@ -363,7 +376,7 @@ CORE_COMPARE_FIELDS = [
     "address_raw", "address_norm", "place_detail", "landmark", "access",
     "parking", "nearby_spots", "tags", "source_urls", "verified_at",
     "confidence", "lat", "lng", "pokemons", "detail_url",
-    "prefecture_site_url", "status"
+    "prefecture_site_url", "status", "is_prefecture_site"
 ]
 
 

--- a/apps/scraper/update_pokefuta.py
+++ b/apps/scraper/update_pokefuta.py
@@ -52,7 +52,7 @@ CORE_COMPARE_FIELDS = [
     "address_raw", "address_norm", "place_detail", "landmark", "access",
     "parking", "nearby_spots", "tags", "source_urls", "verified_at",
     "confidence", "lat", "lng", "pokemons", "detail_url",
-    "prefecture_site_url", "status"
+    "prefecture_site_url", "status", "is_prefecture_site"
 ]
 
 PLACEHOLDER_STRINGS = {s.lower() for s in [
@@ -335,6 +335,18 @@ def parse_detail(detail_url: str, html: str, logger: logging.Logger, title_data:
             address = max(matches, key=len).strip()
             break
     
+    # Detect prefecture_site_url from link text
+    prefecture_site_url = ""
+    is_prefecture_site = False
+    for a in soup.select("a[href]"):
+        txt = a.get_text(strip=True)
+        if "ローカルActs" in txt and "ページへ" in txt:
+            href = a.get("href", "")
+            if href and "/municipality/" in href:
+                prefecture_site_url = href
+                is_prefecture_site = True
+                break
+
     # Use second precision UTC format compatible with JS Date parsing
     now_iso = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
     return {
@@ -349,12 +361,13 @@ def parse_detail(detail_url: str, html: str, logger: logging.Logger, title_data:
         "lng": lng,
         "pokemons": pokemons,
         "detail_url": detail_url,
-        "prefecture_site_url": "",
+        "prefecture_site_url": prefecture_site_url,
         # extended schema (for consistency with incremental updater)
         "first_seen": now_iso,
         "added_at": now_iso,  # alias for first_seen used by web UI
         "last_updated": now_iso,  # unified update timestamp
-        "status": "active"
+        "status": "active",
+        "is_prefecture_site": is_prefecture_site
     }
 
 


### PR DESCRIPTION
## Summary
- Fixed issue where `last_updated` was being updated for all records even when no actual data changed
- Added `is_prefecture_site` field detection in `parse_detail()` function
- Added `is_prefecture_site` to `CORE_COMPARE_FIELDS` for proper comparison
- Fixed duplicate `pokemons` key and added missing `building` field in scrape_pokefuta.py

## Problem
PR #78 showed that the daily scraper was updating `last_updated` timestamps for all岩手県 and 香川県 records without any actual data changes, causing unnecessary noise in the diff.

## Root Cause
1. The `parse_detail()` function wasn't setting the `is_prefecture_site` field
2. `is_prefecture_site` wasn't included in `CORE_COMPARE_FIELDS`
3. This caused scraped records to have a different structure than existing records
4. Field structure mismatches were incorrectly detected as data changes

## Solution
### 1. Detect and set `is_prefecture_site` in `parse_detail()`
Added logic to detect prefecture site URLs by checking for "ローカルActs" links pointing to `/municipality/` pages:
```python
# Detect prefecture_site_url from link text
prefecture_site_url = ""
is_prefecture_site = False
for a in soup.select("a[href]"):
    txt = a.get_text(strip=True)
    if "ローカルActs" in txt and "ページへ" in txt:
        href = a.get("href", "")
        if href and "/municipality/" in href:
            prefecture_site_url = href
            is_prefecture_site = True
            break
```

### 2. Add `is_prefecture_site` to comparison fields
Updated `CORE_COMPARE_FIELDS` to include `"is_prefecture_site"` so that changes to this field are properly detected.

### 3. Fix schema consistency
- Added missing `building` field
- Fixed duplicate `pokemons` key in scrape_pokefuta.py

## Test Results
Verified the fix with unit tests:
```
Test 1 (same data, different timestamp): False ✓
Expected: False (no change)

Test 2 (different is_prefecture_site): True ✓
Expected: True (changed)

Test 3 (different title): True ✓
Expected: True (changed)
```

## Impact
- `last_updated` will only be updated when data actually changes
- No more false positive diffs from field structure mismatches
- Next daily update will only show records with real data changes
- Cleaner git history and easier to spot actual changes

## Related
- Fixes the issue observed in PR #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)