### PR TITLE
feat: Add Pokemon Discovery enhancements with multilingual SEO

### DIFF
--- a/apps/web/assets/pokefuta-map.css
+++ b/apps/web/assets/pokefuta-map.css
@@ -875,6 +875,105 @@ body.pokefuta-map-page {
   color: #168074;
 }
 
+/* Pokemon Info Card */
+.pokefuta-map-page .pokemon-info-card {
+  margin: 14px 0 0;
+  padding: 14px 16px;
+  border-radius: 12px;
+  background: rgba(255, 251, 240, 0.92);
+  border: 1px solid rgba(126, 107, 169, 0.18);
+}
+
+.pokefuta-map-page .pokemon-info-card h4 {
+  margin: 0 0 10px;
+  color: #1f1b18;
+  font-size: 0.92rem;
+  font-weight: 900;
+  letter-spacing: 0;
+}
+
+.pokefuta-map-page .pokemon-info-row {
+  margin: 6px 0;
+  color: #3f3730;
+  font-size: 0.82rem;
+  line-height: 1.5;
+  font-weight: 650;
+}
+
+.pokefuta-map-page .pokemon-info-row strong {
+  font-weight: 900;
+  color: #2a241e;
+}
+
+.pokefuta-map-page .pokemon-type-badge {
+  display: inline-block;
+  margin-right: 6px;
+  padding: 3px 9px;
+  border-radius: 999px;
+  background: rgba(126, 107, 169, 0.15);
+  color: #654aa0;
+  font-size: 0.76rem;
+  font-weight: 800;
+  line-height: 1.3;
+}
+
+.pokefuta-map-page .pokemon-info-multilang {
+  margin: 8px 0 0;
+  padding-top: 8px;
+  border-top: 1px solid rgba(126, 107, 169, 0.12);
+  color: #5b5046;
+  font-size: 0.78rem;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+/* Same Pokemon Section */
+.pokefuta-map-page .same-pokemon-section {
+  margin: 12px 0 0;
+  padding: 12px 0 0;
+  border-top: 1px solid rgba(115, 86, 42, 0.12);
+}
+
+.pokefuta-map-page .same-pokemon-section h5 {
+  margin: 0 0 8px;
+  color: #2a241e;
+  font-size: 0.88rem;
+  font-weight: 900;
+  letter-spacing: 0;
+}
+
+.pokefuta-map-page .same-pokemon-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.pokefuta-map-page .same-pokemon-item {
+  padding: 8px 12px;
+  border: 1px solid rgba(115, 86, 42, 0.14);
+  border-radius: 8px;
+  background: #fffaf0;
+  color: #2a241e;
+  font: inherit;
+  font-size: 0.82rem;
+  font-weight: 750;
+  text-align: left;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.pokefuta-map-page .same-pokemon-item:hover,
+.pokefuta-map-page .same-pokemon-item:focus-visible {
+  background: rgba(126, 107, 169, 0.08);
+  border-color: rgba(126, 107, 169, 0.3);
+  outline: none;
+}
+
+.pokefuta-map-page .same-pokemon-item:active {
+  background: rgba(126, 107, 169, 0.14);
+  transform: scale(0.98);
+}
+
 .pokefuta-cluster {
   display: grid;
   place-items: center;
@@ -998,6 +1097,37 @@ body.pokefuta-map-page {
   .pokefuta-map-page .travel-popup-action {
     min-height: 34px;
     font-size: .7rem;
+  }
+
+  /* Pokemon Info Card - Desktop adjustments */
+  .pokefuta-map-page .pokemon-info-card {
+    padding: 12px 14px;
+  }
+
+  .pokefuta-map-page .pokemon-info-card h4 {
+    font-size: 0.88rem;
+  }
+
+  .pokefuta-map-page .pokemon-info-row {
+    font-size: 0.78rem;
+  }
+
+  .pokefuta-map-page .pokemon-type-badge {
+    font-size: 0.72rem;
+    padding: 2px 8px;
+  }
+
+  .pokefuta-map-page .pokemon-info-multilang {
+    font-size: 0.74rem;
+  }
+
+  .pokefuta-map-page .same-pokemon-section h5 {
+    font-size: 0.84rem;
+  }
+
+  .pokefuta-map-page .same-pokemon-item {
+    font-size: 0.78rem;
+    padding: 7px 11px;
   }
 }
 

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -84,39 +84,63 @@
         window.applyDefaultMeta();
         return;
       }
-      
+
       const prefecture = manhole.prefecture || '';
       const city = manhole.city || '';
       const pokemons = Array.isArray(manhole.pokemons)
         ? manhole.pokemons.filter(p => typeof p === 'string' && !p.includes('ローカルActs'))
         : [];
-      const pokemonText = pokemons.length > 0 
-        ? pokemons.length === 1
-          ? pokemons[0]
-          : pokemons.join('・')
-        : 'ポケモン';
-      
-      // title: {都道府県} {市区町村}のポケふた｜{ポケモン名}のポケモンマンホール
-      const title = prefecture && city
-        ? `${prefecture} ${city}のポケふた｜${pokemonText}のポケモンマンホール`
-        : `ポケふた｜${pokemonText}のポケモンマンホール`;
-      
-      // description: {都道府県}{市区町村}に設置されたポケモンマンホール「ポケふた」を地図で確認できます。登場ポケモンは{ポケモン名}。旅行中の寄り道やポケふた巡りに便利です。
+
+      // Enhanced Pokemon text with English names
+      let pokemonText = 'ポケモン';
+      let pokemonTextEn = '';
+
+      if (pokemons.length > 0) {
+        if (pokemons.length === 1) {
+          pokemonText = pokemons[0];
+          const meta = getPokemonMetadata(pokemons[0]);
+          if (meta && meta.names) {
+            pokemonTextEn = meta.names.en;
+          }
+        } else {
+          pokemonText = pokemons.join('・');
+        }
+      }
+
+      // title: {ポケモン名}のポケふた | {都道府県}{市区町村} | Pokefuta Map
+      const locationPart = prefecture && city
+        ? `${prefecture}${city}`
+        : prefecture || '';
+      const title = locationPart
+        ? `${pokemonText}のポケふた | ${locationPart} | Pokefuta Map`
+        : `${pokemonText}のポケふた | Pokefuta Map`;
+
+      // description: {都道府県}{市区町村}にある{ポケモン名}（English）のポケふた。場所・写真・訪問記録を地図で確認できます。
       const placeText = prefecture && city ? `${prefecture}${city}` : (prefecture || '');
+      const pokemonWithEn = pokemonTextEn ? `${pokemonText}（${pokemonTextEn}）` : pokemonText;
       const description = placeText
-        ? `${placeText}に設置されたポケモンマンホール「ポケふた」を地図で確認できます。登場ポケモンは${pokemonText}。旅行中の寄り道やポケふた巡りに便利です。`
-        : `ポケモンマンホール「ポケふた」を地図で確認できます。登場ポケモンは${pokemonText}。旅行中の寄り道やポケふた巡りに便利です。`;
-      
-      // keywords: ポケふた,{都道府県},{市区町村},{ポケモン名},ポケモンマンホール,マンホール,聖地巡礼,地図
+        ? `${placeText}にある${pokemonWithEn}のポケふた。場所・写真・訪問記録を地図で確認できます。`
+        : `${pokemonWithEn}のポケふた。場所・写真・訪問記録を地図で確認できます。`;
+
+      // keywords: include multilingual Pokemon names
       const keywordParts = ['ポケふた'];
       if (prefecture) keywordParts.push(prefecture);
       if (city) keywordParts.push(city);
-      keywordParts.push(...pokemons);
-      keywordParts.push('ポケモンマンホール', 'マンホール', '聖地巡礼', '地図');
+
+      pokemons.forEach(nameJa => {
+        keywordParts.push(nameJa);
+        const meta = getPokemonMetadata(nameJa);
+        if (meta && meta.names) {
+          if (meta.names.en) keywordParts.push(meta.names.en);
+          if (meta.names.ko) keywordParts.push(meta.names.ko);
+        }
+      });
+
+      keywordParts.push('ポケモンマンホール', 'Pokemon Manhole', 'マンホール', '聖地巡礼', '地図');
       const keywords = keywordParts.join(',');
-      
+
       const canonicalUrl = `${window.SITE_BASE_URL}?manhole=${encodeURIComponent(manhole.id)}`;
-      
+
       document.title = title;
       document.querySelector('link[rel="canonical"]')?.setAttribute('href', canonicalUrl);
       document.querySelector('meta[name="description"]')?.setAttribute('content', description);
@@ -126,7 +150,7 @@
       document.querySelector('meta[property="og:url"]')?.setAttribute('content', canonicalUrl);
       document.querySelector('meta[name="twitter:title"]')?.setAttribute('content', title);
       document.querySelector('meta[name="twitter:description"]')?.setAttribute('content', description);
-      
+
       window.applyManholeJsonLd(manhole);
     };
 
@@ -163,9 +187,20 @@
       const placeText = [manhole.prefecture, manhole.city].filter(Boolean).join('');
       const titleBase = manhole.title || `ポケふた ${manhole.id}`;
       const baseDescription = `${placeText ? `${placeText}の` : ''}ポケモンマンホール（ポケふた）。`;
-      const pokemonDescription = cleanPokemons.length > 0
-        ? `登場ポケモン: ${cleanPokemons.join(', ')}`
-        : '';
+
+      // Enhanced Pokemon description with multilingual names
+      let pokemonDescription = '';
+      if (cleanPokemons.length > 0) {
+        const pokemonInfoList = cleanPokemons.map(nameJa => {
+          const meta = getPokemonMetadata(nameJa);
+          if (meta && meta.names && meta.names.en) {
+            return `${nameJa} (${meta.names.en})`;
+          }
+          return nameJa;
+        });
+        pokemonDescription = `登場ポケモン: ${pokemonInfoList.join(', ')}`;
+      }
+
       const description = [baseDescription, pokemonDescription].filter(Boolean).join(' ');
 
       const jsonLd = {
@@ -192,8 +227,15 @@
         jsonLd['image'] = `https://data.pokefuta.com/manhole/image/${encodeURIComponent(manhole.id)}_latest.jpeg`;
       }
 
-      // keywords にポケモン名を追加
-      const keywordsArray = ['ポケふた', 'ポケモンマンホール', titleBase, ...cleanPokemons];
+      // keywords with multilingual Pokemon names
+      const keywordsArray = ['ポケふた', 'ポケモンマンホール', 'Pokemon Manhole', titleBase];
+      cleanPokemons.forEach(nameJa => {
+        keywordsArray.push(nameJa);
+        const meta = getPokemonMetadata(nameJa);
+        if (meta && meta.names) {
+          if (meta.names.en) keywordsArray.push(meta.names.en);
+        }
+      });
       jsonLd['keywords'] = keywordsArray.join(', ');
 
       const script = document.createElement('script');
@@ -338,14 +380,6 @@
         </div>
       </div>
       <span id="recent-summary" class="sr-only"></span>
-    </div>
-  </div>
-  <!-- バナーを地図上オーバーレイとして配置 -->
-  <div id="sibling-site-banner" class="upload-banner" role="note" aria-label="兄弟サイトへの写真アップロード案内" aria-live="polite" hidden>
-    <div class="upload-banner__inner">
-      <strong class="upload-banner__title">📷 写真協力のお願い</strong>
-      <span class="upload-banner__body">マンホール写真をお持ちなら兄弟サイト <a href="https://pokefuta.com/" target="_blank" rel="noopener" class="upload-banner__link">pokefuta.com</a> にアップロードして共有できます。</span>
-      <button type="button" aria-label="案内を閉じる" id="banner-close" class="upload-banner__close" title="閉じる">✕</button>
     </div>
   </div>
   <footer class="data-links" role="contentinfo" style="margin:16px auto 0; max-width:960px; text-align:center; font-size:0.9rem; color:#444;">
@@ -714,6 +748,10 @@
         `<a href="https://pokefuta.com/" target="_blank" rel="noopener noreferrer" class="travel-popup-action travel-popup-action--secondary travel-popup-action--upload">写真を投稿</a>`
       ].filter(Boolean).join('');
 
+      // Pokemon Info Cards and Same Pokemon section (only if metadata loaded)
+      const pokemonCards = buildPokemonInfoCards(pokemons);
+      const samePokemonSection = buildSamePokemonSection(pokemons, d.id);
+
       return `
         <div class="popup-box popup-box--photo travel-popup-card">
           ${photoBlock}
@@ -727,6 +765,8 @@
             ${photoComment ? `<p class="travel-popup-comment">${escapeHtml(photoComment)}</p>` : ''}
             <div class="travel-popup-pokemon-list" aria-label="登場ポケモン">${pokemonsHtml}</div>
             <div class="popup-actions travel-popup-actions">${links}</div>
+            ${pokemonCards}
+            ${samePokemonSection}
           </div>
         </div>
       `;
@@ -741,6 +781,118 @@
       } catch (error) {
         console.warn('最新写真メタデータの読み込みに失敗しました', error);
       }
+    }
+
+    // Pokemon metadata loader (non-blocking, graceful degradation)
+    var pokemonMetadata = null;
+
+    async function loadPokemonMetadata() {
+      try {
+        const res = await fetch('./pokemon_metadata.json', { cache: 'default' });
+        if (!res.ok) return null;
+        const data = await res.json();
+        if (!Array.isArray(data)) return null;
+        // Create fast lookup map by Japanese name
+        pokemonMetadata = new Map(data.map(p => [p.names?.ja, p]).filter(([k]) => k));
+        console.log(`Pokemon metadata loaded: ${pokemonMetadata.size} entries`);
+        return pokemonMetadata;
+      } catch (error) {
+        console.warn('Pokemon metadata not available', error);
+        return null;
+      }
+    }
+
+    function getPokemonMetadata(nameJa) {
+      if (!pokemonMetadata || !nameJa) return null;
+      return pokemonMetadata.get(nameJa) || null;
+    }
+
+    function buildPokemonInfoCards(pokemons) {
+      if (!pokemonMetadata || !Array.isArray(pokemons) || pokemons.length === 0) return '';
+
+      const cards = pokemons.slice(0, 2).map(nameJa => {
+        const meta = getPokemonMetadata(nameJa);
+        if (!meta || !meta.names) return '';
+
+        const types = Array.isArray(meta.types) ? meta.types.map(t =>
+          `<span class="pokemon-type-badge">${escapeHtml(t.ja || '')} ${t.en ? `(${escapeHtml(t.en)})` : ''}</span>`
+        ).join('') : '';
+
+        const multilang = [meta.names.en, meta.names.ko, meta.names['zh-Hans']]
+          .filter(Boolean)
+          .map(escapeHtml)
+          .join(' / ');
+
+        return `
+          <div class="pokemon-info-card">
+            <h4>${escapeHtml(nameJa)} / ${escapeHtml(meta.names.en || nameJa)}</h4>
+            ${types ? `<div class="pokemon-info-row"><strong>タイプ:</strong> ${types}</div>` : ''}
+            ${meta.generation ? `<div class="pokemon-info-row"><strong>世代:</strong> 第${meta.generation}世代</div>` : ''}
+            ${multilang ? `<div class="pokemon-info-multilang">${multilang}</div>` : ''}
+          </div>
+        `;
+      }).filter(Boolean);
+
+      return cards.join('');
+    }
+
+    function buildSamePokemonSection(pokemons, currentId) {
+      if (!Array.isArray(pokemons) || pokemons.length === 0) return '';
+
+      // Find all manholes with same Pokemon, excluding current one
+      const matches = allData.filter(d =>
+        d.id !== currentId &&
+        Array.isArray(d.pokemons) &&
+        d.pokemons.some(p => pokemons.includes(p))
+      );
+
+      // Deduplicate by manhole ID (keep first occurrence)
+      const seenIds = new Set();
+      const uniqueMatches = matches.filter(d => {
+        if (seenIds.has(d.id)) return false;
+        seenIds.add(d.id);
+        return true;
+      });
+
+      // Sort by prefecture then city
+      uniqueMatches.sort((a, b) => {
+        const prefA = a.prefecture || '';
+        const prefB = b.prefecture || '';
+        if (prefA !== prefB) return prefA.localeCompare(prefB, 'ja');
+        return (a.city || '').localeCompare(b.city || '', 'ja');
+      });
+
+      // Take max 5 items
+      const displayMatches = uniqueMatches.slice(0, 5);
+
+      if (displayMatches.length === 0) return '';
+
+      const items = displayMatches.map(d => {
+        const safeTitleJs = escapeJs(d.title || d.id);
+        const safeIdJs = escapeJs(d.id);
+
+        // Extract Pokemon names for this manhole
+        const pokemonNames = Array.isArray(d.pokemons)
+          ? d.pokemons.filter(p => !p.includes('ローカルActs')).slice(0, 2).join('・')
+          : '';
+        const pokemonDisplay = pokemonNames ? ` (${pokemonNames})` : '';
+
+        return `
+          <button type="button" class="same-pokemon-item"
+                  data-manhole-id="${escapeHtml(d.id)}"
+                  onclick="openManholePopup('${safeIdJs}'); collapseBottomSheet();"
+                  title="${escapeHtml(d.title || 'ポケふた')}を開く">
+            ${escapeHtml(d.prefecture || '不明')} ${escapeHtml(d.city || '')}${escapeHtml(pokemonDisplay)}
+          </button>
+        `;
+      }).join('');
+
+      return `
+        <div class="same-pokemon-section">
+          <h5>同じポケモンのポケふた</h5>
+          <div class="same-pokemon-list">${items}</div>
+        </div>
+      `;
     }
 
     async function loadPokefutaData() {
@@ -833,6 +985,8 @@
           d._addedDate = normalizeDateString(raw);
         });
         await loadLatestPhotoMeta();
+        // Load Pokemon metadata asynchronously (non-blocking)
+        loadPokemonMetadata().catch(err => console.warn('Pokemon metadata loading failed', err));
         initMarkerLayer();
         // Build markers
         allMarkers = [];
@@ -1639,16 +1793,6 @@
     initControlsToggle(); // Initialize toggle early, before data loading
     initLocationSearch();
     loadPokefutaData();
-    // Banner 初期化
-    (function initSiblingBanner(){
-      const banner = document.getElementById('sibling-site-banner');
-      if(!banner) return;
-      if (document.body.classList.contains('pokefuta-map-page')) return;
-      const closed = localStorage.getItem('pf_banner_closed');
-      if(!closed) banner.hidden = false;
-      const btn = document.getElementById('banner-close');
-      if(btn){ btn.addEventListener('click',()=>{ banner.hidden = true; localStorage.setItem('pf_banner_closed','1'); }); }
-    })();
   </script>
 </body>
 </html>

--- a/apps/web/pokemon_metadata.json
+++ b/apps/web/pokemon_metadata.json
@@ -1,0 +1,26561 @@
+[
+  {
+    "id": "0001",
+    "no": "0001",
+    "form": null,
+    "names": {
+      "ja": "フシギダネ",
+      "en": "Bulbasaur",
+      "ko": "이상해씨",
+      "zh-Hans": "妙蛙种子",
+      "zh-Hant": "妙蛙種子"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0001",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0002",
+    "no": "0002",
+    "form": null,
+    "names": {
+      "ja": "フシギソウ",
+      "en": "Ivysaur",
+      "ko": "이상해풀",
+      "zh-Hans": "妙蛙草",
+      "zh-Hant": "妙蛙草"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0002",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0003",
+    "no": "0003",
+    "form": null,
+    "names": {
+      "ja": "フシギバナ",
+      "en": "Venusaur",
+      "ko": "이상해꽃",
+      "zh-Hans": "妙蛙花",
+      "zh-Hant": "妙蛙花"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0003",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0004",
+    "no": "0004",
+    "form": null,
+    "names": {
+      "ja": "ヒトカゲ",
+      "en": "Charmander",
+      "ko": "파이리",
+      "zh-Hans": "小火龙",
+      "zh-Hant": "小火龍"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0004",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0005",
+    "no": "0005",
+    "form": null,
+    "names": {
+      "ja": "リザード",
+      "en": "Charmeleon",
+      "ko": "리자드",
+      "zh-Hans": "火恐龙",
+      "zh-Hant": "火恐龍"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0005",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0006",
+    "no": "0006",
+    "form": null,
+    "names": {
+      "ja": "リザードン",
+      "en": "Charizard",
+      "ko": "리자몽",
+      "zh-Hans": "喷火龙",
+      "zh-Hant": "噴火龍"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0006",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0007",
+    "no": "0007",
+    "form": null,
+    "names": {
+      "ja": "ゼニガメ",
+      "en": "Squirtle",
+      "ko": "꼬부기",
+      "zh-Hans": "杰尼龟",
+      "zh-Hant": "傑尼龜"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0007",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0008",
+    "no": "0008",
+    "form": null,
+    "names": {
+      "ja": "カメール",
+      "en": "Wartortle",
+      "ko": "어니부기",
+      "zh-Hans": "卡咪龟",
+      "zh-Hant": "卡咪龜"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0008",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0009",
+    "no": "0009",
+    "form": null,
+    "names": {
+      "ja": "カメックス",
+      "en": "Blastoise",
+      "ko": "거북왕",
+      "zh-Hans": "水箭龟",
+      "zh-Hant": "水箭龜"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0009",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0010",
+    "no": "0010",
+    "form": null,
+    "names": {
+      "ja": "キャタピー",
+      "en": "Caterpie",
+      "ko": "캐터피",
+      "zh-Hans": "绿毛虫",
+      "zh-Hant": "綠毛蟲"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0010",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0011",
+    "no": "0011",
+    "form": null,
+    "names": {
+      "ja": "トランセル",
+      "en": "Metapod",
+      "ko": "단데기",
+      "zh-Hans": "铁甲蛹",
+      "zh-Hant": "鐵甲蛹"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0011",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0012",
+    "no": "0012",
+    "form": null,
+    "names": {
+      "ja": "バタフリー",
+      "en": "Butterfree",
+      "ko": "버터플",
+      "zh-Hans": "巴大蝶",
+      "zh-Hant": "巴大蝶"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0012",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0013",
+    "no": "0013",
+    "form": null,
+    "names": {
+      "ja": "ビードル",
+      "en": "Weedle",
+      "ko": "뿔충이",
+      "zh-Hans": "独角虫",
+      "zh-Hant": "獨角蟲"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0013",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0014",
+    "no": "0014",
+    "form": null,
+    "names": {
+      "ja": "コクーン",
+      "en": "Kakuna",
+      "ko": "딱충이",
+      "zh-Hans": "铁壳蛹",
+      "zh-Hant": "鐵殼蛹"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0014",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0015",
+    "no": "0015",
+    "form": null,
+    "names": {
+      "ja": "スピアー",
+      "en": "Beedrill",
+      "ko": "독침붕",
+      "zh-Hans": "大针蜂",
+      "zh-Hant": "大針蜂"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0015",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0016",
+    "no": "0016",
+    "form": null,
+    "names": {
+      "ja": "ポッポ",
+      "en": "Pidgey",
+      "ko": "구구",
+      "zh-Hans": "波波",
+      "zh-Hant": "波波"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0016",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0017",
+    "no": "0017",
+    "form": null,
+    "names": {
+      "ja": "ピジョン",
+      "en": "Pidgeotto",
+      "ko": "피죤",
+      "zh-Hans": "比比鸟",
+      "zh-Hant": "比比鳥"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0017",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0018",
+    "no": "0018",
+    "form": null,
+    "names": {
+      "ja": "ピジョット",
+      "en": "Pidgeot",
+      "ko": "피죤투",
+      "zh-Hans": "大比鸟",
+      "zh-Hant": "大比鳥"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0018",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0019",
+    "no": "0019",
+    "form": null,
+    "names": {
+      "ja": "コラッタ",
+      "en": "Rattata",
+      "ko": "꼬렛",
+      "zh-Hans": "小拉达",
+      "zh-Hant": "小拉達"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0019",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0019-alola",
+    "no": "0019",
+    "form": "alola",
+    "names": {
+      "ja": "コラッタ",
+      "en": "Rattata",
+      "ko": "꼬렛",
+      "zh-Hans": "小拉达",
+      "zh-Hant": "小拉達"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0019-alola",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0020",
+    "no": "0020",
+    "form": null,
+    "names": {
+      "ja": "ラッタ",
+      "en": "Raticate",
+      "ko": "레트라",
+      "zh-Hans": "拉达",
+      "zh-Hant": "拉達"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0020",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0020-alola",
+    "no": "0020",
+    "form": "alola",
+    "names": {
+      "ja": "ラッタ",
+      "en": "Raticate",
+      "ko": "레트라",
+      "zh-Hans": "拉达",
+      "zh-Hant": "拉達"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0020-alola",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0021",
+    "no": "0021",
+    "form": null,
+    "names": {
+      "ja": "オニスズメ",
+      "en": "Spearow",
+      "ko": "깨비참",
+      "zh-Hans": "烈雀",
+      "zh-Hant": "烈雀"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0021",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0022",
+    "no": "0022",
+    "form": null,
+    "names": {
+      "ja": "オニドリル",
+      "en": "Fearow",
+      "ko": "깨비드릴조",
+      "zh-Hans": "大嘴雀",
+      "zh-Hant": "大嘴雀"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0022",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0023",
+    "no": "0023",
+    "form": null,
+    "names": {
+      "ja": "アーボ",
+      "en": "Ekans",
+      "ko": "아보",
+      "zh-Hans": "阿柏蛇",
+      "zh-Hant": "阿柏蛇"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0023",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0024",
+    "no": "0024",
+    "form": null,
+    "names": {
+      "ja": "アーボック",
+      "en": "Arbok",
+      "ko": "아보크",
+      "zh-Hans": "阿柏怪",
+      "zh-Hant": "阿柏怪"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0024",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0025",
+    "no": "0025",
+    "form": null,
+    "names": {
+      "ja": "ピカチュウ",
+      "en": "Pikachu",
+      "ko": "피카츄",
+      "zh-Hans": "皮卡丘",
+      "zh-Hant": "皮卡丘"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0025",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0025-alola",
+    "no": "0025",
+    "form": "alola",
+    "names": {
+      "ja": "ピカチュウ",
+      "en": "Pikachu",
+      "ko": "피카츄",
+      "zh-Hans": "皮卡丘",
+      "zh-Hant": "皮卡丘"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0025-alola",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0026",
+    "no": "0026",
+    "form": null,
+    "names": {
+      "ja": "ライチュウ",
+      "en": "Raichu",
+      "ko": "라이츄",
+      "zh-Hans": "雷丘",
+      "zh-Hant": "雷丘"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0026",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0026-alola",
+    "no": "0026",
+    "form": "alola",
+    "names": {
+      "ja": "ライチュウ",
+      "en": "Raichu",
+      "ko": "라이츄",
+      "zh-Hans": "雷丘",
+      "zh-Hant": "雷丘"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0026-alola",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0027",
+    "no": "0027",
+    "form": null,
+    "names": {
+      "ja": "サンド",
+      "en": "Sandshrew",
+      "ko": "모래두지",
+      "zh-Hans": "穿山鼠",
+      "zh-Hant": "穿山鼠"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0027",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0027-alola",
+    "no": "0027",
+    "form": "alola",
+    "names": {
+      "ja": "サンド",
+      "en": "Sandshrew",
+      "ko": "모래두지",
+      "zh-Hans": "穿山鼠",
+      "zh-Hant": "穿山鼠"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0027-alola",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0028",
+    "no": "0028",
+    "form": null,
+    "names": {
+      "ja": "サンドパン",
+      "en": "Sandslash",
+      "ko": "고지",
+      "zh-Hans": "穿山王",
+      "zh-Hant": "穿山王"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0028",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0028-alola",
+    "no": "0028",
+    "form": "alola",
+    "names": {
+      "ja": "サンドパン",
+      "en": "Sandslash",
+      "ko": "고지",
+      "zh-Hans": "穿山王",
+      "zh-Hant": "穿山王"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0028-alola",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0029",
+    "no": "0029",
+    "form": null,
+    "names": {
+      "ja": "ニドラン♀",
+      "en": "Nidoran♀",
+      "ko": "니드런♀",
+      "zh-Hans": "尼多兰",
+      "zh-Hant": "尼多蘭"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0029",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0030",
+    "no": "0030",
+    "form": null,
+    "names": {
+      "ja": "ニドリーナ",
+      "en": "Nidorina",
+      "ko": "니드리나",
+      "zh-Hans": "尼多娜",
+      "zh-Hant": "尼多娜"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0030",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0031",
+    "no": "0031",
+    "form": null,
+    "names": {
+      "ja": "ニドクイン",
+      "en": "Nidoqueen",
+      "ko": "니드퀸",
+      "zh-Hans": "尼多后",
+      "zh-Hant": "尼多后"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0031",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0032",
+    "no": "0032",
+    "form": null,
+    "names": {
+      "ja": "ニドラン♂",
+      "en": "Nidoran♂",
+      "ko": "니드런♂",
+      "zh-Hans": "尼多朗",
+      "zh-Hant": "尼多朗"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0032",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0033",
+    "no": "0033",
+    "form": null,
+    "names": {
+      "ja": "ニドリーノ",
+      "en": "Nidorino",
+      "ko": "니드리노",
+      "zh-Hans": "尼多力诺",
+      "zh-Hant": "尼多力諾"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0033",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0034",
+    "no": "0034",
+    "form": null,
+    "names": {
+      "ja": "ニドキング",
+      "en": "Nidoking",
+      "ko": "니드킹",
+      "zh-Hans": "尼多王",
+      "zh-Hant": "尼多王"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0034",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0035",
+    "no": "0035",
+    "form": null,
+    "names": {
+      "ja": "ピッピ",
+      "en": "Clefairy",
+      "ko": "삐삐",
+      "zh-Hans": "皮皮",
+      "zh-Hant": "皮皮"
+    },
+    "types": [
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0035",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0036",
+    "no": "0036",
+    "form": null,
+    "names": {
+      "ja": "ピクシー",
+      "en": "Clefable",
+      "ko": "픽시",
+      "zh-Hans": "皮可西",
+      "zh-Hant": "皮可西"
+    },
+    "types": [
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0036",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0037",
+    "no": "0037",
+    "form": null,
+    "names": {
+      "ja": "ロコン",
+      "en": "Vulpix",
+      "ko": "식스테일",
+      "zh-Hans": "六尾",
+      "zh-Hant": "六尾"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0037",
+      "evolves_from": null,
+      "evolves_to": [
+        "0038"
+      ]
+    },
+    "color": null
+  },
+  {
+    "id": "0037-alola",
+    "no": "0037",
+    "form": "alola",
+    "names": {
+      "ja": "ロコン",
+      "en": "Vulpix",
+      "ko": "식스테일",
+      "zh-Hans": "六尾",
+      "zh-Hant": "六尾"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0037-alola",
+      "evolves_from": null,
+      "evolves_to": [
+        "0038-alola"
+      ]
+    },
+    "color": null
+  },
+  {
+    "id": "0038",
+    "no": "0038",
+    "form": null,
+    "names": {
+      "ja": "キュウコン",
+      "en": "Ninetales",
+      "ko": "나인테일",
+      "zh-Hans": "九尾",
+      "zh-Hant": "九尾"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0037",
+      "evolves_from": "0037",
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0038-alola",
+    "no": "0038",
+    "form": "alola",
+    "names": {
+      "ja": "キュウコン",
+      "en": "Ninetales",
+      "ko": "나인테일",
+      "zh-Hans": "九尾",
+      "zh-Hant": "九尾"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0037-alola",
+      "evolves_from": "0037-alola",
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0039",
+    "no": "0039",
+    "form": null,
+    "names": {
+      "ja": "プリン",
+      "en": "Jigglypuff",
+      "ko": "푸린",
+      "zh-Hans": "胖丁",
+      "zh-Hant": "胖丁"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0039",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0040",
+    "no": "0040",
+    "form": null,
+    "names": {
+      "ja": "プクリン",
+      "en": "Wigglytuff",
+      "ko": "푸크린",
+      "zh-Hans": "胖可丁",
+      "zh-Hant": "胖可丁"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0040",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0041",
+    "no": "0041",
+    "form": null,
+    "names": {
+      "ja": "ズバット",
+      "en": "Zubat",
+      "ko": "주뱃",
+      "zh-Hans": "超音蝠",
+      "zh-Hant": "超音蝠"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0041",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0042",
+    "no": "0042",
+    "form": null,
+    "names": {
+      "ja": "ゴルバット",
+      "en": "Golbat",
+      "ko": "골뱃",
+      "zh-Hans": "大嘴蝠",
+      "zh-Hant": "大嘴蝠"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0042",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0043",
+    "no": "0043",
+    "form": null,
+    "names": {
+      "ja": "ナゾノクサ",
+      "en": "Oddish",
+      "ko": "뚜벅쵸",
+      "zh-Hans": "走路草",
+      "zh-Hant": "走路草"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0043",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0044",
+    "no": "0044",
+    "form": null,
+    "names": {
+      "ja": "クサイハナ",
+      "en": "Gloom",
+      "ko": "냄새꼬",
+      "zh-Hans": "臭臭花",
+      "zh-Hant": "臭臭花"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0044",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0045",
+    "no": "0045",
+    "form": null,
+    "names": {
+      "ja": "ラフレシア",
+      "en": "Vileplume",
+      "ko": "라플레시아",
+      "zh-Hans": "霸王花",
+      "zh-Hant": "霸王花"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0045",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0046",
+    "no": "0046",
+    "form": null,
+    "names": {
+      "ja": "パラス",
+      "en": "Paras",
+      "ko": "파라스",
+      "zh-Hans": "派拉斯",
+      "zh-Hant": "派拉斯"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0046",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0047",
+    "no": "0047",
+    "form": null,
+    "names": {
+      "ja": "パラセクト",
+      "en": "Parasect",
+      "ko": "파라섹트",
+      "zh-Hans": "派拉斯特",
+      "zh-Hant": "派拉斯特"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0047",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0048",
+    "no": "0048",
+    "form": null,
+    "names": {
+      "ja": "コンパン",
+      "en": "Venonat",
+      "ko": "콘팡",
+      "zh-Hans": "毛球",
+      "zh-Hant": "毛球"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0048",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0049",
+    "no": "0049",
+    "form": null,
+    "names": {
+      "ja": "モルフォン",
+      "en": "Venomoth",
+      "ko": "도나리",
+      "zh-Hans": "摩鲁蛾",
+      "zh-Hant": "摩魯蛾"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0049",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0050",
+    "no": "0050",
+    "form": null,
+    "names": {
+      "ja": "ディグダ",
+      "en": "Diglett",
+      "ko": "디그다",
+      "zh-Hans": "地鼠",
+      "zh-Hant": "地鼠"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0050",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0050-alola",
+    "no": "0050",
+    "form": "alola",
+    "names": {
+      "ja": "ディグダ",
+      "en": "Diglett",
+      "ko": "디그다",
+      "zh-Hans": "地鼠",
+      "zh-Hant": "地鼠"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0050-alola",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0051",
+    "no": "0051",
+    "form": null,
+    "names": {
+      "ja": "ダグトリオ",
+      "en": "Dugtrio",
+      "ko": "닥트리오",
+      "zh-Hans": "三地鼠",
+      "zh-Hant": "三地鼠"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0051",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0051-alola",
+    "no": "0051",
+    "form": "alola",
+    "names": {
+      "ja": "ダグトリオ",
+      "en": "Dugtrio",
+      "ko": "닥트리오",
+      "zh-Hans": "三地鼠",
+      "zh-Hant": "三地鼠"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0051-alola",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0052",
+    "no": "0052",
+    "form": null,
+    "names": {
+      "ja": "ニャース",
+      "en": "Meowth",
+      "ko": "나옹",
+      "zh-Hans": "喵喵",
+      "zh-Hant": "喵喵"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0052",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0052-alola",
+    "no": "0052",
+    "form": "alola",
+    "names": {
+      "ja": "ニャース",
+      "en": "Meowth",
+      "ko": "나옹",
+      "zh-Hans": "喵喵",
+      "zh-Hant": "喵喵"
+    },
+    "types": [
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0052-alola",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0052-galar",
+    "no": "0052",
+    "form": "galar",
+    "names": {
+      "ja": "ニャース",
+      "en": "Meowth",
+      "ko": "나옹",
+      "zh-Hans": "喵喵",
+      "zh-Hant": "喵喵"
+    },
+    "types": [
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0052-galar",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0053",
+    "no": "0053",
+    "form": null,
+    "names": {
+      "ja": "ペルシアン",
+      "en": "Persian",
+      "ko": "페르시온",
+      "zh-Hans": "猫老大",
+      "zh-Hant": "貓老大"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0053",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0053-alola",
+    "no": "0053",
+    "form": "alola",
+    "names": {
+      "ja": "ペルシアン",
+      "en": "Persian",
+      "ko": "페르시온",
+      "zh-Hans": "猫老大",
+      "zh-Hant": "貓老大"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0053-alola",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0054",
+    "no": "0054",
+    "form": null,
+    "names": {
+      "ja": "コダック",
+      "en": "Psyduck",
+      "ko": "고라파덕",
+      "zh-Hans": "可达鸭",
+      "zh-Hant": "可達鴨"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0054",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0055",
+    "no": "0055",
+    "form": null,
+    "names": {
+      "ja": "ゴルダック",
+      "en": "Golduck",
+      "ko": "골덕",
+      "zh-Hans": "哥达鸭",
+      "zh-Hant": "哥達鴨"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0055",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0056",
+    "no": "0056",
+    "form": null,
+    "names": {
+      "ja": "マンキー",
+      "en": "Mankey",
+      "ko": "망키",
+      "zh-Hans": "猴怪",
+      "zh-Hant": "猴怪"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0056",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0057",
+    "no": "0057",
+    "form": null,
+    "names": {
+      "ja": "オコリザル",
+      "en": "Primeape",
+      "ko": "성원숭",
+      "zh-Hans": "火暴猴",
+      "zh-Hant": "火爆猴"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0057",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0058",
+    "no": "0058",
+    "form": null,
+    "names": {
+      "ja": "ガーディ",
+      "en": "Growlithe",
+      "ko": "가디",
+      "zh-Hans": "卡蒂狗",
+      "zh-Hant": "卡蒂狗"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0058",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0058-hisui",
+    "no": "0058",
+    "form": "hisui",
+    "names": {
+      "ja": "ガーディ",
+      "en": "Growlithe",
+      "ko": "가디",
+      "zh-Hans": "卡蒂狗",
+      "zh-Hant": "卡蒂狗"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0058-hisui",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0059",
+    "no": "0059",
+    "form": null,
+    "names": {
+      "ja": "ウインディ",
+      "en": "Arcanine",
+      "ko": "윈디",
+      "zh-Hans": "风速狗",
+      "zh-Hant": "風速狗"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0059",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0059-hisui",
+    "no": "0059",
+    "form": "hisui",
+    "names": {
+      "ja": "ウインディ",
+      "en": "Arcanine",
+      "ko": "윈디",
+      "zh-Hans": "风速狗",
+      "zh-Hant": "風速狗"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0059-hisui",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0060",
+    "no": "0060",
+    "form": null,
+    "names": {
+      "ja": "ニョロモ",
+      "en": "Poliwag",
+      "ko": "발챙이",
+      "zh-Hans": "蚊香蝌蚪",
+      "zh-Hant": "蚊香蝌蚪"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0060",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0061",
+    "no": "0061",
+    "form": null,
+    "names": {
+      "ja": "ニョロゾ",
+      "en": "Poliwhirl",
+      "ko": "슈륙챙이",
+      "zh-Hans": "蚊香君",
+      "zh-Hant": "蚊香君"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0061",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0062",
+    "no": "0062",
+    "form": null,
+    "names": {
+      "ja": "ニョロボン",
+      "en": "Poliwrath",
+      "ko": "강챙이",
+      "zh-Hans": "蚊香泳士",
+      "zh-Hant": "蚊香泳士"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0062",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0063",
+    "no": "0063",
+    "form": null,
+    "names": {
+      "ja": "ケーシィ",
+      "en": "Abra",
+      "ko": "캐이시",
+      "zh-Hans": "凯西",
+      "zh-Hant": "凱西"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0063",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0064",
+    "no": "0064",
+    "form": null,
+    "names": {
+      "ja": "ユンゲラー",
+      "en": "Kadabra",
+      "ko": "윤겔라",
+      "zh-Hans": "勇基拉",
+      "zh-Hant": "勇基拉"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0064",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0065",
+    "no": "0065",
+    "form": null,
+    "names": {
+      "ja": "フーディン",
+      "en": "Alakazam",
+      "ko": "후딘",
+      "zh-Hans": "胡地",
+      "zh-Hant": "胡地"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0065",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0066",
+    "no": "0066",
+    "form": null,
+    "names": {
+      "ja": "ワンリキー",
+      "en": "Machop",
+      "ko": "알통몬",
+      "zh-Hans": "腕力",
+      "zh-Hant": "腕力"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0066",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0067",
+    "no": "0067",
+    "form": null,
+    "names": {
+      "ja": "ゴーリキー",
+      "en": "Machoke",
+      "ko": "근육몬",
+      "zh-Hans": "豪力",
+      "zh-Hant": "豪力"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0067",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0068",
+    "no": "0068",
+    "form": null,
+    "names": {
+      "ja": "カイリキー",
+      "en": "Machamp",
+      "ko": "괴력몬",
+      "zh-Hans": "怪力",
+      "zh-Hant": "怪力"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0068",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0069",
+    "no": "0069",
+    "form": null,
+    "names": {
+      "ja": "マダツボミ",
+      "en": "Bellsprout",
+      "ko": "모다피",
+      "zh-Hans": "喇叭芽",
+      "zh-Hant": "喇叭芽"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0069",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0070",
+    "no": "0070",
+    "form": null,
+    "names": {
+      "ja": "ウツドン",
+      "en": "Weepinbell",
+      "ko": "우츠동",
+      "zh-Hans": "口呆花",
+      "zh-Hant": "口呆花"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0070",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0071",
+    "no": "0071",
+    "form": null,
+    "names": {
+      "ja": "ウツボット",
+      "en": "Victreebel",
+      "ko": "우츠보트",
+      "zh-Hans": "大食花",
+      "zh-Hant": "大食花"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0071",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0072",
+    "no": "0072",
+    "form": null,
+    "names": {
+      "ja": "メノクラゲ",
+      "en": "Tentacool",
+      "ko": "왕눈해",
+      "zh-Hans": "玛瑙水母",
+      "zh-Hant": "瑪瑙水母"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0072",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0073",
+    "no": "0073",
+    "form": null,
+    "names": {
+      "ja": "ドククラゲ",
+      "en": "Tentacruel",
+      "ko": "독파리",
+      "zh-Hans": "毒刺水母",
+      "zh-Hant": "毒刺水母"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0073",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0074",
+    "no": "0074",
+    "form": null,
+    "names": {
+      "ja": "イシツブテ",
+      "en": "Geodude",
+      "ko": "꼬마돌",
+      "zh-Hans": "小拳石",
+      "zh-Hant": "小拳石"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0074",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0074-alola",
+    "no": "0074",
+    "form": "alola",
+    "names": {
+      "ja": "イシツブテ",
+      "en": "Geodude",
+      "ko": "꼬마돌",
+      "zh-Hans": "小拳石",
+      "zh-Hant": "小拳石"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0074-alola",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0075",
+    "no": "0075",
+    "form": null,
+    "names": {
+      "ja": "ゴローン",
+      "en": "Graveler",
+      "ko": "데구리",
+      "zh-Hans": "隆隆石",
+      "zh-Hant": "隆隆石"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0075",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0075-alola",
+    "no": "0075",
+    "form": "alola",
+    "names": {
+      "ja": "ゴローン",
+      "en": "Graveler",
+      "ko": "데구리",
+      "zh-Hans": "隆隆石",
+      "zh-Hant": "隆隆石"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0075-alola",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0076",
+    "no": "0076",
+    "form": null,
+    "names": {
+      "ja": "ゴローニャ",
+      "en": "Golem",
+      "ko": "딱구리",
+      "zh-Hans": "隆隆岩",
+      "zh-Hant": "隆隆岩"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0076",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0076-alola",
+    "no": "0076",
+    "form": "alola",
+    "names": {
+      "ja": "ゴローニャ",
+      "en": "Golem",
+      "ko": "딱구리",
+      "zh-Hans": "隆隆岩",
+      "zh-Hant": "隆隆岩"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0076-alola",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0077",
+    "no": "0077",
+    "form": null,
+    "names": {
+      "ja": "ポニータ",
+      "en": "Ponyta",
+      "ko": "포니타",
+      "zh-Hans": "小火马",
+      "zh-Hant": "小火馬"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0077",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0077-galar",
+    "no": "0077",
+    "form": "galar",
+    "names": {
+      "ja": "ポニータ",
+      "en": "Ponyta",
+      "ko": "포니타",
+      "zh-Hans": "小火马",
+      "zh-Hant": "小火馬"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0077-galar",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0078",
+    "no": "0078",
+    "form": null,
+    "names": {
+      "ja": "ギャロップ",
+      "en": "Rapidash",
+      "ko": "날쌩마",
+      "zh-Hans": "烈焰马",
+      "zh-Hant": "烈焰馬"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0078",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0078-galar",
+    "no": "0078",
+    "form": "galar",
+    "names": {
+      "ja": "ギャロップ",
+      "en": "Rapidash",
+      "ko": "날쌩마",
+      "zh-Hans": "烈焰马",
+      "zh-Hant": "烈焰馬"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0078-galar",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0079",
+    "no": "0079",
+    "form": null,
+    "names": {
+      "ja": "ヤドン",
+      "en": "Slowpoke",
+      "ko": "야돈",
+      "zh-Hans": "呆呆兽",
+      "zh-Hant": "呆呆獸"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0079",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0079-galar",
+    "no": "0079",
+    "form": "galar",
+    "names": {
+      "ja": "ヤドン",
+      "en": "Slowpoke",
+      "ko": "야돈",
+      "zh-Hans": "呆呆兽",
+      "zh-Hant": "呆呆獸"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0079-galar",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0080",
+    "no": "0080",
+    "form": null,
+    "names": {
+      "ja": "ヤドラン",
+      "en": "Slowbro",
+      "ko": "야도란",
+      "zh-Hans": "呆壳兽",
+      "zh-Hant": "呆殼獸"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0080",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0080-galar",
+    "no": "0080",
+    "form": "galar",
+    "names": {
+      "ja": "ヤドラン",
+      "en": "Slowbro",
+      "ko": "야도란",
+      "zh-Hans": "呆壳兽",
+      "zh-Hant": "呆殼獸"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0080-galar",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0081",
+    "no": "0081",
+    "form": null,
+    "names": {
+      "ja": "コイル",
+      "en": "Magnemite",
+      "ko": "코일",
+      "zh-Hans": "小磁怪",
+      "zh-Hant": "小磁怪"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0081",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0082",
+    "no": "0082",
+    "form": null,
+    "names": {
+      "ja": "レアコイル",
+      "en": "Magneton",
+      "ko": "레어코일",
+      "zh-Hans": "三合一磁怪",
+      "zh-Hant": "三合一磁怪"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0082",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0083",
+    "no": "0083",
+    "form": null,
+    "names": {
+      "ja": "カモネギ",
+      "en": "Farfetch’d",
+      "ko": "파오리",
+      "zh-Hans": "大葱鸭",
+      "zh-Hant": "大蔥鴨"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0083",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0083-galar",
+    "no": "0083",
+    "form": "galar",
+    "names": {
+      "ja": "カモネギ",
+      "en": "Farfetch’d",
+      "ko": "파오리",
+      "zh-Hans": "大葱鸭",
+      "zh-Hant": "大蔥鴨"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0083-galar",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0084",
+    "no": "0084",
+    "form": null,
+    "names": {
+      "ja": "ドードー",
+      "en": "Doduo",
+      "ko": "두두",
+      "zh-Hans": "嘟嘟",
+      "zh-Hant": "嘟嘟"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0084",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0085",
+    "no": "0085",
+    "form": null,
+    "names": {
+      "ja": "ドードリオ",
+      "en": "Dodrio",
+      "ko": "두트리오",
+      "zh-Hans": "嘟嘟利",
+      "zh-Hant": "嘟嘟利"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0085",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0086",
+    "no": "0086",
+    "form": null,
+    "names": {
+      "ja": "パウワウ",
+      "en": "Seel",
+      "ko": "쥬쥬",
+      "zh-Hans": "小海狮",
+      "zh-Hant": "小海獅"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0086",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0087",
+    "no": "0087",
+    "form": null,
+    "names": {
+      "ja": "ジュゴン",
+      "en": "Dewgong",
+      "ko": "쥬레곤",
+      "zh-Hans": "白海狮",
+      "zh-Hant": "白海獅"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0087",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0088",
+    "no": "0088",
+    "form": null,
+    "names": {
+      "ja": "ベトベター",
+      "en": "Grimer",
+      "ko": "질퍽이",
+      "zh-Hans": "臭泥",
+      "zh-Hant": "臭泥"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0088",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0088-alola",
+    "no": "0088",
+    "form": "alola",
+    "names": {
+      "ja": "ベトベター",
+      "en": "Grimer",
+      "ko": "질퍽이",
+      "zh-Hans": "臭泥",
+      "zh-Hant": "臭泥"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0088-alola",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0089",
+    "no": "0089",
+    "form": null,
+    "names": {
+      "ja": "ベトベトン",
+      "en": "Muk",
+      "ko": "질뻐기",
+      "zh-Hans": "臭臭泥",
+      "zh-Hant": "臭臭泥"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0089",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0089-alola",
+    "no": "0089",
+    "form": "alola",
+    "names": {
+      "ja": "ベトベトン",
+      "en": "Muk",
+      "ko": "질뻐기",
+      "zh-Hans": "臭臭泥",
+      "zh-Hant": "臭臭泥"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0089-alola",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0090",
+    "no": "0090",
+    "form": null,
+    "names": {
+      "ja": "シェルダー",
+      "en": "Shellder",
+      "ko": "셀러",
+      "zh-Hans": "大舌贝",
+      "zh-Hant": "大舌貝"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0090",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0091",
+    "no": "0091",
+    "form": null,
+    "names": {
+      "ja": "パルシェン",
+      "en": "Cloyster",
+      "ko": "파르셀",
+      "zh-Hans": "刺甲贝",
+      "zh-Hant": "刺甲貝"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0091",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0092",
+    "no": "0092",
+    "form": null,
+    "names": {
+      "ja": "ゴース",
+      "en": "Gastly",
+      "ko": "고오스",
+      "zh-Hans": "鬼斯",
+      "zh-Hant": "鬼斯"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0092",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0093",
+    "no": "0093",
+    "form": null,
+    "names": {
+      "ja": "ゴースト",
+      "en": "Haunter",
+      "ko": "고우스트",
+      "zh-Hans": "鬼斯通",
+      "zh-Hant": "鬼斯通"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0093",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0094",
+    "no": "0094",
+    "form": null,
+    "names": {
+      "ja": "ゲンガー",
+      "en": "Gengar",
+      "ko": "팬텀",
+      "zh-Hans": "耿鬼",
+      "zh-Hant": "耿鬼"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0094",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0095",
+    "no": "0095",
+    "form": null,
+    "names": {
+      "ja": "イワーク",
+      "en": "Onix",
+      "ko": "롱스톤",
+      "zh-Hans": "大岩蛇",
+      "zh-Hant": "大岩蛇"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0095",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0096",
+    "no": "0096",
+    "form": null,
+    "names": {
+      "ja": "スリープ",
+      "en": "Drowzee",
+      "ko": "슬리프",
+      "zh-Hans": "催眠貘",
+      "zh-Hant": "催眠貘"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0096",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0097",
+    "no": "0097",
+    "form": null,
+    "names": {
+      "ja": "スリーパー",
+      "en": "Hypno",
+      "ko": "슬리퍼",
+      "zh-Hans": "引梦貘人",
+      "zh-Hant": "引夢貘人"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0097",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0098",
+    "no": "0098",
+    "form": null,
+    "names": {
+      "ja": "クラブ",
+      "en": "Krabby",
+      "ko": "크랩",
+      "zh-Hans": "大钳蟹",
+      "zh-Hant": "大鉗蟹"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0098",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0099",
+    "no": "0099",
+    "form": null,
+    "names": {
+      "ja": "キングラー",
+      "en": "Kingler",
+      "ko": "킹크랩",
+      "zh-Hans": "巨钳蟹",
+      "zh-Hant": "巨鉗蟹"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0099",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0100",
+    "no": "0100",
+    "form": null,
+    "names": {
+      "ja": "ビリリダマ",
+      "en": "Voltorb",
+      "ko": "찌리리공",
+      "zh-Hans": "霹雳电球",
+      "zh-Hant": "霹靂電球"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0100",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0100-hisui",
+    "no": "0100",
+    "form": "hisui",
+    "names": {
+      "ja": "ビリリダマ",
+      "en": "Voltorb",
+      "ko": "찌리리공",
+      "zh-Hans": "霹雳电球",
+      "zh-Hant": "霹靂電球"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0100-hisui",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0101",
+    "no": "0101",
+    "form": null,
+    "names": {
+      "ja": "マルマイン",
+      "en": "Electrode",
+      "ko": "붐볼",
+      "zh-Hans": "顽皮雷弹",
+      "zh-Hant": "頑皮雷彈"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0101",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0101-hisui",
+    "no": "0101",
+    "form": "hisui",
+    "names": {
+      "ja": "マルマイン",
+      "en": "Electrode",
+      "ko": "붐볼",
+      "zh-Hans": "顽皮雷弹",
+      "zh-Hant": "頑皮雷彈"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0101-hisui",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0102",
+    "no": "0102",
+    "form": null,
+    "names": {
+      "ja": "タマタマ",
+      "en": "Exeggcute",
+      "ko": "아라리",
+      "zh-Hans": "蛋蛋",
+      "zh-Hant": "蛋蛋"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0102",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0103",
+    "no": "0103",
+    "form": null,
+    "names": {
+      "ja": "ナッシー",
+      "en": "Exeggutor",
+      "ko": "나시",
+      "zh-Hans": "椰蛋树",
+      "zh-Hant": "椰蛋樹"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0103",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0103-alola",
+    "no": "0103",
+    "form": "alola",
+    "names": {
+      "ja": "ナッシー",
+      "en": "Exeggutor",
+      "ko": "나시",
+      "zh-Hans": "椰蛋树",
+      "zh-Hant": "椰蛋樹"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0103-alola",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0104",
+    "no": "0104",
+    "form": null,
+    "names": {
+      "ja": "カラカラ",
+      "en": "Cubone",
+      "ko": "탕구리",
+      "zh-Hans": "卡拉卡拉",
+      "zh-Hant": "卡拉卡拉"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0104",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0105",
+    "no": "0105",
+    "form": null,
+    "names": {
+      "ja": "ガラガラ",
+      "en": "Marowak",
+      "ko": "텅구리",
+      "zh-Hans": "嘎啦嘎啦",
+      "zh-Hant": "嘎啦嘎啦"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0105",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0105-alola",
+    "no": "0105",
+    "form": "alola",
+    "names": {
+      "ja": "ガラガラ",
+      "en": "Marowak",
+      "ko": "텅구리",
+      "zh-Hans": "嘎啦嘎啦",
+      "zh-Hant": "嘎啦嘎啦"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0105-alola",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0106",
+    "no": "0106",
+    "form": null,
+    "names": {
+      "ja": "サワムラー",
+      "en": "Hitmonlee",
+      "ko": "시라소몬",
+      "zh-Hans": "飞腿郎",
+      "zh-Hant": "飛腿郎"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0106",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0107",
+    "no": "0107",
+    "form": null,
+    "names": {
+      "ja": "エビワラー",
+      "en": "Hitmonchan",
+      "ko": "홍수몬",
+      "zh-Hans": "快拳郎",
+      "zh-Hant": "快拳郎"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0107",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0108",
+    "no": "0108",
+    "form": null,
+    "names": {
+      "ja": "ベロリンガ",
+      "en": "Lickitung",
+      "ko": "내루미",
+      "zh-Hans": "大舌头",
+      "zh-Hant": "大舌頭"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0108",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0109",
+    "no": "0109",
+    "form": null,
+    "names": {
+      "ja": "ドガース",
+      "en": "Koffing",
+      "ko": "또가스",
+      "zh-Hans": "瓦斯弹",
+      "zh-Hant": "瓦斯彈"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0109",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0110",
+    "no": "0110",
+    "form": null,
+    "names": {
+      "ja": "マタドガス",
+      "en": "Weezing",
+      "ko": "또도가스",
+      "zh-Hans": "双弹瓦斯",
+      "zh-Hant": "雙彈瓦斯"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0110",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0110-galar",
+    "no": "0110",
+    "form": "galar",
+    "names": {
+      "ja": "マタドガス",
+      "en": "Weezing",
+      "ko": "또도가스",
+      "zh-Hans": "双弹瓦斯",
+      "zh-Hant": "雙彈瓦斯"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0110-galar",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0111",
+    "no": "0111",
+    "form": null,
+    "names": {
+      "ja": "サイホーン",
+      "en": "Rhyhorn",
+      "ko": "뿔카노",
+      "zh-Hans": "独角犀牛",
+      "zh-Hant": "獨角犀牛"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0111",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0112",
+    "no": "0112",
+    "form": null,
+    "names": {
+      "ja": "サイドン",
+      "en": "Rhydon",
+      "ko": "코뿌리",
+      "zh-Hans": "钻角犀兽",
+      "zh-Hant": "鑽角犀獸"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0112",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0113",
+    "no": "0113",
+    "form": null,
+    "names": {
+      "ja": "ラッキー",
+      "en": "Chansey",
+      "ko": "럭키",
+      "zh-Hans": "吉利蛋",
+      "zh-Hant": "吉利蛋"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0113",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0114",
+    "no": "0114",
+    "form": null,
+    "names": {
+      "ja": "モンジャラ",
+      "en": "Tangela",
+      "ko": "덩쿠리",
+      "zh-Hans": "蔓藤怪",
+      "zh-Hant": "蔓藤怪"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0114",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0115",
+    "no": "0115",
+    "form": null,
+    "names": {
+      "ja": "ガルーラ",
+      "en": "Kangaskhan",
+      "ko": "캥카",
+      "zh-Hans": "袋兽",
+      "zh-Hant": "袋獸"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0115",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0116",
+    "no": "0116",
+    "form": null,
+    "names": {
+      "ja": "タッツー",
+      "en": "Horsea",
+      "ko": "쏘드라",
+      "zh-Hans": "墨海马",
+      "zh-Hant": "墨海馬"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0116",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0117",
+    "no": "0117",
+    "form": null,
+    "names": {
+      "ja": "シードラ",
+      "en": "Seadra",
+      "ko": "시드라",
+      "zh-Hans": "海刺龙",
+      "zh-Hant": "海刺龍"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0117",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0118",
+    "no": "0118",
+    "form": null,
+    "names": {
+      "ja": "トサキント",
+      "en": "Goldeen",
+      "ko": "콘치",
+      "zh-Hans": "角金鱼",
+      "zh-Hant": "角金魚"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0118",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0119",
+    "no": "0119",
+    "form": null,
+    "names": {
+      "ja": "アズマオウ",
+      "en": "Seaking",
+      "ko": "왕콘치",
+      "zh-Hans": "金鱼王",
+      "zh-Hant": "金魚王"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0119",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0120",
+    "no": "0120",
+    "form": null,
+    "names": {
+      "ja": "ヒトデマン",
+      "en": "Staryu",
+      "ko": "별가사리",
+      "zh-Hans": "海星星",
+      "zh-Hant": "海星星"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0120",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0121",
+    "no": "0121",
+    "form": null,
+    "names": {
+      "ja": "スターミー",
+      "en": "Starmie",
+      "ko": "아쿠스타",
+      "zh-Hans": "宝石海星",
+      "zh-Hant": "寶石海星"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0121",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0122",
+    "no": "0122",
+    "form": null,
+    "names": {
+      "ja": "バリヤード",
+      "en": "Mr. Mime",
+      "ko": "마임맨",
+      "zh-Hans": "魔墙人偶",
+      "zh-Hant": "魔牆人偶"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0122",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0122-galar",
+    "no": "0122",
+    "form": "galar",
+    "names": {
+      "ja": "バリヤード",
+      "en": "Mr. Mime",
+      "ko": "마임맨",
+      "zh-Hans": "魔墙人偶",
+      "zh-Hant": "魔牆人偶"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0122-galar",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0123",
+    "no": "0123",
+    "form": null,
+    "names": {
+      "ja": "ストライク",
+      "en": "Scyther",
+      "ko": "스라크",
+      "zh-Hans": "飞天螳螂",
+      "zh-Hant": "飛天螳螂"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0123",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0124",
+    "no": "0124",
+    "form": null,
+    "names": {
+      "ja": "ルージュラ",
+      "en": "Jynx",
+      "ko": "루주라",
+      "zh-Hans": "迷唇姐",
+      "zh-Hant": "迷唇姐"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0124",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0125",
+    "no": "0125",
+    "form": null,
+    "names": {
+      "ja": "エレブー",
+      "en": "Electabuzz",
+      "ko": "에레브",
+      "zh-Hans": "电击兽",
+      "zh-Hant": "電擊獸"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0125",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0126",
+    "no": "0126",
+    "form": null,
+    "names": {
+      "ja": "ブーバー",
+      "en": "Magmar",
+      "ko": "마그마",
+      "zh-Hans": "鸭嘴火兽",
+      "zh-Hant": "鴨嘴火獸"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0126",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0127",
+    "no": "0127",
+    "form": null,
+    "names": {
+      "ja": "カイロス",
+      "en": "Pinsir",
+      "ko": "쁘사이저",
+      "zh-Hans": "凯罗斯",
+      "zh-Hant": "凱羅斯"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0127",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0128",
+    "no": "0128",
+    "form": null,
+    "names": {
+      "ja": "ケンタロス",
+      "en": "Tauros",
+      "ko": "켄타로스",
+      "zh-Hans": "肯泰罗",
+      "zh-Hant": "肯泰羅"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0128",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0128-paldea",
+    "no": "0128",
+    "form": "paldea",
+    "names": {
+      "ja": "ケンタロス",
+      "en": "Tauros",
+      "ko": "켄타로스",
+      "zh-Hans": "肯泰罗",
+      "zh-Hant": "肯泰羅"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0128-paldea",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0129",
+    "no": "0129",
+    "form": null,
+    "names": {
+      "ja": "コイキング",
+      "en": "Magikarp",
+      "ko": "잉어킹",
+      "zh-Hans": "鲤鱼王",
+      "zh-Hant": "鯉魚王"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0129",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0130",
+    "no": "0130",
+    "form": null,
+    "names": {
+      "ja": "ギャラドス",
+      "en": "Gyarados",
+      "ko": "갸라도스",
+      "zh-Hans": "暴鲤龙",
+      "zh-Hant": "暴鯉龍"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0130",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0131",
+    "no": "0131",
+    "form": null,
+    "names": {
+      "ja": "ラプラス",
+      "en": "Lapras",
+      "ko": "라프라스",
+      "zh-Hans": "拉普拉斯",
+      "zh-Hant": "拉普拉斯"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0131",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0132",
+    "no": "0132",
+    "form": null,
+    "names": {
+      "ja": "メタモン",
+      "en": "Ditto",
+      "ko": "메타몽",
+      "zh-Hans": "百变怪",
+      "zh-Hant": "百變怪"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0132",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0133",
+    "no": "0133",
+    "form": null,
+    "names": {
+      "ja": "イーブイ",
+      "en": "Eevee",
+      "ko": "이브이",
+      "zh-Hans": "伊布",
+      "zh-Hant": "伊布"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0133",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0134",
+    "no": "0134",
+    "form": null,
+    "names": {
+      "ja": "シャワーズ",
+      "en": "Vaporeon",
+      "ko": "샤미드",
+      "zh-Hans": "水伊布",
+      "zh-Hant": "水伊布"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0134",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0135",
+    "no": "0135",
+    "form": null,
+    "names": {
+      "ja": "サンダース",
+      "en": "Jolteon",
+      "ko": "쥬피썬더",
+      "zh-Hans": "雷伊布",
+      "zh-Hant": "雷伊布"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0135",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0136",
+    "no": "0136",
+    "form": null,
+    "names": {
+      "ja": "ブースター",
+      "en": "Flareon",
+      "ko": "부스터",
+      "zh-Hans": "火伊布",
+      "zh-Hant": "火伊布"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0136",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0137",
+    "no": "0137",
+    "form": null,
+    "names": {
+      "ja": "ポリゴン",
+      "en": "Porygon",
+      "ko": "폴리곤",
+      "zh-Hans": "多边兽",
+      "zh-Hant": "多邊獸"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0137",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0138",
+    "no": "0138",
+    "form": null,
+    "names": {
+      "ja": "オムナイト",
+      "en": "Omanyte",
+      "ko": "암나이트",
+      "zh-Hans": "菊石兽",
+      "zh-Hant": "菊石獸"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0138",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0139",
+    "no": "0139",
+    "form": null,
+    "names": {
+      "ja": "オムスター",
+      "en": "Omastar",
+      "ko": "암스타",
+      "zh-Hans": "多刺菊石兽",
+      "zh-Hant": "多刺菊石獸"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0139",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0140",
+    "no": "0140",
+    "form": null,
+    "names": {
+      "ja": "カブト",
+      "en": "Kabuto",
+      "ko": "투구",
+      "zh-Hans": "化石盔",
+      "zh-Hant": "化石盔"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0140",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0141",
+    "no": "0141",
+    "form": null,
+    "names": {
+      "ja": "カブトプス",
+      "en": "Kabutops",
+      "ko": "투구푸스",
+      "zh-Hans": "镰刀盔",
+      "zh-Hant": "鐮刀盔"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0141",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0142",
+    "no": "0142",
+    "form": null,
+    "names": {
+      "ja": "プテラ",
+      "en": "Aerodactyl",
+      "ko": "프테라",
+      "zh-Hans": "化石翼龙",
+      "zh-Hant": "化石翼龍"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0142",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0143",
+    "no": "0143",
+    "form": null,
+    "names": {
+      "ja": "カビゴン",
+      "en": "Snorlax",
+      "ko": "잠만보",
+      "zh-Hans": "卡比兽",
+      "zh-Hant": "卡比獸"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0143",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0144",
+    "no": "0144",
+    "form": null,
+    "names": {
+      "ja": "フリーザー",
+      "en": "Articuno",
+      "ko": "프리져",
+      "zh-Hans": "急冻鸟",
+      "zh-Hant": "急凍鳥"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0144",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0144-galar",
+    "no": "0144",
+    "form": "galar",
+    "names": {
+      "ja": "フリーザー",
+      "en": "Articuno",
+      "ko": "프리져",
+      "zh-Hans": "急冻鸟",
+      "zh-Hant": "急凍鳥"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0144-galar",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0145",
+    "no": "0145",
+    "form": null,
+    "names": {
+      "ja": "サンダー",
+      "en": "Zapdos",
+      "ko": "썬더",
+      "zh-Hans": "闪电鸟",
+      "zh-Hant": "閃電鳥"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0145",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0145-galar",
+    "no": "0145",
+    "form": "galar",
+    "names": {
+      "ja": "サンダー",
+      "en": "Zapdos",
+      "ko": "썬더",
+      "zh-Hans": "闪电鸟",
+      "zh-Hant": "閃電鳥"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0145-galar",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0146",
+    "no": "0146",
+    "form": null,
+    "names": {
+      "ja": "ファイヤー",
+      "en": "Moltres",
+      "ko": "파이어",
+      "zh-Hans": "火焰鸟",
+      "zh-Hant": "火焰鳥"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0146",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0146-galar",
+    "no": "0146",
+    "form": "galar",
+    "names": {
+      "ja": "ファイヤー",
+      "en": "Moltres",
+      "ko": "파이어",
+      "zh-Hans": "火焰鸟",
+      "zh-Hant": "火焰鳥"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0146-galar",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0147",
+    "no": "0147",
+    "form": null,
+    "names": {
+      "ja": "ミニリュウ",
+      "en": "Dratini",
+      "ko": "미뇽",
+      "zh-Hans": "迷你龙",
+      "zh-Hant": "迷你龍"
+    },
+    "types": [
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0147",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0148",
+    "no": "0148",
+    "form": null,
+    "names": {
+      "ja": "ハクリュー",
+      "en": "Dragonair",
+      "ko": "신뇽",
+      "zh-Hans": "哈克龙",
+      "zh-Hant": "哈克龍"
+    },
+    "types": [
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0148",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0149",
+    "no": "0149",
+    "form": null,
+    "names": {
+      "ja": "カイリュー",
+      "en": "Dragonite",
+      "ko": "망나뇽",
+      "zh-Hans": "快龙",
+      "zh-Hant": "快龍"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0149",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0150",
+    "no": "0150",
+    "form": null,
+    "names": {
+      "ja": "ミュウツー",
+      "en": "Mewtwo",
+      "ko": "뮤츠",
+      "zh-Hans": "超梦",
+      "zh-Hant": "超夢"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0150",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0151",
+    "no": "0151",
+    "form": null,
+    "names": {
+      "ja": "ミュウ",
+      "en": "Mew",
+      "ko": "뮤",
+      "zh-Hans": "梦幻",
+      "zh-Hant": "夢幻"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0151",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0152",
+    "no": "0152",
+    "form": null,
+    "names": {
+      "ja": "チコリータ",
+      "en": "Chikorita",
+      "ko": "치코리타",
+      "zh-Hans": "菊草叶",
+      "zh-Hant": "菊草葉"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0152",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0153",
+    "no": "0153",
+    "form": null,
+    "names": {
+      "ja": "ベイリーフ",
+      "en": "Bayleef",
+      "ko": "베이리프",
+      "zh-Hans": "月桂叶",
+      "zh-Hant": "月桂葉"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0153",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0154",
+    "no": "0154",
+    "form": null,
+    "names": {
+      "ja": "メガニウム",
+      "en": "Meganium",
+      "ko": "메가니움",
+      "zh-Hans": "大竺葵",
+      "zh-Hant": "大竺葵"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0154",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0155",
+    "no": "0155",
+    "form": null,
+    "names": {
+      "ja": "ヒノアラシ",
+      "en": "Cyndaquil",
+      "ko": "브케인",
+      "zh-Hans": "火球鼠",
+      "zh-Hant": "火球鼠"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0155",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0156",
+    "no": "0156",
+    "form": null,
+    "names": {
+      "ja": "マグマラシ",
+      "en": "Quilava",
+      "ko": "마그케인",
+      "zh-Hans": "火岩鼠",
+      "zh-Hant": "火岩鼠"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0156",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0157",
+    "no": "0157",
+    "form": null,
+    "names": {
+      "ja": "バクフーン",
+      "en": "Typhlosion",
+      "ko": "블레이범",
+      "zh-Hans": "火暴兽",
+      "zh-Hant": "火爆獸"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0157",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0157-hisui",
+    "no": "0157",
+    "form": "hisui",
+    "names": {
+      "ja": "バクフーン",
+      "en": "Typhlosion",
+      "ko": "블레이범",
+      "zh-Hans": "火暴兽",
+      "zh-Hant": "火爆獸"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0157-hisui",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0158",
+    "no": "0158",
+    "form": null,
+    "names": {
+      "ja": "ワニノコ",
+      "en": "Totodile",
+      "ko": "리아코",
+      "zh-Hans": "小锯鳄",
+      "zh-Hant": "小鋸鱷"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0158",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0159",
+    "no": "0159",
+    "form": null,
+    "names": {
+      "ja": "アリゲイツ",
+      "en": "Croconaw",
+      "ko": "엘리게이",
+      "zh-Hans": "蓝鳄",
+      "zh-Hant": "藍鱷"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0159",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0160",
+    "no": "0160",
+    "form": null,
+    "names": {
+      "ja": "オーダイル",
+      "en": "Feraligatr",
+      "ko": "장크로다일",
+      "zh-Hans": "大力鳄",
+      "zh-Hant": "大力鱷"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0160",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0161",
+    "no": "0161",
+    "form": null,
+    "names": {
+      "ja": "オタチ",
+      "en": "Sentret",
+      "ko": "꼬리선",
+      "zh-Hans": "尾立",
+      "zh-Hant": "尾立"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0161",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0162",
+    "no": "0162",
+    "form": null,
+    "names": {
+      "ja": "オオタチ",
+      "en": "Furret",
+      "ko": "다꼬리",
+      "zh-Hans": "大尾立",
+      "zh-Hant": "大尾立"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0162",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0163",
+    "no": "0163",
+    "form": null,
+    "names": {
+      "ja": "ホーホー",
+      "en": "Hoothoot",
+      "ko": "부우부",
+      "zh-Hans": "咕咕",
+      "zh-Hant": "咕咕"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0163",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0164",
+    "no": "0164",
+    "form": null,
+    "names": {
+      "ja": "ヨルノズク",
+      "en": "Noctowl",
+      "ko": "야부엉",
+      "zh-Hans": "猫头夜鹰",
+      "zh-Hant": "貓頭夜鷹"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0164",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0165",
+    "no": "0165",
+    "form": null,
+    "names": {
+      "ja": "レディバ",
+      "en": "Ledyba",
+      "ko": "레디바",
+      "zh-Hans": "芭瓢虫",
+      "zh-Hant": "芭瓢蟲"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0165",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0166",
+    "no": "0166",
+    "form": null,
+    "names": {
+      "ja": "レディアン",
+      "en": "Ledian",
+      "ko": "레디안",
+      "zh-Hans": "安瓢虫",
+      "zh-Hant": "安瓢蟲"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0166",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0167",
+    "no": "0167",
+    "form": null,
+    "names": {
+      "ja": "イトマル",
+      "en": "Spinarak",
+      "ko": "페이검",
+      "zh-Hans": "圆丝蛛",
+      "zh-Hant": "圓絲蛛"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0167",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0168",
+    "no": "0168",
+    "form": null,
+    "names": {
+      "ja": "アリアドス",
+      "en": "Ariados",
+      "ko": "아리아도스",
+      "zh-Hans": "阿利多斯",
+      "zh-Hant": "阿利多斯"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0168",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0169",
+    "no": "0169",
+    "form": null,
+    "names": {
+      "ja": "クロバット",
+      "en": "Crobat",
+      "ko": "크로뱃",
+      "zh-Hans": "叉字蝠",
+      "zh-Hant": "叉字蝠"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0169",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0170",
+    "no": "0170",
+    "form": null,
+    "names": {
+      "ja": "チョンチー",
+      "en": "Chinchou",
+      "ko": "초라기",
+      "zh-Hans": "灯笼鱼",
+      "zh-Hant": "燈籠魚"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0170",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0171",
+    "no": "0171",
+    "form": null,
+    "names": {
+      "ja": "ランターン",
+      "en": "Lanturn",
+      "ko": "랜턴",
+      "zh-Hans": "电灯怪",
+      "zh-Hant": "電燈怪"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0171",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0172",
+    "no": "0172",
+    "form": null,
+    "names": {
+      "ja": "ピチュー",
+      "en": "Pichu",
+      "ko": "피츄",
+      "zh-Hans": "皮丘",
+      "zh-Hant": "皮丘"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0172",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0173",
+    "no": "0173",
+    "form": null,
+    "names": {
+      "ja": "ピィ",
+      "en": "Cleffa",
+      "ko": "삐",
+      "zh-Hans": "皮宝宝",
+      "zh-Hant": "皮寶寶"
+    },
+    "types": [
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0173",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0174",
+    "no": "0174",
+    "form": null,
+    "names": {
+      "ja": "ププリン",
+      "en": "Igglybuff",
+      "ko": "푸푸린",
+      "zh-Hans": "宝宝丁",
+      "zh-Hant": "寶寶丁"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0174",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0175",
+    "no": "0175",
+    "form": null,
+    "names": {
+      "ja": "トゲピー",
+      "en": "Togepi",
+      "ko": "토게피",
+      "zh-Hans": "波克比",
+      "zh-Hant": "波克比"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0175",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0176",
+    "no": "0176",
+    "form": null,
+    "names": {
+      "ja": "トゲチック",
+      "en": "Togetic",
+      "ko": "토게틱",
+      "zh-Hans": "波克基古",
+      "zh-Hant": "波克基古"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0176",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0177",
+    "no": "0177",
+    "form": null,
+    "names": {
+      "ja": "ネイティ",
+      "en": "Natu",
+      "ko": "네이티",
+      "zh-Hans": "天然雀",
+      "zh-Hant": "天然雀"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0177",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0178",
+    "no": "0178",
+    "form": null,
+    "names": {
+      "ja": "ネイティオ",
+      "en": "Xatu",
+      "ko": "네이티오",
+      "zh-Hans": "天然鸟",
+      "zh-Hant": "天然鳥"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0178",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0179",
+    "no": "0179",
+    "form": null,
+    "names": {
+      "ja": "メリープ",
+      "en": "Mareep",
+      "ko": "메리프",
+      "zh-Hans": "咩利羊",
+      "zh-Hant": "咩利羊"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0179",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0180",
+    "no": "0180",
+    "form": null,
+    "names": {
+      "ja": "モココ",
+      "en": "Flaaffy",
+      "ko": "보송송",
+      "zh-Hans": "茸茸羊",
+      "zh-Hant": "茸茸羊"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0180",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0181",
+    "no": "0181",
+    "form": null,
+    "names": {
+      "ja": "デンリュウ",
+      "en": "Ampharos",
+      "ko": "전룡",
+      "zh-Hans": "电龙",
+      "zh-Hant": "電龍"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0181",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0182",
+    "no": "0182",
+    "form": null,
+    "names": {
+      "ja": "キレイハナ",
+      "en": "Bellossom",
+      "ko": "아르코",
+      "zh-Hans": "美丽花",
+      "zh-Hant": "美麗花"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0182",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0183",
+    "no": "0183",
+    "form": null,
+    "names": {
+      "ja": "マリル",
+      "en": "Marill",
+      "ko": "마릴",
+      "zh-Hans": "玛力露",
+      "zh-Hant": "瑪力露"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0183",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0184",
+    "no": "0184",
+    "form": null,
+    "names": {
+      "ja": "マリルリ",
+      "en": "Azumarill",
+      "ko": "마릴리",
+      "zh-Hans": "玛力露丽",
+      "zh-Hant": "瑪力露麗"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0184",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0185",
+    "no": "0185",
+    "form": null,
+    "names": {
+      "ja": "ウソッキー",
+      "en": "Sudowoodo",
+      "ko": "꼬지모",
+      "zh-Hans": "树才怪",
+      "zh-Hant": "樹才怪"
+    },
+    "types": [
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0185",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0186",
+    "no": "0186",
+    "form": null,
+    "names": {
+      "ja": "ニョロトノ",
+      "en": "Politoed",
+      "ko": "왕구리",
+      "zh-Hans": "蚊香蛙皇",
+      "zh-Hant": "蚊香蛙皇"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0186",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0187",
+    "no": "0187",
+    "form": null,
+    "names": {
+      "ja": "ハネッコ",
+      "en": "Hoppip",
+      "ko": "통통코",
+      "zh-Hans": "毽子草",
+      "zh-Hant": "毽子草"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0187",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0188",
+    "no": "0188",
+    "form": null,
+    "names": {
+      "ja": "ポポッコ",
+      "en": "Skiploom",
+      "ko": "두코",
+      "zh-Hans": "毽子花",
+      "zh-Hant": "毽子花"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0188",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0189",
+    "no": "0189",
+    "form": null,
+    "names": {
+      "ja": "ワタッコ",
+      "en": "Jumpluff",
+      "ko": "솜솜코",
+      "zh-Hans": "毽子棉",
+      "zh-Hant": "毽子棉"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0189",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0190",
+    "no": "0190",
+    "form": null,
+    "names": {
+      "ja": "エイパム",
+      "en": "Aipom",
+      "ko": "에이팜",
+      "zh-Hans": "长尾怪手",
+      "zh-Hant": "長尾怪手"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0190",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0191",
+    "no": "0191",
+    "form": null,
+    "names": {
+      "ja": "ヒマナッツ",
+      "en": "Sunkern",
+      "ko": "해너츠",
+      "zh-Hans": "向日种子",
+      "zh-Hant": "向日種子"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0191",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0192",
+    "no": "0192",
+    "form": null,
+    "names": {
+      "ja": "キマワリ",
+      "en": "Sunflora",
+      "ko": "해루미",
+      "zh-Hans": "向日花怪",
+      "zh-Hant": "向日花怪"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0192",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0193",
+    "no": "0193",
+    "form": null,
+    "names": {
+      "ja": "ヤンヤンマ",
+      "en": "Yanma",
+      "ko": "왕자리",
+      "zh-Hans": "蜻蜻蜓",
+      "zh-Hant": "蜻蜻蜓"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0193",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0194",
+    "no": "0194",
+    "form": null,
+    "names": {
+      "ja": "ウパー",
+      "en": "Wooper",
+      "ko": "우파",
+      "zh-Hans": "乌波",
+      "zh-Hant": "烏波"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0194",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0194-paldea",
+    "no": "0194",
+    "form": "paldea",
+    "names": {
+      "ja": "ウパー",
+      "en": "Wooper",
+      "ko": "우파",
+      "zh-Hans": "乌波",
+      "zh-Hant": "烏波"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0194-paldea",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0195",
+    "no": "0195",
+    "form": null,
+    "names": {
+      "ja": "ヌオー",
+      "en": "Quagsire",
+      "ko": "누오",
+      "zh-Hans": "沼王",
+      "zh-Hant": "沼王"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0195",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0196",
+    "no": "0196",
+    "form": null,
+    "names": {
+      "ja": "エーフィ",
+      "en": "Espeon",
+      "ko": "에브이",
+      "zh-Hans": "太阳伊布",
+      "zh-Hant": "太陽伊布"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0196",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0197",
+    "no": "0197",
+    "form": null,
+    "names": {
+      "ja": "ブラッキー",
+      "en": "Umbreon",
+      "ko": "블래키",
+      "zh-Hans": "月亮伊布",
+      "zh-Hant": "月亮伊布"
+    },
+    "types": [
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0197",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0198",
+    "no": "0198",
+    "form": null,
+    "names": {
+      "ja": "ヤミカラス",
+      "en": "Murkrow",
+      "ko": "니로우",
+      "zh-Hans": "黑暗鸦",
+      "zh-Hant": "黑暗鴉"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0198",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0199",
+    "no": "0199",
+    "form": null,
+    "names": {
+      "ja": "ヤドキング",
+      "en": "Slowking",
+      "ko": "야도킹",
+      "zh-Hans": "呆呆王",
+      "zh-Hant": "呆呆王"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0199",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0199-galar",
+    "no": "0199",
+    "form": "galar",
+    "names": {
+      "ja": "ヤドキング",
+      "en": "Slowking",
+      "ko": "야도킹",
+      "zh-Hans": "呆呆王",
+      "zh-Hant": "呆呆王"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0199-galar",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0200",
+    "no": "0200",
+    "form": null,
+    "names": {
+      "ja": "ムウマ",
+      "en": "Misdreavus",
+      "ko": "무우마",
+      "zh-Hans": "梦妖",
+      "zh-Hant": "夢妖"
+    },
+    "types": [
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0200",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0201",
+    "no": "0201",
+    "form": null,
+    "names": {
+      "ja": "アンノーン",
+      "en": "Unown",
+      "ko": "안농",
+      "zh-Hans": "未知图腾",
+      "zh-Hant": "未知圖騰"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0201",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0202",
+    "no": "0202",
+    "form": null,
+    "names": {
+      "ja": "ソーナンス",
+      "en": "Wobbuffet",
+      "ko": "마자용",
+      "zh-Hans": "果然翁",
+      "zh-Hant": "果然翁"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0202",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0203",
+    "no": "0203",
+    "form": null,
+    "names": {
+      "ja": "キリンリキ",
+      "en": "Girafarig",
+      "ko": "키링키",
+      "zh-Hans": "麒麟奇",
+      "zh-Hant": "麒麟奇"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0203",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0204",
+    "no": "0204",
+    "form": null,
+    "names": {
+      "ja": "クヌギダマ",
+      "en": "Pineco",
+      "ko": "피콘",
+      "zh-Hans": "榛果球",
+      "zh-Hant": "榛果球"
+    },
+    "types": [
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0204",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0205",
+    "no": "0205",
+    "form": null,
+    "names": {
+      "ja": "フォレトス",
+      "en": "Forretress",
+      "ko": "쏘콘",
+      "zh-Hans": "佛烈托斯",
+      "zh-Hant": "佛烈托斯"
+    },
+    "types": [
+      {
+        "ja": "むし",
+        "en": "Bug"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0205",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0206",
+    "no": "0206",
+    "form": null,
+    "names": {
+      "ja": "ノコッチ",
+      "en": "Dunsparce",
+      "ko": "노고치",
+      "zh-Hans": "土龙弟弟",
+      "zh-Hant": "土龍弟弟"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0206",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0207",
+    "no": "0207",
+    "form": null,
+    "names": {
+      "ja": "グライガー",
+      "en": "Gligar",
+      "ko": "글라이거",
+      "zh-Hans": "天蝎",
+      "zh-Hant": "天蠍"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0207",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0208",
+    "no": "0208",
+    "form": null,
+    "names": {
+      "ja": "ハガネール",
+      "en": "Steelix",
+      "ko": "강철톤",
+      "zh-Hans": "大钢蛇",
+      "zh-Hant": "大鋼蛇"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0208",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0209",
+    "no": "0209",
+    "form": null,
+    "names": {
+      "ja": "ブルー",
+      "en": "Snubbull",
+      "ko": "블루",
+      "zh-Hans": "布鲁",
+      "zh-Hant": "布魯"
+    },
+    "types": [
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0209",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0210",
+    "no": "0210",
+    "form": null,
+    "names": {
+      "ja": "グランブル",
+      "en": "Granbull",
+      "ko": "그랑블루",
+      "zh-Hans": "布鲁皇",
+      "zh-Hant": "布魯皇"
+    },
+    "types": [
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0210",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0211",
+    "no": "0211",
+    "form": null,
+    "names": {
+      "ja": "ハリーセン",
+      "en": "Qwilfish",
+      "ko": "침바루",
+      "zh-Hans": "千针鱼",
+      "zh-Hant": "千針魚"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0211",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0211-hisui",
+    "no": "0211",
+    "form": "hisui",
+    "names": {
+      "ja": "ハリーセン",
+      "en": "Qwilfish",
+      "ko": "침바루",
+      "zh-Hans": "千针鱼",
+      "zh-Hant": "千針魚"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0211-hisui",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0212",
+    "no": "0212",
+    "form": null,
+    "names": {
+      "ja": "ハッサム",
+      "en": "Scizor",
+      "ko": "핫삼",
+      "zh-Hans": "巨钳螳螂",
+      "zh-Hant": "巨鉗螳螂"
+    },
+    "types": [
+      {
+        "ja": "むし",
+        "en": "Bug"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0212",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0213",
+    "no": "0213",
+    "form": null,
+    "names": {
+      "ja": "ツボツボ",
+      "en": "Shuckle",
+      "ko": "단단지",
+      "zh-Hans": "壶壶",
+      "zh-Hant": "壺壺"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0213",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0214",
+    "no": "0214",
+    "form": null,
+    "names": {
+      "ja": "ヘラクロス",
+      "en": "Heracross",
+      "ko": "헤라크로스",
+      "zh-Hans": "赫拉克罗斯",
+      "zh-Hant": "赫拉克羅斯"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0214",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0215",
+    "no": "0215",
+    "form": null,
+    "names": {
+      "ja": "ニューラ",
+      "en": "Sneasel",
+      "ko": "포푸니",
+      "zh-Hans": "狃拉",
+      "zh-Hant": "狃拉"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0215",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0215-hisui",
+    "no": "0215",
+    "form": "hisui",
+    "names": {
+      "ja": "ニューラ",
+      "en": "Sneasel",
+      "ko": "포푸니",
+      "zh-Hans": "狃拉",
+      "zh-Hant": "狃拉"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0215-hisui",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0216",
+    "no": "0216",
+    "form": null,
+    "names": {
+      "ja": "ヒメグマ",
+      "en": "Teddiursa",
+      "ko": "깜지곰",
+      "zh-Hans": "熊宝宝",
+      "zh-Hant": "熊寶寶"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0216",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0217",
+    "no": "0217",
+    "form": null,
+    "names": {
+      "ja": "リングマ",
+      "en": "Ursaring",
+      "ko": "링곰",
+      "zh-Hans": "圈圈熊",
+      "zh-Hant": "圈圈熊"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0217",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0218",
+    "no": "0218",
+    "form": null,
+    "names": {
+      "ja": "マグマッグ",
+      "en": "Slugma",
+      "ko": "마그마그",
+      "zh-Hans": "熔岩虫",
+      "zh-Hant": "熔岩蟲"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0218",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0219",
+    "no": "0219",
+    "form": null,
+    "names": {
+      "ja": "マグカルゴ",
+      "en": "Magcargo",
+      "ko": "마그카르고",
+      "zh-Hans": "熔岩蜗牛",
+      "zh-Hant": "熔岩蝸牛"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0219",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0220",
+    "no": "0220",
+    "form": null,
+    "names": {
+      "ja": "ウリムー",
+      "en": "Swinub",
+      "ko": "꾸꾸리",
+      "zh-Hans": "小山猪",
+      "zh-Hant": "小山豬"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      },
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0220",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0221",
+    "no": "0221",
+    "form": null,
+    "names": {
+      "ja": "イノムー",
+      "en": "Piloswine",
+      "ko": "메꾸리",
+      "zh-Hans": "长毛猪",
+      "zh-Hant": "長毛豬"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      },
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0221",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0222",
+    "no": "0222",
+    "form": null,
+    "names": {
+      "ja": "サニーゴ",
+      "en": "Corsola",
+      "ko": "코산호",
+      "zh-Hans": "太阳珊瑚",
+      "zh-Hant": "太陽珊瑚"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0222",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0222-galar",
+    "no": "0222",
+    "form": "galar",
+    "names": {
+      "ja": "サニーゴ",
+      "en": "Corsola",
+      "ko": "코산호",
+      "zh-Hans": "太阳珊瑚",
+      "zh-Hant": "太陽珊瑚"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0222-galar",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0223",
+    "no": "0223",
+    "form": null,
+    "names": {
+      "ja": "テッポウオ",
+      "en": "Remoraid",
+      "ko": "총어",
+      "zh-Hans": "铁炮鱼",
+      "zh-Hant": "鐵炮魚"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0223",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0224",
+    "no": "0224",
+    "form": null,
+    "names": {
+      "ja": "オクタン",
+      "en": "Octillery",
+      "ko": "대포무노",
+      "zh-Hans": "章鱼桶",
+      "zh-Hant": "章魚桶"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0224",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0225",
+    "no": "0225",
+    "form": null,
+    "names": {
+      "ja": "デリバード",
+      "en": "Delibird",
+      "ko": "딜리버드",
+      "zh-Hans": "信使鸟",
+      "zh-Hant": "信使鳥"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0225",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0226",
+    "no": "0226",
+    "form": null,
+    "names": {
+      "ja": "マンタイン",
+      "en": "Mantine",
+      "ko": "만타인",
+      "zh-Hans": "巨翅飞鱼",
+      "zh-Hant": "巨翅飛魚"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0226",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0227",
+    "no": "0227",
+    "form": null,
+    "names": {
+      "ja": "エアームド",
+      "en": "Skarmory",
+      "ko": "무장조",
+      "zh-Hans": "盔甲鸟",
+      "zh-Hant": "盔甲鳥"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0227",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0228",
+    "no": "0228",
+    "form": null,
+    "names": {
+      "ja": "デルビル",
+      "en": "Houndour",
+      "ko": "델빌",
+      "zh-Hans": "戴鲁比",
+      "zh-Hant": "戴魯比"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0228",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0229",
+    "no": "0229",
+    "form": null,
+    "names": {
+      "ja": "ヘルガー",
+      "en": "Houndoom",
+      "ko": "헬가",
+      "zh-Hans": "黑鲁加",
+      "zh-Hant": "黑魯加"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0229",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0230",
+    "no": "0230",
+    "form": null,
+    "names": {
+      "ja": "キングドラ",
+      "en": "Kingdra",
+      "ko": "킹드라",
+      "zh-Hans": "刺龙王",
+      "zh-Hant": "刺龍王"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0230",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0231",
+    "no": "0231",
+    "form": null,
+    "names": {
+      "ja": "ゴマゾウ",
+      "en": "Phanpy",
+      "ko": "코코리",
+      "zh-Hans": "小小象",
+      "zh-Hant": "小小象"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0231",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0232",
+    "no": "0232",
+    "form": null,
+    "names": {
+      "ja": "ドンファン",
+      "en": "Donphan",
+      "ko": "코리갑",
+      "zh-Hans": "顿甲",
+      "zh-Hant": "頓甲"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0232",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0233",
+    "no": "0233",
+    "form": null,
+    "names": {
+      "ja": "ポリゴン２",
+      "en": "Porygon2",
+      "ko": "폴리곤2",
+      "zh-Hans": "多边兽２型",
+      "zh-Hant": "多邊獸Ⅱ"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0233",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0234",
+    "no": "0234",
+    "form": null,
+    "names": {
+      "ja": "オドシシ",
+      "en": "Stantler",
+      "ko": "노라키",
+      "zh-Hans": "惊角鹿",
+      "zh-Hant": "驚角鹿"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0234",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0235",
+    "no": "0235",
+    "form": null,
+    "names": {
+      "ja": "ドーブル",
+      "en": "Smeargle",
+      "ko": "루브도",
+      "zh-Hans": "图图犬",
+      "zh-Hant": "圖圖犬"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0235",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0236",
+    "no": "0236",
+    "form": null,
+    "names": {
+      "ja": "バルキー",
+      "en": "Tyrogue",
+      "ko": "배루키",
+      "zh-Hans": "无畏小子",
+      "zh-Hant": "無畏小子"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0236",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0237",
+    "no": "0237",
+    "form": null,
+    "names": {
+      "ja": "カポエラー",
+      "en": "Hitmontop",
+      "ko": "카포에라",
+      "zh-Hans": "战舞郎",
+      "zh-Hant": "戰舞郎"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0237",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0238",
+    "no": "0238",
+    "form": null,
+    "names": {
+      "ja": "ムチュール",
+      "en": "Smoochum",
+      "ko": "뽀뽀라",
+      "zh-Hans": "迷唇娃",
+      "zh-Hant": "迷唇娃"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0238",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0239",
+    "no": "0239",
+    "form": null,
+    "names": {
+      "ja": "エレキッド",
+      "en": "Elekid",
+      "ko": "에레키드",
+      "zh-Hans": "电击怪",
+      "zh-Hant": "電擊怪"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0239",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0240",
+    "no": "0240",
+    "form": null,
+    "names": {
+      "ja": "ブビィ",
+      "en": "Magby",
+      "ko": "마그비",
+      "zh-Hans": "鸭嘴宝宝",
+      "zh-Hant": "鴨嘴寶寶"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0240",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0241",
+    "no": "0241",
+    "form": null,
+    "names": {
+      "ja": "ミルタンク",
+      "en": "Miltank",
+      "ko": "밀탱크",
+      "zh-Hans": "大奶罐",
+      "zh-Hant": "大奶罐"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0241",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0242",
+    "no": "0242",
+    "form": null,
+    "names": {
+      "ja": "ハピナス",
+      "en": "Blissey",
+      "ko": "해피너스",
+      "zh-Hans": "幸福蛋",
+      "zh-Hant": "幸福蛋"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0242",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0243",
+    "no": "0243",
+    "form": null,
+    "names": {
+      "ja": "ライコウ",
+      "en": "Raikou",
+      "ko": "라이코",
+      "zh-Hans": "雷公",
+      "zh-Hant": "雷公"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0243",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0244",
+    "no": "0244",
+    "form": null,
+    "names": {
+      "ja": "エンテイ",
+      "en": "Entei",
+      "ko": "앤테이",
+      "zh-Hans": "炎帝",
+      "zh-Hant": "炎帝"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0244",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0245",
+    "no": "0245",
+    "form": null,
+    "names": {
+      "ja": "スイクン",
+      "en": "Suicune",
+      "ko": "스이쿤",
+      "zh-Hans": "水君",
+      "zh-Hant": "水君"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0245",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0246",
+    "no": "0246",
+    "form": null,
+    "names": {
+      "ja": "ヨーギラス",
+      "en": "Larvitar",
+      "ko": "애버라스",
+      "zh-Hans": "幼基拉斯",
+      "zh-Hant": "幼基拉斯"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0246",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0247",
+    "no": "0247",
+    "form": null,
+    "names": {
+      "ja": "サナギラス",
+      "en": "Pupitar",
+      "ko": "데기라스",
+      "zh-Hans": "沙基拉斯",
+      "zh-Hant": "沙基拉斯"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0247",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0248",
+    "no": "0248",
+    "form": null,
+    "names": {
+      "ja": "バンギラス",
+      "en": "Tyranitar",
+      "ko": "마기라스",
+      "zh-Hans": "班基拉斯",
+      "zh-Hant": "班基拉斯"
+    },
+    "types": [
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0248",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0249",
+    "no": "0249",
+    "form": null,
+    "names": {
+      "ja": "ルギア",
+      "en": "Lugia",
+      "ko": "루기아",
+      "zh-Hans": "洛奇亚",
+      "zh-Hant": "洛奇亞"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0249",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0250",
+    "no": "0250",
+    "form": null,
+    "names": {
+      "ja": "ホウオウ",
+      "en": "Ho-Oh",
+      "ko": "칠색조",
+      "zh-Hans": "凤王",
+      "zh-Hant": "鳳王"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0250",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0251",
+    "no": "0251",
+    "form": null,
+    "names": {
+      "ja": "セレビィ",
+      "en": "Celebi",
+      "ko": "세레비",
+      "zh-Hans": "时拉比",
+      "zh-Hant": "時拉比"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0251",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0252",
+    "no": "0252",
+    "form": null,
+    "names": {
+      "ja": "キモリ",
+      "en": "Treecko",
+      "ko": "나무지기",
+      "zh-Hans": "木守宫",
+      "zh-Hant": "木守宮"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0252",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0253",
+    "no": "0253",
+    "form": null,
+    "names": {
+      "ja": "ジュプトル",
+      "en": "Grovyle",
+      "ko": "나무돌이",
+      "zh-Hans": "森林蜥蜴",
+      "zh-Hant": "森林蜥蜴"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0253",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0254",
+    "no": "0254",
+    "form": null,
+    "names": {
+      "ja": "ジュカイン",
+      "en": "Sceptile",
+      "ko": "나무킹",
+      "zh-Hans": "蜥蜴王",
+      "zh-Hant": "蜥蜴王"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0254",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0255",
+    "no": "0255",
+    "form": null,
+    "names": {
+      "ja": "アチャモ",
+      "en": "Torchic",
+      "ko": "아차모",
+      "zh-Hans": "火稚鸡",
+      "zh-Hant": "火稚雞"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0255",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0256",
+    "no": "0256",
+    "form": null,
+    "names": {
+      "ja": "ワカシャモ",
+      "en": "Combusken",
+      "ko": "영치코",
+      "zh-Hans": "力壮鸡",
+      "zh-Hant": "力壯雞"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0256",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0257",
+    "no": "0257",
+    "form": null,
+    "names": {
+      "ja": "バシャーモ",
+      "en": "Blaziken",
+      "ko": "번치코",
+      "zh-Hans": "火焰鸡",
+      "zh-Hant": "火焰雞"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0257",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0258",
+    "no": "0258",
+    "form": null,
+    "names": {
+      "ja": "ミズゴロウ",
+      "en": "Mudkip",
+      "ko": "물짱이",
+      "zh-Hans": "水跃鱼",
+      "zh-Hant": "水躍魚"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0258",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0259",
+    "no": "0259",
+    "form": null,
+    "names": {
+      "ja": "ヌマクロー",
+      "en": "Marshtomp",
+      "ko": "늪짱이",
+      "zh-Hans": "沼跃鱼",
+      "zh-Hant": "沼躍魚"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0259",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0260",
+    "no": "0260",
+    "form": null,
+    "names": {
+      "ja": "ラグラージ",
+      "en": "Swampert",
+      "ko": "대짱이",
+      "zh-Hans": "巨沼怪",
+      "zh-Hant": "巨沼怪"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0260",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0261",
+    "no": "0261",
+    "form": null,
+    "names": {
+      "ja": "ポチエナ",
+      "en": "Poochyena",
+      "ko": "포챠나",
+      "zh-Hans": "土狼犬",
+      "zh-Hant": "土狼犬"
+    },
+    "types": [
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0261",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0262",
+    "no": "0262",
+    "form": null,
+    "names": {
+      "ja": "グラエナ",
+      "en": "Mightyena",
+      "ko": "그라에나",
+      "zh-Hans": "大狼犬",
+      "zh-Hant": "大狼犬"
+    },
+    "types": [
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0262",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0263",
+    "no": "0263",
+    "form": null,
+    "names": {
+      "ja": "ジグザグマ",
+      "en": "Zigzagoon",
+      "ko": "지그제구리",
+      "zh-Hans": "蛇纹熊",
+      "zh-Hant": "蛇紋熊"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0263",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0263-galar",
+    "no": "0263",
+    "form": "galar",
+    "names": {
+      "ja": "ジグザグマ",
+      "en": "Zigzagoon",
+      "ko": "지그제구리",
+      "zh-Hans": "蛇纹熊",
+      "zh-Hant": "蛇紋熊"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0263-galar",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0264",
+    "no": "0264",
+    "form": null,
+    "names": {
+      "ja": "マッスグマ",
+      "en": "Linoone",
+      "ko": "직구리",
+      "zh-Hans": "直冲熊",
+      "zh-Hant": "直衝熊"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0264",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0264-galar",
+    "no": "0264",
+    "form": "galar",
+    "names": {
+      "ja": "マッスグマ",
+      "en": "Linoone",
+      "ko": "직구리",
+      "zh-Hans": "直冲熊",
+      "zh-Hant": "直衝熊"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0264-galar",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0265",
+    "no": "0265",
+    "form": null,
+    "names": {
+      "ja": "ケムッソ",
+      "en": "Wurmple",
+      "ko": "개무소",
+      "zh-Hans": "刺尾虫",
+      "zh-Hant": "刺尾蟲"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0265",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0266",
+    "no": "0266",
+    "form": null,
+    "names": {
+      "ja": "カラサリス",
+      "en": "Silcoon",
+      "ko": "실쿤",
+      "zh-Hans": "甲壳茧",
+      "zh-Hant": "甲殼繭"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0266",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0267",
+    "no": "0267",
+    "form": null,
+    "names": {
+      "ja": "アゲハント",
+      "en": "Beautifly",
+      "ko": "뷰티플라이",
+      "zh-Hans": "狩猎凤蝶",
+      "zh-Hant": "狩獵鳳蝶"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0267",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0268",
+    "no": "0268",
+    "form": null,
+    "names": {
+      "ja": "マユルド",
+      "en": "Cascoon",
+      "ko": "카스쿤",
+      "zh-Hans": "盾甲茧",
+      "zh-Hant": "盾甲繭"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0268",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0269",
+    "no": "0269",
+    "form": null,
+    "names": {
+      "ja": "ドクケイル",
+      "en": "Dustox",
+      "ko": "독케일",
+      "zh-Hans": "毒粉蛾",
+      "zh-Hant": "毒粉蛾"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0269",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0270",
+    "no": "0270",
+    "form": null,
+    "names": {
+      "ja": "ハスボー",
+      "en": "Lotad",
+      "ko": "연꽃몬",
+      "zh-Hans": "莲叶童子",
+      "zh-Hant": "蓮葉童子"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0270",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0271",
+    "no": "0271",
+    "form": null,
+    "names": {
+      "ja": "ハスブレロ",
+      "en": "Lombre",
+      "ko": "로토스",
+      "zh-Hans": "莲帽小童",
+      "zh-Hant": "蓮帽小童"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0271",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0272",
+    "no": "0272",
+    "form": null,
+    "names": {
+      "ja": "ルンパッパ",
+      "en": "Ludicolo",
+      "ko": "로파파",
+      "zh-Hans": "乐天河童",
+      "zh-Hant": "樂天河童"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0272",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0273",
+    "no": "0273",
+    "form": null,
+    "names": {
+      "ja": "タネボー",
+      "en": "Seedot",
+      "ko": "도토링",
+      "zh-Hans": "橡实果",
+      "zh-Hant": "橡實果"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0273",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0274",
+    "no": "0274",
+    "form": null,
+    "names": {
+      "ja": "コノハナ",
+      "en": "Nuzleaf",
+      "ko": "잎새코",
+      "zh-Hans": "长鼻叶",
+      "zh-Hant": "長鼻葉"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0274",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0275",
+    "no": "0275",
+    "form": null,
+    "names": {
+      "ja": "ダーテング",
+      "en": "Shiftry",
+      "ko": "다탱구",
+      "zh-Hans": "狡猾天狗",
+      "zh-Hant": "狡猾天狗"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0275",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0276",
+    "no": "0276",
+    "form": null,
+    "names": {
+      "ja": "スバメ",
+      "en": "Taillow",
+      "ko": "테일로",
+      "zh-Hans": "傲骨燕",
+      "zh-Hant": "傲骨燕"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0276",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0277",
+    "no": "0277",
+    "form": null,
+    "names": {
+      "ja": "オオスバメ",
+      "en": "Swellow",
+      "ko": "스왈로",
+      "zh-Hans": "大王燕",
+      "zh-Hant": "大王燕"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0277",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0278",
+    "no": "0278",
+    "form": null,
+    "names": {
+      "ja": "キャモメ",
+      "en": "Wingull",
+      "ko": "갈모매",
+      "zh-Hans": "长翅鸥",
+      "zh-Hant": "長翅鷗"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0278",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0279",
+    "no": "0279",
+    "form": null,
+    "names": {
+      "ja": "ペリッパー",
+      "en": "Pelipper",
+      "ko": "패리퍼",
+      "zh-Hans": "大嘴鸥",
+      "zh-Hant": "大嘴鷗"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0279",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0280",
+    "no": "0280",
+    "form": null,
+    "names": {
+      "ja": "ラルトス",
+      "en": "Ralts",
+      "ko": "랄토스",
+      "zh-Hans": "拉鲁拉丝",
+      "zh-Hant": "拉魯拉絲"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0280",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0281",
+    "no": "0281",
+    "form": null,
+    "names": {
+      "ja": "キルリア",
+      "en": "Kirlia",
+      "ko": "킬리아",
+      "zh-Hans": "奇鲁莉安",
+      "zh-Hant": "奇魯莉安"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0281",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0282",
+    "no": "0282",
+    "form": null,
+    "names": {
+      "ja": "サーナイト",
+      "en": "Gardevoir",
+      "ko": "가디안",
+      "zh-Hans": "沙奈朵",
+      "zh-Hant": "沙奈朵"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0282",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0283",
+    "no": "0283",
+    "form": null,
+    "names": {
+      "ja": "アメタマ",
+      "en": "Surskit",
+      "ko": "비구술",
+      "zh-Hans": "溜溜糖球",
+      "zh-Hant": "溜溜糖球"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0283",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0284",
+    "no": "0284",
+    "form": null,
+    "names": {
+      "ja": "アメモース",
+      "en": "Masquerain",
+      "ko": "비나방",
+      "zh-Hans": "雨翅蛾",
+      "zh-Hant": "雨翅蛾"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0284",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0285",
+    "no": "0285",
+    "form": null,
+    "names": {
+      "ja": "キノココ",
+      "en": "Shroomish",
+      "ko": "버섯꼬",
+      "zh-Hans": "蘑蘑菇",
+      "zh-Hant": "蘑蘑菇"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0285",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0286",
+    "no": "0286",
+    "form": null,
+    "names": {
+      "ja": "キノガッサ",
+      "en": "Breloom",
+      "ko": "버섯모",
+      "zh-Hans": "斗笠菇",
+      "zh-Hant": "斗笠菇"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0286",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0287",
+    "no": "0287",
+    "form": null,
+    "names": {
+      "ja": "ナマケロ",
+      "en": "Slakoth",
+      "ko": "게을로",
+      "zh-Hans": "懒人獭",
+      "zh-Hant": "懶人獺"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0287",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0288",
+    "no": "0288",
+    "form": null,
+    "names": {
+      "ja": "ヤルキモノ",
+      "en": "Vigoroth",
+      "ko": "발바로",
+      "zh-Hans": "过动猿",
+      "zh-Hant": "過動猿"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0288",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0289",
+    "no": "0289",
+    "form": null,
+    "names": {
+      "ja": "ケッキング",
+      "en": "Slaking",
+      "ko": "게을킹",
+      "zh-Hans": "请假王",
+      "zh-Hant": "請假王"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0289",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0290",
+    "no": "0290",
+    "form": null,
+    "names": {
+      "ja": "ツチニン",
+      "en": "Nincada",
+      "ko": "토중몬",
+      "zh-Hans": "土居忍士",
+      "zh-Hant": "土居忍士"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0290",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0291",
+    "no": "0291",
+    "form": null,
+    "names": {
+      "ja": "テッカニン",
+      "en": "Ninjask",
+      "ko": "아이스크",
+      "zh-Hans": "铁面忍者",
+      "zh-Hant": "鐵面忍者"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0291",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0292",
+    "no": "0292",
+    "form": null,
+    "names": {
+      "ja": "ヌケニン",
+      "en": "Shedinja",
+      "ko": "껍질몬",
+      "zh-Hans": "脱壳忍者",
+      "zh-Hant": "脫殼忍者"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0292",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0293",
+    "no": "0293",
+    "form": null,
+    "names": {
+      "ja": "ゴニョニョ",
+      "en": "Whismur",
+      "ko": "소곤룡",
+      "zh-Hans": "咕妞妞",
+      "zh-Hant": "咕妞妞"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0293",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0294",
+    "no": "0294",
+    "form": null,
+    "names": {
+      "ja": "ドゴーム",
+      "en": "Loudred",
+      "ko": "노공룡",
+      "zh-Hans": "吼爆弹",
+      "zh-Hant": "吼爆彈"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0294",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0295",
+    "no": "0295",
+    "form": null,
+    "names": {
+      "ja": "バクオング",
+      "en": "Exploud",
+      "ko": "폭음룡",
+      "zh-Hans": "爆音怪",
+      "zh-Hant": "爆音怪"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0295",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0296",
+    "no": "0296",
+    "form": null,
+    "names": {
+      "ja": "マクノシタ",
+      "en": "Makuhita",
+      "ko": "마크탕",
+      "zh-Hans": "幕下力士",
+      "zh-Hant": "幕下力士"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0296",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0297",
+    "no": "0297",
+    "form": null,
+    "names": {
+      "ja": "ハリテヤマ",
+      "en": "Hariyama",
+      "ko": "하리뭉",
+      "zh-Hans": "铁掌力士",
+      "zh-Hant": "鐵掌力士"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0297",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0298",
+    "no": "0298",
+    "form": null,
+    "names": {
+      "ja": "ルリリ",
+      "en": "Azurill",
+      "ko": "루리리",
+      "zh-Hans": "露力丽",
+      "zh-Hant": "露力麗"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0298",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0299",
+    "no": "0299",
+    "form": null,
+    "names": {
+      "ja": "ノズパス",
+      "en": "Nosepass",
+      "ko": "코코파스",
+      "zh-Hans": "朝北鼻",
+      "zh-Hant": "朝北鼻"
+    },
+    "types": [
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0299",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0300",
+    "no": "0300",
+    "form": null,
+    "names": {
+      "ja": "エネコ",
+      "en": "Skitty",
+      "ko": "에나비",
+      "zh-Hans": "向尾喵",
+      "zh-Hant": "向尾喵"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0300",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0301",
+    "no": "0301",
+    "form": null,
+    "names": {
+      "ja": "エネコロロ",
+      "en": "Delcatty",
+      "ko": "델케티",
+      "zh-Hans": "优雅猫",
+      "zh-Hant": "優雅貓"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0301",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0302",
+    "no": "0302",
+    "form": null,
+    "names": {
+      "ja": "ヤミラミ",
+      "en": "Sableye",
+      "ko": "깜까미",
+      "zh-Hans": "勾魂眼",
+      "zh-Hant": "勾魂眼"
+    },
+    "types": [
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0302",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0303",
+    "no": "0303",
+    "form": null,
+    "names": {
+      "ja": "クチート",
+      "en": "Mawile",
+      "ko": "입치트",
+      "zh-Hans": "大嘴娃",
+      "zh-Hant": "大嘴娃"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0303",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0304",
+    "no": "0304",
+    "form": null,
+    "names": {
+      "ja": "ココドラ",
+      "en": "Aron",
+      "ko": "가보리",
+      "zh-Hans": "可可多拉",
+      "zh-Hant": "可可多拉"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0304",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0305",
+    "no": "0305",
+    "form": null,
+    "names": {
+      "ja": "コドラ",
+      "en": "Lairon",
+      "ko": "갱도라",
+      "zh-Hans": "可多拉",
+      "zh-Hant": "可多拉"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0305",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0306",
+    "no": "0306",
+    "form": null,
+    "names": {
+      "ja": "ボスゴドラ",
+      "en": "Aggron",
+      "ko": "보스로라",
+      "zh-Hans": "波士可多拉",
+      "zh-Hant": "波士可多拉"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0306",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0307",
+    "no": "0307",
+    "form": null,
+    "names": {
+      "ja": "アサナン",
+      "en": "Meditite",
+      "ko": "요가랑",
+      "zh-Hans": "玛沙那",
+      "zh-Hant": "瑪沙那"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      },
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0307",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0308",
+    "no": "0308",
+    "form": null,
+    "names": {
+      "ja": "チャーレム",
+      "en": "Medicham",
+      "ko": "요가램",
+      "zh-Hans": "恰雷姆",
+      "zh-Hant": "恰雷姆"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      },
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0308",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0309",
+    "no": "0309",
+    "form": null,
+    "names": {
+      "ja": "ラクライ",
+      "en": "Electrike",
+      "ko": "썬더라이",
+      "zh-Hans": "落雷兽",
+      "zh-Hant": "落雷獸"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0309",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0310",
+    "no": "0310",
+    "form": null,
+    "names": {
+      "ja": "ライボルト",
+      "en": "Manectric",
+      "ko": "썬더볼트",
+      "zh-Hans": "雷电兽",
+      "zh-Hant": "雷電獸"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0310",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0311",
+    "no": "0311",
+    "form": null,
+    "names": {
+      "ja": "プラスル",
+      "en": "Plusle",
+      "ko": "플러시",
+      "zh-Hans": "正电拍拍",
+      "zh-Hant": "正電拍拍"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0311",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0312",
+    "no": "0312",
+    "form": null,
+    "names": {
+      "ja": "マイナン",
+      "en": "Minun",
+      "ko": "마이농",
+      "zh-Hans": "负电拍拍",
+      "zh-Hant": "負電拍拍"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0312",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0313",
+    "no": "0313",
+    "form": null,
+    "names": {
+      "ja": "バルビート",
+      "en": "Volbeat",
+      "ko": "볼비트",
+      "zh-Hans": "电萤虫",
+      "zh-Hant": "電螢蟲"
+    },
+    "types": [
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0313",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0314",
+    "no": "0314",
+    "form": null,
+    "names": {
+      "ja": "イルミーゼ",
+      "en": "Illumise",
+      "ko": "네오비트",
+      "zh-Hans": "甜甜萤",
+      "zh-Hant": "甜甜螢"
+    },
+    "types": [
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0314",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0315",
+    "no": "0315",
+    "form": null,
+    "names": {
+      "ja": "ロゼリア",
+      "en": "Roselia",
+      "ko": "로젤리아",
+      "zh-Hans": "毒蔷薇",
+      "zh-Hant": "毒薔薇"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0315",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0316",
+    "no": "0316",
+    "form": null,
+    "names": {
+      "ja": "ゴクリン",
+      "en": "Gulpin",
+      "ko": "꼴깍몬",
+      "zh-Hans": "溶食兽",
+      "zh-Hant": "溶食獸"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0316",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0317",
+    "no": "0317",
+    "form": null,
+    "names": {
+      "ja": "マルノーム",
+      "en": "Swalot",
+      "ko": "꿀꺽몬",
+      "zh-Hans": "吞食兽",
+      "zh-Hant": "吞食獸"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0317",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0318",
+    "no": "0318",
+    "form": null,
+    "names": {
+      "ja": "キバニア",
+      "en": "Carvanha",
+      "ko": "샤프니아",
+      "zh-Hans": "利牙鱼",
+      "zh-Hant": "利牙魚"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0318",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0319",
+    "no": "0319",
+    "form": null,
+    "names": {
+      "ja": "サメハダー",
+      "en": "Sharpedo",
+      "ko": "샤크니아",
+      "zh-Hans": "巨牙鲨",
+      "zh-Hant": "巨牙鯊"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0319",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0320",
+    "no": "0320",
+    "form": null,
+    "names": {
+      "ja": "ホエルコ",
+      "en": "Wailmer",
+      "ko": "고래왕자",
+      "zh-Hans": "吼吼鲸",
+      "zh-Hant": "吼吼鯨"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0320",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0321",
+    "no": "0321",
+    "form": null,
+    "names": {
+      "ja": "ホエルオー",
+      "en": "Wailord",
+      "ko": "고래왕",
+      "zh-Hans": "吼鲸王",
+      "zh-Hant": "吼鯨王"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0321",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0322",
+    "no": "0322",
+    "form": null,
+    "names": {
+      "ja": "ドンメル",
+      "en": "Numel",
+      "ko": "둔타",
+      "zh-Hans": "呆火驼",
+      "zh-Hant": "呆火駝"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0322",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0323",
+    "no": "0323",
+    "form": null,
+    "names": {
+      "ja": "バクーダ",
+      "en": "Camerupt",
+      "ko": "폭타",
+      "zh-Hans": "喷火驼",
+      "zh-Hant": "噴火駝"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0323",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0324",
+    "no": "0324",
+    "form": null,
+    "names": {
+      "ja": "コータス",
+      "en": "Torkoal",
+      "ko": "코터스",
+      "zh-Hans": "煤炭龟",
+      "zh-Hant": "煤炭龜"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0324",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0325",
+    "no": "0325",
+    "form": null,
+    "names": {
+      "ja": "バネブー",
+      "en": "Spoink",
+      "ko": "피그점프",
+      "zh-Hans": "跳跳猪",
+      "zh-Hant": "跳跳豬"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0325",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0326",
+    "no": "0326",
+    "form": null,
+    "names": {
+      "ja": "ブーピッグ",
+      "en": "Grumpig",
+      "ko": "피그킹",
+      "zh-Hans": "噗噗猪",
+      "zh-Hant": "噗噗豬"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0326",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0327",
+    "no": "0327",
+    "form": null,
+    "names": {
+      "ja": "パッチール",
+      "en": "Spinda",
+      "ko": "얼루기",
+      "zh-Hans": "晃晃斑",
+      "zh-Hant": "晃晃斑"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0327",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0328",
+    "no": "0328",
+    "form": null,
+    "names": {
+      "ja": "ナックラー",
+      "en": "Trapinch",
+      "ko": "톱치",
+      "zh-Hans": "大颚蚁",
+      "zh-Hant": "大顎蟻"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0328",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0329",
+    "no": "0329",
+    "form": null,
+    "names": {
+      "ja": "ビブラーバ",
+      "en": "Vibrava",
+      "ko": "비브라바",
+      "zh-Hans": "超音波幼虫",
+      "zh-Hant": "超音波幼蟲"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0329",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0330",
+    "no": "0330",
+    "form": null,
+    "names": {
+      "ja": "フライゴン",
+      "en": "Flygon",
+      "ko": "플라이곤",
+      "zh-Hans": "沙漠蜻蜓",
+      "zh-Hant": "沙漠蜻蜓"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0330",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0331",
+    "no": "0331",
+    "form": null,
+    "names": {
+      "ja": "サボネア",
+      "en": "Cacnea",
+      "ko": "선인왕",
+      "zh-Hans": "刺球仙人掌",
+      "zh-Hant": "刺球仙人掌"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0331",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0332",
+    "no": "0332",
+    "form": null,
+    "names": {
+      "ja": "ノクタス",
+      "en": "Cacturne",
+      "ko": "밤선인",
+      "zh-Hans": "梦歌仙人掌",
+      "zh-Hant": "夢歌仙人掌"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0332",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0333",
+    "no": "0333",
+    "form": null,
+    "names": {
+      "ja": "チルット",
+      "en": "Swablu",
+      "ko": "파비코",
+      "zh-Hans": "青绵鸟",
+      "zh-Hant": "青綿鳥"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0333",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0334",
+    "no": "0334",
+    "form": null,
+    "names": {
+      "ja": "チルタリス",
+      "en": "Altaria",
+      "ko": "파비코리",
+      "zh-Hans": "七夕青鸟",
+      "zh-Hant": "七夕青鳥"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0334",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0335",
+    "no": "0335",
+    "form": null,
+    "names": {
+      "ja": "ザングース",
+      "en": "Zangoose",
+      "ko": "쟝고",
+      "zh-Hans": "猫鼬斩",
+      "zh-Hant": "貓鼬斬"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0335",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0336",
+    "no": "0336",
+    "form": null,
+    "names": {
+      "ja": "ハブネーク",
+      "en": "Seviper",
+      "ko": "세비퍼",
+      "zh-Hans": "饭匙蛇",
+      "zh-Hant": "飯匙蛇"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0336",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0337",
+    "no": "0337",
+    "form": null,
+    "names": {
+      "ja": "ルナトーン",
+      "en": "Lunatone",
+      "ko": "루나톤",
+      "zh-Hans": "月石",
+      "zh-Hant": "月石"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0337",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0338",
+    "no": "0338",
+    "form": null,
+    "names": {
+      "ja": "ソルロック",
+      "en": "Solrock",
+      "ko": "솔록",
+      "zh-Hans": "太阳岩",
+      "zh-Hant": "太陽岩"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0338",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0339",
+    "no": "0339",
+    "form": null,
+    "names": {
+      "ja": "ドジョッチ",
+      "en": "Barboach",
+      "ko": "미꾸리",
+      "zh-Hans": "泥泥鳅",
+      "zh-Hant": "泥泥鰍"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0339",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0340",
+    "no": "0340",
+    "form": null,
+    "names": {
+      "ja": "ナマズン",
+      "en": "Whiscash",
+      "ko": "메깅",
+      "zh-Hans": "鲶鱼王",
+      "zh-Hant": "鯰魚王"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0340",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0341",
+    "no": "0341",
+    "form": null,
+    "names": {
+      "ja": "ヘイガニ",
+      "en": "Corphish",
+      "ko": "가재군",
+      "zh-Hans": "龙虾小兵",
+      "zh-Hant": "龍蝦小兵"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0341",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0342",
+    "no": "0342",
+    "form": null,
+    "names": {
+      "ja": "シザリガー",
+      "en": "Crawdaunt",
+      "ko": "가재장군",
+      "zh-Hans": "铁螯龙虾",
+      "zh-Hant": "鐵螯龍蝦"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0342",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0343",
+    "no": "0343",
+    "form": null,
+    "names": {
+      "ja": "ヤジロン",
+      "en": "Baltoy",
+      "ko": "오뚝군",
+      "zh-Hans": "天秤偶",
+      "zh-Hant": "天秤偶"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0343",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0344",
+    "no": "0344",
+    "form": null,
+    "names": {
+      "ja": "ネンドール",
+      "en": "Claydol",
+      "ko": "점토도리",
+      "zh-Hans": "念力土偶",
+      "zh-Hant": "念力土偶"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0344",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0345",
+    "no": "0345",
+    "form": null,
+    "names": {
+      "ja": "リリーラ",
+      "en": "Lileep",
+      "ko": "릴링",
+      "zh-Hans": "触手百合",
+      "zh-Hant": "觸手百合"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0345",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0346",
+    "no": "0346",
+    "form": null,
+    "names": {
+      "ja": "ユレイドル",
+      "en": "Cradily",
+      "ko": "릴리요",
+      "zh-Hans": "摇篮百合",
+      "zh-Hant": "搖籃百合"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0346",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0347",
+    "no": "0347",
+    "form": null,
+    "names": {
+      "ja": "アノプス",
+      "en": "Anorith",
+      "ko": "아노딥스",
+      "zh-Hans": "太古羽虫",
+      "zh-Hant": "太古羽蟲"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0347",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0348",
+    "no": "0348",
+    "form": null,
+    "names": {
+      "ja": "アーマルド",
+      "en": "Armaldo",
+      "ko": "아말도",
+      "zh-Hans": "太古盔甲",
+      "zh-Hant": "太古盔甲"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0348",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0349",
+    "no": "0349",
+    "form": null,
+    "names": {
+      "ja": "ヒンバス",
+      "en": "Feebas",
+      "ko": "빈티나",
+      "zh-Hans": "丑丑鱼",
+      "zh-Hant": "醜醜魚"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0349",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0350",
+    "no": "0350",
+    "form": null,
+    "names": {
+      "ja": "ミロカロス",
+      "en": "Milotic",
+      "ko": "밀로틱",
+      "zh-Hans": "美纳斯",
+      "zh-Hant": "美納斯"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0350",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0351",
+    "no": "0351",
+    "form": null,
+    "names": {
+      "ja": "ポワルン",
+      "en": "Castform",
+      "ko": "캐스퐁",
+      "zh-Hans": "飘浮泡泡",
+      "zh-Hant": "飄浮泡泡"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0351",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0352",
+    "no": "0352",
+    "form": null,
+    "names": {
+      "ja": "カクレオン",
+      "en": "Kecleon",
+      "ko": "켈리몬",
+      "zh-Hans": "变隐龙",
+      "zh-Hant": "變隱龍"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0352",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0353",
+    "no": "0353",
+    "form": null,
+    "names": {
+      "ja": "カゲボウズ",
+      "en": "Shuppet",
+      "ko": "어둠대신",
+      "zh-Hans": "怨影娃娃",
+      "zh-Hant": "怨影娃娃"
+    },
+    "types": [
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0353",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0354",
+    "no": "0354",
+    "form": null,
+    "names": {
+      "ja": "ジュペッタ",
+      "en": "Banette",
+      "ko": "다크펫",
+      "zh-Hans": "诅咒娃娃",
+      "zh-Hant": "詛咒娃娃"
+    },
+    "types": [
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0354",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0355",
+    "no": "0355",
+    "form": null,
+    "names": {
+      "ja": "ヨマワル",
+      "en": "Duskull",
+      "ko": "해골몽",
+      "zh-Hans": "夜巡灵",
+      "zh-Hant": "夜巡靈"
+    },
+    "types": [
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0355",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0356",
+    "no": "0356",
+    "form": null,
+    "names": {
+      "ja": "サマヨール",
+      "en": "Dusclops",
+      "ko": "미라몽",
+      "zh-Hans": "彷徨夜灵",
+      "zh-Hant": "彷徨夜靈"
+    },
+    "types": [
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0356",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0357",
+    "no": "0357",
+    "form": null,
+    "names": {
+      "ja": "トロピウス",
+      "en": "Tropius",
+      "ko": "트로피우스",
+      "zh-Hans": "热带龙",
+      "zh-Hant": "熱帶龍"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0357",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0358",
+    "no": "0358",
+    "form": null,
+    "names": {
+      "ja": "チリーン",
+      "en": "Chimecho",
+      "ko": "치렁",
+      "zh-Hans": "风铃铃",
+      "zh-Hant": "風鈴鈴"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0358",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0359",
+    "no": "0359",
+    "form": null,
+    "names": {
+      "ja": "アブソル",
+      "en": "Absol",
+      "ko": "앱솔",
+      "zh-Hans": "阿勃梭鲁",
+      "zh-Hant": "阿勃梭魯"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0359",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0360",
+    "no": "0360",
+    "form": null,
+    "names": {
+      "ja": "ソーナノ",
+      "en": "Wynaut",
+      "ko": "마자",
+      "zh-Hans": "小果然",
+      "zh-Hant": "小果然"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0360",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0361",
+    "no": "0361",
+    "form": null,
+    "names": {
+      "ja": "ユキワラシ",
+      "en": "Snorunt",
+      "ko": "눈꼬마",
+      "zh-Hans": "雪童子",
+      "zh-Hant": "雪童子"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0361",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0362",
+    "no": "0362",
+    "form": null,
+    "names": {
+      "ja": "オニゴーリ",
+      "en": "Glalie",
+      "ko": "얼음귀신",
+      "zh-Hans": "冰鬼护",
+      "zh-Hant": "冰鬼護"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0362",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0363",
+    "no": "0363",
+    "form": null,
+    "names": {
+      "ja": "タマザラシ",
+      "en": "Spheal",
+      "ko": "대굴레오",
+      "zh-Hans": "海豹球",
+      "zh-Hant": "海豹球"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0363",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0364",
+    "no": "0364",
+    "form": null,
+    "names": {
+      "ja": "トドグラー",
+      "en": "Sealeo",
+      "ko": "씨레오",
+      "zh-Hans": "海魔狮",
+      "zh-Hant": "海魔獅"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0364",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0365",
+    "no": "0365",
+    "form": null,
+    "names": {
+      "ja": "トドゼルガ",
+      "en": "Walrein",
+      "ko": "씨카이저",
+      "zh-Hans": "帝牙海狮",
+      "zh-Hant": "帝牙海獅"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0365",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0366",
+    "no": "0366",
+    "form": null,
+    "names": {
+      "ja": "パールル",
+      "en": "Clamperl",
+      "ko": "진주몽",
+      "zh-Hans": "珍珠贝",
+      "zh-Hant": "珍珠貝"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0366",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0367",
+    "no": "0367",
+    "form": null,
+    "names": {
+      "ja": "ハンテール",
+      "en": "Huntail",
+      "ko": "헌테일",
+      "zh-Hans": "猎斑鱼",
+      "zh-Hant": "獵斑魚"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0367",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0368",
+    "no": "0368",
+    "form": null,
+    "names": {
+      "ja": "サクラビス",
+      "en": "Gorebyss",
+      "ko": "분홍장이",
+      "zh-Hans": "樱花鱼",
+      "zh-Hant": "櫻花魚"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0368",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0369",
+    "no": "0369",
+    "form": null,
+    "names": {
+      "ja": "ジーランス",
+      "en": "Relicanth",
+      "ko": "시라칸",
+      "zh-Hans": "古空棘鱼",
+      "zh-Hant": "古空棘魚"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0369",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0370",
+    "no": "0370",
+    "form": null,
+    "names": {
+      "ja": "ラブカス",
+      "en": "Luvdisc",
+      "ko": "사랑동이",
+      "zh-Hans": "爱心鱼",
+      "zh-Hant": "愛心魚"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0370",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0371",
+    "no": "0371",
+    "form": null,
+    "names": {
+      "ja": "タツベイ",
+      "en": "Bagon",
+      "ko": "아공이",
+      "zh-Hans": "宝贝龙",
+      "zh-Hant": "寶貝龍"
+    },
+    "types": [
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0371",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0372",
+    "no": "0372",
+    "form": null,
+    "names": {
+      "ja": "コモルー",
+      "en": "Shelgon",
+      "ko": "쉘곤",
+      "zh-Hans": "甲壳龙",
+      "zh-Hant": "甲殼龍"
+    },
+    "types": [
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0372",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0373",
+    "no": "0373",
+    "form": null,
+    "names": {
+      "ja": "ボーマンダ",
+      "en": "Salamence",
+      "ko": "보만다",
+      "zh-Hans": "暴飞龙",
+      "zh-Hant": "暴飛龍"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0373",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0374",
+    "no": "0374",
+    "form": null,
+    "names": {
+      "ja": "ダンバル",
+      "en": "Beldum",
+      "ko": "메탕",
+      "zh-Hans": "铁哑铃",
+      "zh-Hant": "鐵啞鈴"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0374",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0375",
+    "no": "0375",
+    "form": null,
+    "names": {
+      "ja": "メタング",
+      "en": "Metang",
+      "ko": "메탕구",
+      "zh-Hans": "金属怪",
+      "zh-Hant": "金屬怪"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0375",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0376",
+    "no": "0376",
+    "form": null,
+    "names": {
+      "ja": "メタグロス",
+      "en": "Metagross",
+      "ko": "메타그로스",
+      "zh-Hans": "巨金怪",
+      "zh-Hant": "巨金怪"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0376",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0377",
+    "no": "0377",
+    "form": null,
+    "names": {
+      "ja": "レジロック",
+      "en": "Regirock",
+      "ko": "레지락",
+      "zh-Hans": "雷吉洛克",
+      "zh-Hant": "雷吉洛克"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0377",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0378",
+    "no": "0378",
+    "form": null,
+    "names": {
+      "ja": "レジアイス",
+      "en": "Regice",
+      "ko": "레지아이스",
+      "zh-Hans": "雷吉艾斯",
+      "zh-Hant": "雷吉艾斯"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0378",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0379",
+    "no": "0379",
+    "form": null,
+    "names": {
+      "ja": "レジスチル",
+      "en": "Registeel",
+      "ko": "레지스틸",
+      "zh-Hans": "雷吉斯奇鲁",
+      "zh-Hant": "雷吉斯奇魯"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0379",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0380",
+    "no": "0380",
+    "form": null,
+    "names": {
+      "ja": "ラティアス",
+      "en": "Latias",
+      "ko": "라티아스",
+      "zh-Hans": "拉帝亚斯",
+      "zh-Hant": "拉帝亞斯"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0380",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0381",
+    "no": "0381",
+    "form": null,
+    "names": {
+      "ja": "ラティオス",
+      "en": "Latios",
+      "ko": "라티오스",
+      "zh-Hans": "拉帝欧斯",
+      "zh-Hant": "拉帝歐斯"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0381",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0382",
+    "no": "0382",
+    "form": null,
+    "names": {
+      "ja": "カイオーガ",
+      "en": "Kyogre",
+      "ko": "가이오가",
+      "zh-Hans": "盖欧卡",
+      "zh-Hant": "蓋歐卡"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0382",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0383",
+    "no": "0383",
+    "form": null,
+    "names": {
+      "ja": "グラードン",
+      "en": "Groudon",
+      "ko": "그란돈",
+      "zh-Hans": "固拉多",
+      "zh-Hant": "固拉多"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0383",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0384",
+    "no": "0384",
+    "form": null,
+    "names": {
+      "ja": "レックウザ",
+      "en": "Rayquaza",
+      "ko": "레쿠쟈",
+      "zh-Hans": "烈空坐",
+      "zh-Hant": "烈空坐"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0384",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0385",
+    "no": "0385",
+    "form": null,
+    "names": {
+      "ja": "ジラーチ",
+      "en": "Jirachi",
+      "ko": "지라치",
+      "zh-Hans": "基拉祈",
+      "zh-Hant": "基拉祈"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0385",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0386",
+    "no": "0386",
+    "form": null,
+    "names": {
+      "ja": "デオキシス",
+      "en": "Deoxys",
+      "ko": "테오키스",
+      "zh-Hans": "代欧奇希斯",
+      "zh-Hant": "代歐奇希斯"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0386",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0387",
+    "no": "0387",
+    "form": null,
+    "names": {
+      "ja": "ナエトル",
+      "en": "Turtwig",
+      "ko": "모부기",
+      "zh-Hans": "草苗龟",
+      "zh-Hant": "草苗龜"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0387",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0388",
+    "no": "0388",
+    "form": null,
+    "names": {
+      "ja": "ハヤシガメ",
+      "en": "Grotle",
+      "ko": "수풀부기",
+      "zh-Hans": "树林龟",
+      "zh-Hant": "樹林龜"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0388",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0389",
+    "no": "0389",
+    "form": null,
+    "names": {
+      "ja": "ドダイトス",
+      "en": "Torterra",
+      "ko": "토대부기",
+      "zh-Hans": "土台龟",
+      "zh-Hant": "土台龜"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0389",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0390",
+    "no": "0390",
+    "form": null,
+    "names": {
+      "ja": "ヒコザル",
+      "en": "Chimchar",
+      "ko": "불꽃숭이",
+      "zh-Hans": "小火焰猴",
+      "zh-Hant": "小火焰猴"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0390",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0391",
+    "no": "0391",
+    "form": null,
+    "names": {
+      "ja": "モウカザル",
+      "en": "Monferno",
+      "ko": "파이숭이",
+      "zh-Hans": "猛火猴",
+      "zh-Hant": "猛火猴"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0391",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0392",
+    "no": "0392",
+    "form": null,
+    "names": {
+      "ja": "ゴウカザル",
+      "en": "Infernape",
+      "ko": "초염몽",
+      "zh-Hans": "烈焰猴",
+      "zh-Hant": "烈焰猴"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0392",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0393",
+    "no": "0393",
+    "form": null,
+    "names": {
+      "ja": "ポッチャマ",
+      "en": "Piplup",
+      "ko": "팽도리",
+      "zh-Hans": "波加曼",
+      "zh-Hant": "波加曼"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0393",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0394",
+    "no": "0394",
+    "form": null,
+    "names": {
+      "ja": "ポッタイシ",
+      "en": "Prinplup",
+      "ko": "팽태자",
+      "zh-Hans": "波皇子",
+      "zh-Hant": "波皇子"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0394",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0395",
+    "no": "0395",
+    "form": null,
+    "names": {
+      "ja": "エンペルト",
+      "en": "Empoleon",
+      "ko": "엠페르트",
+      "zh-Hans": "帝王拿波",
+      "zh-Hant": "帝王拿波"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0395",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0396",
+    "no": "0396",
+    "form": null,
+    "names": {
+      "ja": "ムックル",
+      "en": "Starly",
+      "ko": "찌르꼬",
+      "zh-Hans": "姆克儿",
+      "zh-Hant": "姆克兒"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0396",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0397",
+    "no": "0397",
+    "form": null,
+    "names": {
+      "ja": "ムクバード",
+      "en": "Staravia",
+      "ko": "찌르버드",
+      "zh-Hans": "姆克鸟",
+      "zh-Hant": "姆克鳥"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0397",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0398",
+    "no": "0398",
+    "form": null,
+    "names": {
+      "ja": "ムクホーク",
+      "en": "Staraptor",
+      "ko": "찌르호크",
+      "zh-Hans": "姆克鹰",
+      "zh-Hant": "姆克鷹"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0398",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0399",
+    "no": "0399",
+    "form": null,
+    "names": {
+      "ja": "ビッパ",
+      "en": "Bidoof",
+      "ko": "비버니",
+      "zh-Hans": "大牙狸",
+      "zh-Hant": "大牙狸"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0399",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0400",
+    "no": "0400",
+    "form": null,
+    "names": {
+      "ja": "ビーダル",
+      "en": "Bibarel",
+      "ko": "비버통",
+      "zh-Hans": "大尾狸",
+      "zh-Hant": "大尾狸"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0400",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0401",
+    "no": "0401",
+    "form": null,
+    "names": {
+      "ja": "コロボーシ",
+      "en": "Kricketot",
+      "ko": "귀뚤뚜기",
+      "zh-Hans": "圆法师",
+      "zh-Hant": "圓法師"
+    },
+    "types": [
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0401",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0402",
+    "no": "0402",
+    "form": null,
+    "names": {
+      "ja": "コロトック",
+      "en": "Kricketune",
+      "ko": "귀뚤톡크",
+      "zh-Hans": "音箱蟀",
+      "zh-Hant": "音箱蟀"
+    },
+    "types": [
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0402",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0403",
+    "no": "0403",
+    "form": null,
+    "names": {
+      "ja": "コリンク",
+      "en": "Shinx",
+      "ko": "꼬링크",
+      "zh-Hans": "小猫怪",
+      "zh-Hant": "小貓怪"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0403",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0404",
+    "no": "0404",
+    "form": null,
+    "names": {
+      "ja": "ルクシオ",
+      "en": "Luxio",
+      "ko": "럭시오",
+      "zh-Hans": "勒克猫",
+      "zh-Hant": "勒克貓"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0404",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0405",
+    "no": "0405",
+    "form": null,
+    "names": {
+      "ja": "レントラー",
+      "en": "Luxray",
+      "ko": "렌트라",
+      "zh-Hans": "伦琴猫",
+      "zh-Hant": "倫琴貓"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0405",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0406",
+    "no": "0406",
+    "form": null,
+    "names": {
+      "ja": "スボミー",
+      "en": "Budew",
+      "ko": "꼬몽울",
+      "zh-Hans": "含羞苞",
+      "zh-Hant": "含羞苞"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0406",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0407",
+    "no": "0407",
+    "form": null,
+    "names": {
+      "ja": "ロズレイド",
+      "en": "Roserade",
+      "ko": "로즈레이드",
+      "zh-Hans": "罗丝雷朵",
+      "zh-Hant": "羅絲雷朵"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0407",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0408",
+    "no": "0408",
+    "form": null,
+    "names": {
+      "ja": "ズガイドス",
+      "en": "Cranidos",
+      "ko": "두개도스",
+      "zh-Hans": "头盖龙",
+      "zh-Hant": "頭蓋龍"
+    },
+    "types": [
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0408",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0409",
+    "no": "0409",
+    "form": null,
+    "names": {
+      "ja": "ラムパルド",
+      "en": "Rampardos",
+      "ko": "램펄드",
+      "zh-Hans": "战槌龙",
+      "zh-Hant": "戰槌龍"
+    },
+    "types": [
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0409",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0410",
+    "no": "0410",
+    "form": null,
+    "names": {
+      "ja": "タテトプス",
+      "en": "Shieldon",
+      "ko": "방패톱스",
+      "zh-Hans": "盾甲龙",
+      "zh-Hant": "盾甲龍"
+    },
+    "types": [
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0410",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0411",
+    "no": "0411",
+    "form": null,
+    "names": {
+      "ja": "トリデプス",
+      "en": "Bastiodon",
+      "ko": "바리톱스",
+      "zh-Hans": "护城龙",
+      "zh-Hant": "護城龍"
+    },
+    "types": [
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0411",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0412",
+    "no": "0412",
+    "form": null,
+    "names": {
+      "ja": "ミノムッチ",
+      "en": "Burmy",
+      "ko": "도롱충이",
+      "zh-Hans": "结草儿",
+      "zh-Hant": "結草兒"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0412",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0413",
+    "no": "0413",
+    "form": null,
+    "names": {
+      "ja": "ミノマダム",
+      "en": "Wormadam",
+      "ko": "도롱마담",
+      "zh-Hans": "结草贵妇",
+      "zh-Hant": "結草貴婦"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0413",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0414",
+    "no": "0414",
+    "form": null,
+    "names": {
+      "ja": "ガーメイル",
+      "en": "Mothim",
+      "ko": "나메일",
+      "zh-Hans": "绅士蛾",
+      "zh-Hant": "紳士蛾"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0414",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0415",
+    "no": "0415",
+    "form": null,
+    "names": {
+      "ja": "ミツハニー",
+      "en": "Combee",
+      "ko": "세꿀버리",
+      "zh-Hans": "三蜜蜂",
+      "zh-Hant": "三蜜蜂"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0415",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0416",
+    "no": "0416",
+    "form": null,
+    "names": {
+      "ja": "ビークイン",
+      "en": "Vespiquen",
+      "ko": "비퀸",
+      "zh-Hans": "蜂女王",
+      "zh-Hant": "蜂女王"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0416",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0417",
+    "no": "0417",
+    "form": null,
+    "names": {
+      "ja": "パチリス",
+      "en": "Pachirisu",
+      "ko": "파치리스",
+      "zh-Hans": "帕奇利兹",
+      "zh-Hant": "帕奇利茲"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0417",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0418",
+    "no": "0418",
+    "form": null,
+    "names": {
+      "ja": "ブイゼル",
+      "en": "Buizel",
+      "ko": "브이젤",
+      "zh-Hans": "泳圈鼬",
+      "zh-Hant": "泳圈鼬"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0418",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0419",
+    "no": "0419",
+    "form": null,
+    "names": {
+      "ja": "フローゼル",
+      "en": "Floatzel",
+      "ko": "플로젤",
+      "zh-Hans": "浮潜鼬",
+      "zh-Hant": "浮潛鼬"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0419",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0420",
+    "no": "0420",
+    "form": null,
+    "names": {
+      "ja": "チェリンボ",
+      "en": "Cherubi",
+      "ko": "체리버",
+      "zh-Hans": "樱花宝",
+      "zh-Hant": "櫻花寶"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0420",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0421",
+    "no": "0421",
+    "form": null,
+    "names": {
+      "ja": "チェリム",
+      "en": "Cherrim",
+      "ko": "체리꼬",
+      "zh-Hans": "樱花儿",
+      "zh-Hant": "櫻花兒"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0421",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0422",
+    "no": "0422",
+    "form": null,
+    "names": {
+      "ja": "カラナクシ",
+      "en": "Shellos",
+      "ko": "깝질무",
+      "zh-Hans": "无壳海兔",
+      "zh-Hant": "無殼海兔"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0422",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0423",
+    "no": "0423",
+    "form": null,
+    "names": {
+      "ja": "トリトドン",
+      "en": "Gastrodon",
+      "ko": "트리토돈",
+      "zh-Hans": "海兔兽",
+      "zh-Hant": "海兔獸"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0423",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0424",
+    "no": "0424",
+    "form": null,
+    "names": {
+      "ja": "エテボース",
+      "en": "Ambipom",
+      "ko": "겟핸보숭",
+      "zh-Hans": "双尾怪手",
+      "zh-Hant": "雙尾怪手"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0424",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0425",
+    "no": "0425",
+    "form": null,
+    "names": {
+      "ja": "フワンテ",
+      "en": "Drifloon",
+      "ko": "흔들풍손",
+      "zh-Hans": "飘飘球",
+      "zh-Hant": "飄飄球"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0425",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0426",
+    "no": "0426",
+    "form": null,
+    "names": {
+      "ja": "フワライド",
+      "en": "Drifblim",
+      "ko": "둥실라이드",
+      "zh-Hans": "随风球",
+      "zh-Hant": "隨風球"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0426",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0427",
+    "no": "0427",
+    "form": null,
+    "names": {
+      "ja": "ミミロル",
+      "en": "Buneary",
+      "ko": "이어롤",
+      "zh-Hans": "卷卷耳",
+      "zh-Hant": "捲捲耳"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0427",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0428",
+    "no": "0428",
+    "form": null,
+    "names": {
+      "ja": "ミミロップ",
+      "en": "Lopunny",
+      "ko": "이어롭",
+      "zh-Hans": "长耳兔",
+      "zh-Hant": "長耳兔"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0428",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0429",
+    "no": "0429",
+    "form": null,
+    "names": {
+      "ja": "ムウマージ",
+      "en": "Mismagius",
+      "ko": "무우마직",
+      "zh-Hans": "梦妖魔",
+      "zh-Hant": "夢妖魔"
+    },
+    "types": [
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0429",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0430",
+    "no": "0430",
+    "form": null,
+    "names": {
+      "ja": "ドンカラス",
+      "en": "Honchkrow",
+      "ko": "돈크로우",
+      "zh-Hans": "乌鸦头头",
+      "zh-Hant": "烏鴉頭頭"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0430",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0431",
+    "no": "0431",
+    "form": null,
+    "names": {
+      "ja": "ニャルマー",
+      "en": "Glameow",
+      "ko": "나옹마",
+      "zh-Hans": "魅力喵",
+      "zh-Hant": "魅力喵"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0431",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0432",
+    "no": "0432",
+    "form": null,
+    "names": {
+      "ja": "ブニャット",
+      "en": "Purugly",
+      "ko": "몬냥이",
+      "zh-Hans": "东施喵",
+      "zh-Hant": "東施喵"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0432",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0433",
+    "no": "0433",
+    "form": null,
+    "names": {
+      "ja": "リーシャン",
+      "en": "Chingling",
+      "ko": "랑딸랑",
+      "zh-Hans": "铃铛响",
+      "zh-Hant": "鈴鐺響"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0433",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0434",
+    "no": "0434",
+    "form": null,
+    "names": {
+      "ja": "スカンプー",
+      "en": "Stunky",
+      "ko": "스컹뿡",
+      "zh-Hans": "臭鼬噗",
+      "zh-Hant": "臭鼬噗"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0434",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0435",
+    "no": "0435",
+    "form": null,
+    "names": {
+      "ja": "スカタンク",
+      "en": "Skuntank",
+      "ko": "스컹탱크",
+      "zh-Hans": "坦克臭鼬",
+      "zh-Hant": "坦克臭鼬"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0435",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0436",
+    "no": "0436",
+    "form": null,
+    "names": {
+      "ja": "ドーミラー",
+      "en": "Bronzor",
+      "ko": "동미러",
+      "zh-Hans": "铜镜怪",
+      "zh-Hant": "銅鏡怪"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0436",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0437",
+    "no": "0437",
+    "form": null,
+    "names": {
+      "ja": "ドータクン",
+      "en": "Bronzong",
+      "ko": "동탁군",
+      "zh-Hans": "青铜钟",
+      "zh-Hant": "青銅鐘"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0437",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0438",
+    "no": "0438",
+    "form": null,
+    "names": {
+      "ja": "ウソハチ",
+      "en": "Bonsly",
+      "ko": "꼬지지",
+      "zh-Hans": "盆才怪",
+      "zh-Hant": "盆才怪"
+    },
+    "types": [
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0438",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0439",
+    "no": "0439",
+    "form": null,
+    "names": {
+      "ja": "マネネ",
+      "en": "Mime Jr.",
+      "ko": "흉내내",
+      "zh-Hans": "魔尼尼",
+      "zh-Hant": "魔尼尼"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0439",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0440",
+    "no": "0440",
+    "form": null,
+    "names": {
+      "ja": "ピンプク",
+      "en": "Happiny",
+      "ko": "핑복",
+      "zh-Hans": "小福蛋",
+      "zh-Hant": "小福蛋"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0440",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0441",
+    "no": "0441",
+    "form": null,
+    "names": {
+      "ja": "ペラップ",
+      "en": "Chatot",
+      "ko": "페라페",
+      "zh-Hans": "聒噪鸟",
+      "zh-Hant": "聒噪鳥"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0441",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0442",
+    "no": "0442",
+    "form": null,
+    "names": {
+      "ja": "ミカルゲ",
+      "en": "Spiritomb",
+      "ko": "화강돌",
+      "zh-Hans": "花岩怪",
+      "zh-Hant": "花岩怪"
+    },
+    "types": [
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0442",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0443",
+    "no": "0443",
+    "form": null,
+    "names": {
+      "ja": "フカマル",
+      "en": "Gible",
+      "ko": "딥상어동",
+      "zh-Hans": "圆陆鲨",
+      "zh-Hant": "圓陸鯊"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0443",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0444",
+    "no": "0444",
+    "form": null,
+    "names": {
+      "ja": "ガバイト",
+      "en": "Gabite",
+      "ko": "한바이트",
+      "zh-Hans": "尖牙陆鲨",
+      "zh-Hant": "尖牙陸鯊"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0444",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0445",
+    "no": "0445",
+    "form": null,
+    "names": {
+      "ja": "ガブリアス",
+      "en": "Garchomp",
+      "ko": "한카리아스",
+      "zh-Hans": "烈咬陆鲨",
+      "zh-Hant": "烈咬陸鯊"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0445",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0446",
+    "no": "0446",
+    "form": null,
+    "names": {
+      "ja": "ゴンベ",
+      "en": "Munchlax",
+      "ko": "먹고자",
+      "zh-Hans": "小卡比兽",
+      "zh-Hant": "小卡比獸"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0446",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0447",
+    "no": "0447",
+    "form": null,
+    "names": {
+      "ja": "リオル",
+      "en": "Riolu",
+      "ko": "리오르",
+      "zh-Hans": "利欧路",
+      "zh-Hant": "利歐路"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0447",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0448",
+    "no": "0448",
+    "form": null,
+    "names": {
+      "ja": "ルカリオ",
+      "en": "Lucario",
+      "ko": "루카리오",
+      "zh-Hans": "路卡利欧",
+      "zh-Hant": "路卡利歐"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0448",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0449",
+    "no": "0449",
+    "form": null,
+    "names": {
+      "ja": "ヒポポタス",
+      "en": "Hippopotas",
+      "ko": "히포포타스",
+      "zh-Hans": "沙河马",
+      "zh-Hant": "沙河馬"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0449",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0450",
+    "no": "0450",
+    "form": null,
+    "names": {
+      "ja": "カバルドン",
+      "en": "Hippowdon",
+      "ko": "하마돈",
+      "zh-Hans": "河马兽",
+      "zh-Hant": "河馬獸"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0450",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0451",
+    "no": "0451",
+    "form": null,
+    "names": {
+      "ja": "スコルピ",
+      "en": "Skorupi",
+      "ko": "스콜피",
+      "zh-Hans": "钳尾蝎",
+      "zh-Hant": "鉗尾蠍"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0451",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0452",
+    "no": "0452",
+    "form": null,
+    "names": {
+      "ja": "ドラピオン",
+      "en": "Drapion",
+      "ko": "드래피온",
+      "zh-Hans": "龙王蝎",
+      "zh-Hant": "龍王蠍"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0452",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0453",
+    "no": "0453",
+    "form": null,
+    "names": {
+      "ja": "グレッグル",
+      "en": "Croagunk",
+      "ko": "삐딱구리",
+      "zh-Hans": "不良蛙",
+      "zh-Hant": "不良蛙"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0453",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0454",
+    "no": "0454",
+    "form": null,
+    "names": {
+      "ja": "ドクロッグ",
+      "en": "Toxicroak",
+      "ko": "독개굴",
+      "zh-Hans": "毒骷蛙",
+      "zh-Hant": "毒骷蛙"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0454",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0455",
+    "no": "0455",
+    "form": null,
+    "names": {
+      "ja": "マスキッパ",
+      "en": "Carnivine",
+      "ko": "무스틈니",
+      "zh-Hans": "尖牙笼",
+      "zh-Hant": "尖牙籠"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0455",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0456",
+    "no": "0456",
+    "form": null,
+    "names": {
+      "ja": "ケイコウオ",
+      "en": "Finneon",
+      "ko": "형광어",
+      "zh-Hans": "荧光鱼",
+      "zh-Hant": "螢光魚"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0456",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0457",
+    "no": "0457",
+    "form": null,
+    "names": {
+      "ja": "ネオラント",
+      "en": "Lumineon",
+      "ko": "네오라이트",
+      "zh-Hans": "霓虹鱼",
+      "zh-Hant": "霓虹魚"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0457",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0458",
+    "no": "0458",
+    "form": null,
+    "names": {
+      "ja": "タマンタ",
+      "en": "Mantyke",
+      "ko": "타만타",
+      "zh-Hans": "小球飞鱼",
+      "zh-Hant": "小球飛魚"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0458",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0459",
+    "no": "0459",
+    "form": null,
+    "names": {
+      "ja": "ユキカブリ",
+      "en": "Snover",
+      "ko": "눈쓰개",
+      "zh-Hans": "雪笠怪",
+      "zh-Hant": "雪笠怪"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0459",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0460",
+    "no": "0460",
+    "form": null,
+    "names": {
+      "ja": "ユキノオー",
+      "en": "Abomasnow",
+      "ko": "눈설왕",
+      "zh-Hans": "暴雪王",
+      "zh-Hant": "暴雪王"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0460",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0461",
+    "no": "0461",
+    "form": null,
+    "names": {
+      "ja": "マニューラ",
+      "en": "Weavile",
+      "ko": "포푸니라",
+      "zh-Hans": "玛狃拉",
+      "zh-Hant": "瑪狃拉"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0461",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0462",
+    "no": "0462",
+    "form": null,
+    "names": {
+      "ja": "ジバコイル",
+      "en": "Magnezone",
+      "ko": "자포코일",
+      "zh-Hans": "自爆磁怪",
+      "zh-Hant": "自爆磁怪"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0462",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0463",
+    "no": "0463",
+    "form": null,
+    "names": {
+      "ja": "ベロベルト",
+      "en": "Lickilicky",
+      "ko": "내룸벨트",
+      "zh-Hans": "大舌舔",
+      "zh-Hant": "大舌舔"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0463",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0464",
+    "no": "0464",
+    "form": null,
+    "names": {
+      "ja": "ドサイドン",
+      "en": "Rhyperior",
+      "ko": "거대코뿌리",
+      "zh-Hans": "超甲狂犀",
+      "zh-Hant": "超甲狂犀"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0464",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0465",
+    "no": "0465",
+    "form": null,
+    "names": {
+      "ja": "モジャンボ",
+      "en": "Tangrowth",
+      "ko": "덩쿠림보",
+      "zh-Hans": "巨蔓藤",
+      "zh-Hant": "巨蔓藤"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0465",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0466",
+    "no": "0466",
+    "form": null,
+    "names": {
+      "ja": "エレキブル",
+      "en": "Electivire",
+      "ko": "에레키블",
+      "zh-Hans": "电击魔兽",
+      "zh-Hant": "電擊魔獸"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0466",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0467",
+    "no": "0467",
+    "form": null,
+    "names": {
+      "ja": "ブーバーン",
+      "en": "Magmortar",
+      "ko": "마그마번",
+      "zh-Hans": "鸭嘴炎兽",
+      "zh-Hant": "鴨嘴炎獸"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0467",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0468",
+    "no": "0468",
+    "form": null,
+    "names": {
+      "ja": "トゲキッス",
+      "en": "Togekiss",
+      "ko": "토게키스",
+      "zh-Hans": "波克基斯",
+      "zh-Hant": "波克基斯"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0468",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0469",
+    "no": "0469",
+    "form": null,
+    "names": {
+      "ja": "メガヤンマ",
+      "en": "Yanmega",
+      "ko": "메가자리",
+      "zh-Hans": "远古巨蜓",
+      "zh-Hant": "遠古巨蜓"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0469",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0470",
+    "no": "0470",
+    "form": null,
+    "names": {
+      "ja": "リーフィア",
+      "en": "Leafeon",
+      "ko": "리피아",
+      "zh-Hans": "叶伊布",
+      "zh-Hant": "葉伊布"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0470",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0471",
+    "no": "0471",
+    "form": null,
+    "names": {
+      "ja": "グレイシア",
+      "en": "Glaceon",
+      "ko": "글레이시아",
+      "zh-Hans": "冰伊布",
+      "zh-Hant": "冰伊布"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0471",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0472",
+    "no": "0472",
+    "form": null,
+    "names": {
+      "ja": "グライオン",
+      "en": "Gliscor",
+      "ko": "글라이온",
+      "zh-Hans": "天蝎王",
+      "zh-Hant": "天蠍王"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0472",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0473",
+    "no": "0473",
+    "form": null,
+    "names": {
+      "ja": "マンムー",
+      "en": "Mamoswine",
+      "ko": "맘모꾸리",
+      "zh-Hans": "象牙猪",
+      "zh-Hant": "象牙豬"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      },
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0473",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0474",
+    "no": "0474",
+    "form": null,
+    "names": {
+      "ja": "ポリゴンＺ",
+      "en": "Porygon-Z",
+      "ko": "폴리곤Z",
+      "zh-Hans": "多边兽乙型",
+      "zh-Hant": "多邊獸Ｚ"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0474",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0475",
+    "no": "0475",
+    "form": null,
+    "names": {
+      "ja": "エルレイド",
+      "en": "Gallade",
+      "ko": "엘레이드",
+      "zh-Hans": "艾路雷朵",
+      "zh-Hant": "艾路雷朵"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      },
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0475",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0476",
+    "no": "0476",
+    "form": null,
+    "names": {
+      "ja": "ダイノーズ",
+      "en": "Probopass",
+      "ko": "대코파스",
+      "zh-Hans": "大朝北鼻",
+      "zh-Hant": "大朝北鼻"
+    },
+    "types": [
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0476",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0477",
+    "no": "0477",
+    "form": null,
+    "names": {
+      "ja": "ヨノワール",
+      "en": "Dusknoir",
+      "ko": "야느와르몽",
+      "zh-Hans": "黑夜魔灵",
+      "zh-Hant": "黑夜魔靈"
+    },
+    "types": [
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0477",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0478",
+    "no": "0478",
+    "form": null,
+    "names": {
+      "ja": "ユキメノコ",
+      "en": "Froslass",
+      "ko": "눈여아",
+      "zh-Hans": "雪妖女",
+      "zh-Hant": "雪妖女"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0478",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0479",
+    "no": "0479",
+    "form": null,
+    "names": {
+      "ja": "ロトム",
+      "en": "Rotom",
+      "ko": "로토무",
+      "zh-Hans": "洛托姆",
+      "zh-Hant": "洛托姆"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0479",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0480",
+    "no": "0480",
+    "form": null,
+    "names": {
+      "ja": "ユクシー",
+      "en": "Uxie",
+      "ko": "유크시",
+      "zh-Hans": "由克希",
+      "zh-Hant": "由克希"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0480",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0481",
+    "no": "0481",
+    "form": null,
+    "names": {
+      "ja": "エムリット",
+      "en": "Mesprit",
+      "ko": "엠라이트",
+      "zh-Hans": "艾姆利多",
+      "zh-Hant": "艾姆利多"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0481",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0482",
+    "no": "0482",
+    "form": null,
+    "names": {
+      "ja": "アグノム",
+      "en": "Azelf",
+      "ko": "아그놈",
+      "zh-Hans": "亚克诺姆",
+      "zh-Hant": "亞克諾姆"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0482",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0483",
+    "no": "0483",
+    "form": null,
+    "names": {
+      "ja": "ディアルガ",
+      "en": "Dialga",
+      "ko": "디아루가",
+      "zh-Hans": "帝牙卢卡",
+      "zh-Hant": "帝牙盧卡"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0483",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0484",
+    "no": "0484",
+    "form": null,
+    "names": {
+      "ja": "パルキア",
+      "en": "Palkia",
+      "ko": "펄기아",
+      "zh-Hans": "帕路奇亚",
+      "zh-Hant": "帕路奇亞"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0484",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0485",
+    "no": "0485",
+    "form": null,
+    "names": {
+      "ja": "ヒードラン",
+      "en": "Heatran",
+      "ko": "히드런",
+      "zh-Hans": "席多蓝恩",
+      "zh-Hant": "席多藍恩"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0485",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0486",
+    "no": "0486",
+    "form": null,
+    "names": {
+      "ja": "レジギガス",
+      "en": "Regigigas",
+      "ko": "레지기가스",
+      "zh-Hans": "雷吉奇卡斯",
+      "zh-Hant": "雷吉奇卡斯"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0486",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0487",
+    "no": "0487",
+    "form": null,
+    "names": {
+      "ja": "ギラティナ",
+      "en": "Giratina",
+      "ko": "기라티나",
+      "zh-Hans": "骑拉帝纳",
+      "zh-Hant": "騎拉帝納"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0487",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0488",
+    "no": "0488",
+    "form": null,
+    "names": {
+      "ja": "クレセリア",
+      "en": "Cresselia",
+      "ko": "크레세리아",
+      "zh-Hans": "克雷色利亚",
+      "zh-Hant": "克雷色利亞"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0488",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0489",
+    "no": "0489",
+    "form": null,
+    "names": {
+      "ja": "フィオネ",
+      "en": "Phione",
+      "ko": "피오네",
+      "zh-Hans": "霏欧纳",
+      "zh-Hant": "霏歐納"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0489",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0490",
+    "no": "0490",
+    "form": null,
+    "names": {
+      "ja": "マナフィ",
+      "en": "Manaphy",
+      "ko": "마나피",
+      "zh-Hans": "玛纳霏",
+      "zh-Hant": "瑪納霏"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0490",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0491",
+    "no": "0491",
+    "form": null,
+    "names": {
+      "ja": "ダークライ",
+      "en": "Darkrai",
+      "ko": "다크라이",
+      "zh-Hans": "达克莱伊",
+      "zh-Hant": "達克萊伊"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0491",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0492",
+    "no": "0492",
+    "form": null,
+    "names": {
+      "ja": "シェイミ",
+      "en": "Shaymin",
+      "ko": "쉐이미",
+      "zh-Hans": "谢米",
+      "zh-Hant": "謝米"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0492",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0493",
+    "no": "0493",
+    "form": null,
+    "names": {
+      "ja": "アルセウス",
+      "en": "Arceus",
+      "ko": "아르세우스",
+      "zh-Hans": "阿尔宙斯",
+      "zh-Hant": "阿爾宙斯"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0493",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0494",
+    "no": "0494",
+    "form": null,
+    "names": {
+      "ja": "ビクティニ",
+      "en": "Victini",
+      "ko": "비크티니",
+      "zh-Hans": "比克提尼",
+      "zh-Hant": "比克提尼"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0494",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0495",
+    "no": "0495",
+    "form": null,
+    "names": {
+      "ja": "ツタージャ",
+      "en": "Snivy",
+      "ko": "주리비얀",
+      "zh-Hans": "藤藤蛇",
+      "zh-Hant": "藤藤蛇"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0495",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0496",
+    "no": "0496",
+    "form": null,
+    "names": {
+      "ja": "ジャノビー",
+      "en": "Servine",
+      "ko": "샤비",
+      "zh-Hans": "青藤蛇",
+      "zh-Hant": "青藤蛇"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0496",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0497",
+    "no": "0497",
+    "form": null,
+    "names": {
+      "ja": "ジャローダ",
+      "en": "Serperior",
+      "ko": "샤로다",
+      "zh-Hans": "君主蛇",
+      "zh-Hant": "君主蛇"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0497",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0498",
+    "no": "0498",
+    "form": null,
+    "names": {
+      "ja": "ポカブ",
+      "en": "Tepig",
+      "ko": "뚜꾸리",
+      "zh-Hans": "暖暖猪",
+      "zh-Hant": "暖暖豬"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0498",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0499",
+    "no": "0499",
+    "form": null,
+    "names": {
+      "ja": "チャオブー",
+      "en": "Pignite",
+      "ko": "차오꿀",
+      "zh-Hans": "炒炒猪",
+      "zh-Hant": "炒炒豬"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0499",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0500",
+    "no": "0500",
+    "form": null,
+    "names": {
+      "ja": "エンブオー",
+      "en": "Emboar",
+      "ko": "염무왕",
+      "zh-Hans": "炎武王",
+      "zh-Hant": "炎武王"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0500",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0501",
+    "no": "0501",
+    "form": null,
+    "names": {
+      "ja": "ミジュマル",
+      "en": "Oshawott",
+      "ko": "수댕이",
+      "zh-Hans": "水水獭",
+      "zh-Hant": "水水獺"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0501",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0502",
+    "no": "0502",
+    "form": null,
+    "names": {
+      "ja": "フタチマル",
+      "en": "Dewott",
+      "ko": "쌍검자비",
+      "zh-Hans": "双刃丸",
+      "zh-Hant": "雙刃丸"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0502",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0503",
+    "no": "0503",
+    "form": null,
+    "names": {
+      "ja": "ダイケンキ",
+      "en": "Samurott",
+      "ko": "대검귀",
+      "zh-Hans": "大剑鬼",
+      "zh-Hant": "大劍鬼"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0503",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0503-hisui",
+    "no": "0503",
+    "form": "hisui",
+    "names": {
+      "ja": "ダイケンキ",
+      "en": "Samurott",
+      "ko": "대검귀",
+      "zh-Hans": "大剑鬼",
+      "zh-Hant": "大劍鬼"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0503-hisui",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0504",
+    "no": "0504",
+    "form": null,
+    "names": {
+      "ja": "ミネズミ",
+      "en": "Patrat",
+      "ko": "보르쥐",
+      "zh-Hans": "探探鼠",
+      "zh-Hant": "探探鼠"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0504",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0505",
+    "no": "0505",
+    "form": null,
+    "names": {
+      "ja": "ミルホッグ",
+      "en": "Watchog",
+      "ko": "보르그",
+      "zh-Hans": "步哨鼠",
+      "zh-Hant": "步哨鼠"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0505",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0506",
+    "no": "0506",
+    "form": null,
+    "names": {
+      "ja": "ヨーテリー",
+      "en": "Lillipup",
+      "ko": "요테리",
+      "zh-Hans": "小约克",
+      "zh-Hant": "小約克"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0506",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0507",
+    "no": "0507",
+    "form": null,
+    "names": {
+      "ja": "ハーデリア",
+      "en": "Herdier",
+      "ko": "하데리어",
+      "zh-Hans": "哈约克",
+      "zh-Hant": "哈約克"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0507",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0508",
+    "no": "0508",
+    "form": null,
+    "names": {
+      "ja": "ムーランド",
+      "en": "Stoutland",
+      "ko": "바랜드",
+      "zh-Hans": "长毛狗",
+      "zh-Hant": "長毛狗"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0508",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0509",
+    "no": "0509",
+    "form": null,
+    "names": {
+      "ja": "チョロネコ",
+      "en": "Purrloin",
+      "ko": "쌔비냥",
+      "zh-Hans": "扒手猫",
+      "zh-Hant": "扒手貓"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0509",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0510",
+    "no": "0510",
+    "form": null,
+    "names": {
+      "ja": "レパルダス",
+      "en": "Liepard",
+      "ko": "레파르다스",
+      "zh-Hans": "酷豹",
+      "zh-Hant": "酷豹"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0510",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0511",
+    "no": "0511",
+    "form": null,
+    "names": {
+      "ja": "ヤナップ",
+      "en": "Pansage",
+      "ko": "야나프",
+      "zh-Hans": "花椰猴",
+      "zh-Hant": "花椰猴"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0511",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0512",
+    "no": "0512",
+    "form": null,
+    "names": {
+      "ja": "ヤナッキー",
+      "en": "Simisage",
+      "ko": "야나키",
+      "zh-Hans": "花椰猿",
+      "zh-Hant": "花椰猿"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0512",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0513",
+    "no": "0513",
+    "form": null,
+    "names": {
+      "ja": "バオップ",
+      "en": "Pansear",
+      "ko": "바오프",
+      "zh-Hans": "爆香猴",
+      "zh-Hant": "爆香猴"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0513",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0514",
+    "no": "0514",
+    "form": null,
+    "names": {
+      "ja": "バオッキー",
+      "en": "Simisear",
+      "ko": "바오키",
+      "zh-Hans": "爆香猿",
+      "zh-Hant": "爆香猿"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0514",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0515",
+    "no": "0515",
+    "form": null,
+    "names": {
+      "ja": "ヒヤップ",
+      "en": "Panpour",
+      "ko": "앗차프",
+      "zh-Hans": "冷水猴",
+      "zh-Hant": "冷水猴"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0515",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0516",
+    "no": "0516",
+    "form": null,
+    "names": {
+      "ja": "ヒヤッキー",
+      "en": "Simipour",
+      "ko": "앗차키",
+      "zh-Hans": "冷水猿",
+      "zh-Hant": "冷水猿"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0516",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0517",
+    "no": "0517",
+    "form": null,
+    "names": {
+      "ja": "ムンナ",
+      "en": "Munna",
+      "ko": "몽나",
+      "zh-Hans": "食梦梦",
+      "zh-Hant": "食夢夢"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0517",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0518",
+    "no": "0518",
+    "form": null,
+    "names": {
+      "ja": "ムシャーナ",
+      "en": "Musharna",
+      "ko": "몽얌나",
+      "zh-Hans": "梦梦蚀",
+      "zh-Hant": "夢夢蝕"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0518",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0519",
+    "no": "0519",
+    "form": null,
+    "names": {
+      "ja": "マメパト",
+      "en": "Pidove",
+      "ko": "콩둘기",
+      "zh-Hans": "豆豆鸽",
+      "zh-Hant": "豆豆鴿"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0519",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0520",
+    "no": "0520",
+    "form": null,
+    "names": {
+      "ja": "ハトーボー",
+      "en": "Tranquill",
+      "ko": "유토브",
+      "zh-Hans": "咕咕鸽",
+      "zh-Hant": "咕咕鴿"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0520",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0521",
+    "no": "0521",
+    "form": null,
+    "names": {
+      "ja": "ケンホロウ",
+      "en": "Unfezant",
+      "ko": "켄호로우",
+      "zh-Hans": "高傲雉鸡",
+      "zh-Hant": "高傲雉雞"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0521",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0522",
+    "no": "0522",
+    "form": null,
+    "names": {
+      "ja": "シママ",
+      "en": "Blitzle",
+      "ko": "줄뮤마",
+      "zh-Hans": "斑斑马",
+      "zh-Hant": "斑斑馬"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0522",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0523",
+    "no": "0523",
+    "form": null,
+    "names": {
+      "ja": "ゼブライカ",
+      "en": "Zebstrika",
+      "ko": "제브라이카",
+      "zh-Hans": "雷电斑马",
+      "zh-Hant": "雷電斑馬"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0523",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0524",
+    "no": "0524",
+    "form": null,
+    "names": {
+      "ja": "ダンゴロ",
+      "en": "Roggenrola",
+      "ko": "단굴",
+      "zh-Hans": "石丸子",
+      "zh-Hant": "石丸子"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0524",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0525",
+    "no": "0525",
+    "form": null,
+    "names": {
+      "ja": "ガントル",
+      "en": "Boldore",
+      "ko": "암트르",
+      "zh-Hans": "地幔岩",
+      "zh-Hant": "地幔岩"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0525",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0526",
+    "no": "0526",
+    "form": null,
+    "names": {
+      "ja": "ギガイアス",
+      "en": "Gigalith",
+      "ko": "기가이어스",
+      "zh-Hans": "庞岩怪",
+      "zh-Hant": "龐岩怪"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0526",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0527",
+    "no": "0527",
+    "form": null,
+    "names": {
+      "ja": "コロモリ",
+      "en": "Woobat",
+      "ko": "또르박쥐",
+      "zh-Hans": "滚滚蝙蝠",
+      "zh-Hant": "滾滾蝙蝠"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0527",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0528",
+    "no": "0528",
+    "form": null,
+    "names": {
+      "ja": "ココロモリ",
+      "en": "Swoobat",
+      "ko": "맘박쥐",
+      "zh-Hans": "心蝙蝠",
+      "zh-Hant": "心蝙蝠"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0528",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0529",
+    "no": "0529",
+    "form": null,
+    "names": {
+      "ja": "モグリュー",
+      "en": "Drilbur",
+      "ko": "두더류",
+      "zh-Hans": "螺钉地鼠",
+      "zh-Hant": "螺釘地鼠"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0529",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0530",
+    "no": "0530",
+    "form": null,
+    "names": {
+      "ja": "ドリュウズ",
+      "en": "Excadrill",
+      "ko": "몰드류",
+      "zh-Hans": "龙头地鼠",
+      "zh-Hant": "龍頭地鼠"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0530",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0531",
+    "no": "0531",
+    "form": null,
+    "names": {
+      "ja": "タブンネ",
+      "en": "Audino",
+      "ko": "다부니",
+      "zh-Hans": "差不多娃娃",
+      "zh-Hant": "差不多娃娃"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0531",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0532",
+    "no": "0532",
+    "form": null,
+    "names": {
+      "ja": "ドッコラー",
+      "en": "Timburr",
+      "ko": "으랏차",
+      "zh-Hans": "搬运小匠",
+      "zh-Hant": "搬運小匠"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0532",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0533",
+    "no": "0533",
+    "form": null,
+    "names": {
+      "ja": "ドテッコツ",
+      "en": "Gurdurr",
+      "ko": "토쇠골",
+      "zh-Hans": "铁骨土人",
+      "zh-Hant": "鐵骨土人"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0533",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0534",
+    "no": "0534",
+    "form": null,
+    "names": {
+      "ja": "ローブシン",
+      "en": "Conkeldurr",
+      "ko": "노보청",
+      "zh-Hans": "修建老匠",
+      "zh-Hant": "修建老匠"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0534",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0535",
+    "no": "0535",
+    "form": null,
+    "names": {
+      "ja": "オタマロ",
+      "en": "Tympole",
+      "ko": "동챙이",
+      "zh-Hans": "圆蝌蚪",
+      "zh-Hant": "圓蝌蚪"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0535",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0536",
+    "no": "0536",
+    "form": null,
+    "names": {
+      "ja": "ガマガル",
+      "en": "Palpitoad",
+      "ko": "두까비",
+      "zh-Hans": "蓝蟾蜍",
+      "zh-Hant": "藍蟾蜍"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0536",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0537",
+    "no": "0537",
+    "form": null,
+    "names": {
+      "ja": "ガマゲロゲ",
+      "en": "Seismitoad",
+      "ko": "두빅굴",
+      "zh-Hans": "蟾蜍王",
+      "zh-Hant": "蟾蜍王"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0537",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0538",
+    "no": "0538",
+    "form": null,
+    "names": {
+      "ja": "ナゲキ",
+      "en": "Throh",
+      "ko": "던지미",
+      "zh-Hans": "投摔鬼",
+      "zh-Hant": "投摔鬼"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0538",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0539",
+    "no": "0539",
+    "form": null,
+    "names": {
+      "ja": "ダゲキ",
+      "en": "Sawk",
+      "ko": "타격귀",
+      "zh-Hans": "打击鬼",
+      "zh-Hant": "打擊鬼"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0539",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0540",
+    "no": "0540",
+    "form": null,
+    "names": {
+      "ja": "クルミル",
+      "en": "Sewaddle",
+      "ko": "두르보",
+      "zh-Hans": "虫宝包",
+      "zh-Hant": "蟲寶包"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0540",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0541",
+    "no": "0541",
+    "form": null,
+    "names": {
+      "ja": "クルマユ",
+      "en": "Swadloon",
+      "ko": "두르쿤",
+      "zh-Hans": "宝包茧",
+      "zh-Hant": "寶包繭"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0541",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0542",
+    "no": "0542",
+    "form": null,
+    "names": {
+      "ja": "ハハコモリ",
+      "en": "Leavanny",
+      "ko": "모아머",
+      "zh-Hans": "保姆虫",
+      "zh-Hant": "保母蟲"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0542",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0543",
+    "no": "0543",
+    "form": null,
+    "names": {
+      "ja": "フシデ",
+      "en": "Venipede",
+      "ko": "마디네",
+      "zh-Hans": "百足蜈蚣",
+      "zh-Hant": "百足蜈蚣"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0543",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0544",
+    "no": "0544",
+    "form": null,
+    "names": {
+      "ja": "ホイーガ",
+      "en": "Whirlipede",
+      "ko": "휠구",
+      "zh-Hans": "车轮球",
+      "zh-Hant": "車輪毬"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0544",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0545",
+    "no": "0545",
+    "form": null,
+    "names": {
+      "ja": "ペンドラー",
+      "en": "Scolipede",
+      "ko": "펜드라",
+      "zh-Hans": "蜈蚣王",
+      "zh-Hant": "蜈蚣王"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0545",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0546",
+    "no": "0546",
+    "form": null,
+    "names": {
+      "ja": "モンメン",
+      "en": "Cottonee",
+      "ko": "소미안",
+      "zh-Hans": "木棉球",
+      "zh-Hant": "木棉球"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0546",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0547",
+    "no": "0547",
+    "form": null,
+    "names": {
+      "ja": "エルフーン",
+      "en": "Whimsicott",
+      "ko": "엘풍",
+      "zh-Hans": "风妖精",
+      "zh-Hant": "風妖精"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0547",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0548",
+    "no": "0548",
+    "form": null,
+    "names": {
+      "ja": "チュリネ",
+      "en": "Petilil",
+      "ko": "치릴리",
+      "zh-Hans": "百合根娃娃",
+      "zh-Hant": "百合根娃娃"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0548",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0549",
+    "no": "0549",
+    "form": null,
+    "names": {
+      "ja": "ドレディア",
+      "en": "Lilligant",
+      "ko": "드레디어",
+      "zh-Hans": "裙儿小姐",
+      "zh-Hant": "裙兒小姐"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0549",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0549-hisui",
+    "no": "0549",
+    "form": "hisui",
+    "names": {
+      "ja": "ドレディア",
+      "en": "Lilligant",
+      "ko": "드레디어",
+      "zh-Hans": "裙儿小姐",
+      "zh-Hant": "裙兒小姐"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0549-hisui",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0550",
+    "no": "0550",
+    "form": null,
+    "names": {
+      "ja": "バスラオ",
+      "en": "Basculin",
+      "ko": "배쓰나이",
+      "zh-Hans": "野蛮鲈鱼",
+      "zh-Hant": "野蠻鱸魚"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0550",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0551",
+    "no": "0551",
+    "form": null,
+    "names": {
+      "ja": "メグロコ",
+      "en": "Sandile",
+      "ko": "깜눈크",
+      "zh-Hans": "黑眼鳄",
+      "zh-Hant": "黑眼鱷"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0551",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0552",
+    "no": "0552",
+    "form": null,
+    "names": {
+      "ja": "ワルビル",
+      "en": "Krokorok",
+      "ko": "악비르",
+      "zh-Hans": "混混鳄",
+      "zh-Hant": "混混鱷"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0552",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0553",
+    "no": "0553",
+    "form": null,
+    "names": {
+      "ja": "ワルビアル",
+      "en": "Krookodile",
+      "ko": "악비아르",
+      "zh-Hans": "流氓鳄",
+      "zh-Hant": "流氓鱷"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0553",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0554",
+    "no": "0554",
+    "form": null,
+    "names": {
+      "ja": "ダルマッカ",
+      "en": "Darumaka",
+      "ko": "달막화",
+      "zh-Hans": "火红不倒翁",
+      "zh-Hant": "火紅不倒翁"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0554",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0554-galar",
+    "no": "0554",
+    "form": "galar",
+    "names": {
+      "ja": "ダルマッカ",
+      "en": "Darumaka",
+      "ko": "달막화",
+      "zh-Hans": "火红不倒翁",
+      "zh-Hant": "火紅不倒翁"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0554-galar",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0555",
+    "no": "0555",
+    "form": null,
+    "names": {
+      "ja": "ヒヒダルマ",
+      "en": "Darmanitan",
+      "ko": "불비달마",
+      "zh-Hans": "达摩狒狒",
+      "zh-Hant": "達摩狒狒"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0555",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0555-galar",
+    "no": "0555",
+    "form": "galar",
+    "names": {
+      "ja": "ヒヒダルマ",
+      "en": "Darmanitan",
+      "ko": "불비달마",
+      "zh-Hans": "达摩狒狒",
+      "zh-Hant": "達摩狒狒"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0555-galar",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0556",
+    "no": "0556",
+    "form": null,
+    "names": {
+      "ja": "マラカッチ",
+      "en": "Maractus",
+      "ko": "마라카치",
+      "zh-Hans": "沙铃仙人掌",
+      "zh-Hant": "沙鈴仙人掌"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0556",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0557",
+    "no": "0557",
+    "form": null,
+    "names": {
+      "ja": "イシズマイ",
+      "en": "Dwebble",
+      "ko": "돌살이",
+      "zh-Hans": "石居蟹",
+      "zh-Hant": "石居蟹"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0557",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0558",
+    "no": "0558",
+    "form": null,
+    "names": {
+      "ja": "イワパレス",
+      "en": "Crustle",
+      "ko": "암팰리스",
+      "zh-Hans": "岩殿居蟹",
+      "zh-Hant": "岩殿居蟹"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0558",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0559",
+    "no": "0559",
+    "form": null,
+    "names": {
+      "ja": "ズルッグ",
+      "en": "Scraggy",
+      "ko": "곤율랭",
+      "zh-Hans": "滑滑小子",
+      "zh-Hant": "滑滑小子"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0559",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0560",
+    "no": "0560",
+    "form": null,
+    "names": {
+      "ja": "ズルズキン",
+      "en": "Scrafty",
+      "ko": "곤율거니",
+      "zh-Hans": "头巾混混",
+      "zh-Hant": "頭巾混混"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0560",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0561",
+    "no": "0561",
+    "form": null,
+    "names": {
+      "ja": "シンボラー",
+      "en": "Sigilyph",
+      "ko": "심보러",
+      "zh-Hans": "象征鸟",
+      "zh-Hant": "象徵鳥"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0561",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0562",
+    "no": "0562",
+    "form": null,
+    "names": {
+      "ja": "デスマス",
+      "en": "Yamask",
+      "ko": "데스마스",
+      "zh-Hans": "哭哭面具",
+      "zh-Hant": "哭哭面具"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0562",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0562-galar",
+    "no": "0562",
+    "form": "galar",
+    "names": {
+      "ja": "デスマス",
+      "en": "Yamask",
+      "ko": "데스마스",
+      "zh-Hans": "哭哭面具",
+      "zh-Hant": "哭哭面具"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0562-galar",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0563",
+    "no": "0563",
+    "form": null,
+    "names": {
+      "ja": "デスカーン",
+      "en": "Cofagrigus",
+      "ko": "데스니칸",
+      "zh-Hans": "迭失棺",
+      "zh-Hant": "死神棺"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0563",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0564",
+    "no": "0564",
+    "form": null,
+    "names": {
+      "ja": "プロトーガ",
+      "en": "Tirtouga",
+      "ko": "프로토가",
+      "zh-Hans": "原盖海龟",
+      "zh-Hant": "原蓋海龜"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0564",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0565",
+    "no": "0565",
+    "form": null,
+    "names": {
+      "ja": "アバゴーラ",
+      "en": "Carracosta",
+      "ko": "늑골라",
+      "zh-Hans": "肋骨海龟",
+      "zh-Hant": "肋骨海龜"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0565",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0566",
+    "no": "0566",
+    "form": null,
+    "names": {
+      "ja": "アーケン",
+      "en": "Archen",
+      "ko": "아켄",
+      "zh-Hans": "始祖小鸟",
+      "zh-Hant": "始祖小鳥"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0566",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0567",
+    "no": "0567",
+    "form": null,
+    "names": {
+      "ja": "アーケオス",
+      "en": "Archeops",
+      "ko": "아케오스",
+      "zh-Hans": "始祖大鸟",
+      "zh-Hant": "始祖大鳥"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0567",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0568",
+    "no": "0568",
+    "form": null,
+    "names": {
+      "ja": "ヤブクロン",
+      "en": "Trubbish",
+      "ko": "깨봉이",
+      "zh-Hans": "破破袋",
+      "zh-Hant": "破破袋"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0568",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0569",
+    "no": "0569",
+    "form": null,
+    "names": {
+      "ja": "ダストダス",
+      "en": "Garbodor",
+      "ko": "더스트나",
+      "zh-Hans": "灰尘山",
+      "zh-Hant": "灰塵山"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0569",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0570",
+    "no": "0570",
+    "form": null,
+    "names": {
+      "ja": "ゾロア",
+      "en": "Zorua",
+      "ko": "조로아",
+      "zh-Hans": "索罗亚",
+      "zh-Hant": "索羅亞"
+    },
+    "types": [
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0570",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0570-hisui",
+    "no": "0570",
+    "form": "hisui",
+    "names": {
+      "ja": "ゾロア",
+      "en": "Zorua",
+      "ko": "조로아",
+      "zh-Hans": "索罗亚",
+      "zh-Hant": "索羅亞"
+    },
+    "types": [
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0570-hisui",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0571",
+    "no": "0571",
+    "form": null,
+    "names": {
+      "ja": "ゾロアーク",
+      "en": "Zoroark",
+      "ko": "조로아크",
+      "zh-Hans": "索罗亚克",
+      "zh-Hant": "索羅亞克"
+    },
+    "types": [
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0571",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0571-hisui",
+    "no": "0571",
+    "form": "hisui",
+    "names": {
+      "ja": "ゾロアーク",
+      "en": "Zoroark",
+      "ko": "조로아크",
+      "zh-Hans": "索罗亚克",
+      "zh-Hant": "索羅亞克"
+    },
+    "types": [
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0571-hisui",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0572",
+    "no": "0572",
+    "form": null,
+    "names": {
+      "ja": "チラーミィ",
+      "en": "Minccino",
+      "ko": "치라미",
+      "zh-Hans": "泡沫栗鼠",
+      "zh-Hant": "泡沫栗鼠"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0572",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0573",
+    "no": "0573",
+    "form": null,
+    "names": {
+      "ja": "チラチーノ",
+      "en": "Cinccino",
+      "ko": "치라치노",
+      "zh-Hans": "奇诺栗鼠",
+      "zh-Hant": "奇諾栗鼠"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0573",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0574",
+    "no": "0574",
+    "form": null,
+    "names": {
+      "ja": "ゴチム",
+      "en": "Gothita",
+      "ko": "고디탱",
+      "zh-Hans": "哥德宝宝",
+      "zh-Hant": "哥德寶寶"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0574",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0575",
+    "no": "0575",
+    "form": null,
+    "names": {
+      "ja": "ゴチミル",
+      "en": "Gothorita",
+      "ko": "고디보미",
+      "zh-Hans": "哥德小童",
+      "zh-Hant": "哥德小童"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0575",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0576",
+    "no": "0576",
+    "form": null,
+    "names": {
+      "ja": "ゴチルゼル",
+      "en": "Gothitelle",
+      "ko": "고디모아젤",
+      "zh-Hans": "哥德小姐",
+      "zh-Hant": "哥德小姐"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0576",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0577",
+    "no": "0577",
+    "form": null,
+    "names": {
+      "ja": "ユニラン",
+      "en": "Solosis",
+      "ko": "유니란",
+      "zh-Hans": "单卵细胞球",
+      "zh-Hant": "單卵細胞球"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0577",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0578",
+    "no": "0578",
+    "form": null,
+    "names": {
+      "ja": "ダブラン",
+      "en": "Duosion",
+      "ko": "듀란",
+      "zh-Hans": "双卵细胞球",
+      "zh-Hant": "雙卵細胞球"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0578",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0579",
+    "no": "0579",
+    "form": null,
+    "names": {
+      "ja": "ランクルス",
+      "en": "Reuniclus",
+      "ko": "란쿨루스",
+      "zh-Hans": "人造细胞卵",
+      "zh-Hant": "人造細胞卵"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0579",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0580",
+    "no": "0580",
+    "form": null,
+    "names": {
+      "ja": "コアルヒー",
+      "en": "Ducklett",
+      "ko": "꼬지보리",
+      "zh-Hans": "鸭宝宝",
+      "zh-Hant": "鴨寶寶"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0580",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0581",
+    "no": "0581",
+    "form": null,
+    "names": {
+      "ja": "スワンナ",
+      "en": "Swanna",
+      "ko": "스완나",
+      "zh-Hans": "舞天鹅",
+      "zh-Hant": "舞天鵝"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0581",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0582",
+    "no": "0582",
+    "form": null,
+    "names": {
+      "ja": "バニプッチ",
+      "en": "Vanillite",
+      "ko": "바닐프티",
+      "zh-Hans": "迷你冰",
+      "zh-Hant": "迷你冰"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0582",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0583",
+    "no": "0583",
+    "form": null,
+    "names": {
+      "ja": "バニリッチ",
+      "en": "Vanillish",
+      "ko": "바닐리치",
+      "zh-Hans": "多多冰",
+      "zh-Hant": "多多冰"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0583",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0584",
+    "no": "0584",
+    "form": null,
+    "names": {
+      "ja": "バイバニラ",
+      "en": "Vanilluxe",
+      "ko": "배바닐라",
+      "zh-Hans": "双倍多多冰",
+      "zh-Hant": "雙倍多多冰"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0584",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0585",
+    "no": "0585",
+    "form": null,
+    "names": {
+      "ja": "シキジカ",
+      "en": "Deerling",
+      "ko": "사철록",
+      "zh-Hans": "四季鹿",
+      "zh-Hant": "四季鹿"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0585",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0586",
+    "no": "0586",
+    "form": null,
+    "names": {
+      "ja": "メブキジカ",
+      "en": "Sawsbuck",
+      "ko": "바라철록",
+      "zh-Hans": "萌芽鹿",
+      "zh-Hant": "萌芽鹿"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0586",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0587",
+    "no": "0587",
+    "form": null,
+    "names": {
+      "ja": "エモンガ",
+      "en": "Emolga",
+      "ko": "에몽가",
+      "zh-Hans": "电飞鼠",
+      "zh-Hant": "電飛鼠"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0587",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0588",
+    "no": "0588",
+    "form": null,
+    "names": {
+      "ja": "カブルモ",
+      "en": "Karrablast",
+      "ko": "딱정곤",
+      "zh-Hans": "盖盖虫",
+      "zh-Hant": "蓋蓋蟲"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0588",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0589",
+    "no": "0589",
+    "form": null,
+    "names": {
+      "ja": "シュバルゴ",
+      "en": "Escavalier",
+      "ko": "슈바르고",
+      "zh-Hans": "骑士蜗牛",
+      "zh-Hant": "騎士蝸牛"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0589",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0590",
+    "no": "0590",
+    "form": null,
+    "names": {
+      "ja": "タマゲタケ",
+      "en": "Foongus",
+      "ko": "깜놀버슬",
+      "zh-Hans": "哎呀球菇",
+      "zh-Hant": "哎呀球菇"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0590",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0591",
+    "no": "0591",
+    "form": null,
+    "names": {
+      "ja": "モロバレル",
+      "en": "Amoonguss",
+      "ko": "뽀록나",
+      "zh-Hans": "败露球菇",
+      "zh-Hant": "敗露球菇"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0591",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0592",
+    "no": "0592",
+    "form": null,
+    "names": {
+      "ja": "プルリル",
+      "en": "Frillish",
+      "ko": "탱그릴",
+      "zh-Hans": "轻飘飘",
+      "zh-Hant": "輕飄飄"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0592",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0593",
+    "no": "0593",
+    "form": null,
+    "names": {
+      "ja": "ブルンゲル",
+      "en": "Jellicent",
+      "ko": "탱탱겔",
+      "zh-Hans": "胖嘟嘟",
+      "zh-Hant": "胖嘟嘟"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0593",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0594",
+    "no": "0594",
+    "form": null,
+    "names": {
+      "ja": "ママンボウ",
+      "en": "Alomomola",
+      "ko": "맘복치",
+      "zh-Hans": "保姆曼波",
+      "zh-Hant": "保母曼波"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0594",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0595",
+    "no": "0595",
+    "form": null,
+    "names": {
+      "ja": "バチュル",
+      "en": "Joltik",
+      "ko": "파쪼옥",
+      "zh-Hans": "电电虫",
+      "zh-Hant": "電電蟲"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0595",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0596",
+    "no": "0596",
+    "form": null,
+    "names": {
+      "ja": "デンチュラ",
+      "en": "Galvantula",
+      "ko": "전툴라",
+      "zh-Hans": "电蜘蛛",
+      "zh-Hant": "電蜘蛛"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0596",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0597",
+    "no": "0597",
+    "form": null,
+    "names": {
+      "ja": "テッシード",
+      "en": "Ferroseed",
+      "ko": "철시드",
+      "zh-Hans": "种子铁球",
+      "zh-Hant": "種子鐵球"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0597",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0598",
+    "no": "0598",
+    "form": null,
+    "names": {
+      "ja": "ナットレイ",
+      "en": "Ferrothorn",
+      "ko": "너트령",
+      "zh-Hans": "坚果哑铃",
+      "zh-Hant": "堅果啞鈴"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0598",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0599",
+    "no": "0599",
+    "form": null,
+    "names": {
+      "ja": "ギアル",
+      "en": "Klink",
+      "ko": "기어르",
+      "zh-Hans": "齿轮儿",
+      "zh-Hant": "齒輪兒"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0599",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0600",
+    "no": "0600",
+    "form": null,
+    "names": {
+      "ja": "ギギアル",
+      "en": "Klang",
+      "ko": "기기어르",
+      "zh-Hans": "齿轮组",
+      "zh-Hant": "齒輪組"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0600",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0601",
+    "no": "0601",
+    "form": null,
+    "names": {
+      "ja": "ギギギアル",
+      "en": "Klinklang",
+      "ko": "기기기어르",
+      "zh-Hans": "齿轮怪",
+      "zh-Hant": "齒輪怪"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0601",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0602",
+    "no": "0602",
+    "form": null,
+    "names": {
+      "ja": "シビシラス",
+      "en": "Tynamo",
+      "ko": "저리어",
+      "zh-Hans": "麻麻小鱼",
+      "zh-Hant": "麻麻小魚"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0602",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0603",
+    "no": "0603",
+    "form": null,
+    "names": {
+      "ja": "シビビール",
+      "en": "Eelektrik",
+      "ko": "저리릴",
+      "zh-Hans": "麻麻鳗",
+      "zh-Hant": "麻麻鰻"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0603",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0604",
+    "no": "0604",
+    "form": null,
+    "names": {
+      "ja": "シビルドン",
+      "en": "Eelektross",
+      "ko": "저리더프",
+      "zh-Hans": "麻麻鳗鱼王",
+      "zh-Hant": "麻麻鰻魚王"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0604",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0605",
+    "no": "0605",
+    "form": null,
+    "names": {
+      "ja": "リグレー",
+      "en": "Elgyem",
+      "ko": "리그레",
+      "zh-Hans": "小灰怪",
+      "zh-Hant": "小灰怪"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0605",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0606",
+    "no": "0606",
+    "form": null,
+    "names": {
+      "ja": "オーベム",
+      "en": "Beheeyem",
+      "ko": "벰크",
+      "zh-Hans": "大宇怪",
+      "zh-Hant": "大宇怪"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0606",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0607",
+    "no": "0607",
+    "form": null,
+    "names": {
+      "ja": "ヒトモシ",
+      "en": "Litwick",
+      "ko": "불켜미",
+      "zh-Hans": "烛光灵",
+      "zh-Hant": "燭光靈"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0607",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0608",
+    "no": "0608",
+    "form": null,
+    "names": {
+      "ja": "ランプラー",
+      "en": "Lampent",
+      "ko": "램프라",
+      "zh-Hans": "灯火幽灵",
+      "zh-Hant": "燈火幽靈"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0608",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0609",
+    "no": "0609",
+    "form": null,
+    "names": {
+      "ja": "シャンデラ",
+      "en": "Chandelure",
+      "ko": "샹델라",
+      "zh-Hans": "水晶灯火灵",
+      "zh-Hant": "水晶燈火靈"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0609",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0610",
+    "no": "0610",
+    "form": null,
+    "names": {
+      "ja": "キバゴ",
+      "en": "Axew",
+      "ko": "터검니",
+      "zh-Hans": "牙牙",
+      "zh-Hant": "牙牙"
+    },
+    "types": [
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0610",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0611",
+    "no": "0611",
+    "form": null,
+    "names": {
+      "ja": "オノンド",
+      "en": "Fraxure",
+      "ko": "액슨도",
+      "zh-Hans": "斧牙龙",
+      "zh-Hant": "斧牙龍"
+    },
+    "types": [
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0611",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0612",
+    "no": "0612",
+    "form": null,
+    "names": {
+      "ja": "オノノクス",
+      "en": "Haxorus",
+      "ko": "액스라이즈",
+      "zh-Hans": "双斧战龙",
+      "zh-Hant": "雙斧戰龍"
+    },
+    "types": [
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0612",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0613",
+    "no": "0613",
+    "form": null,
+    "names": {
+      "ja": "クマシュン",
+      "en": "Cubchoo",
+      "ko": "코고미",
+      "zh-Hans": "喷嚏熊",
+      "zh-Hant": "噴嚏熊"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0613",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0614",
+    "no": "0614",
+    "form": null,
+    "names": {
+      "ja": "ツンベアー",
+      "en": "Beartic",
+      "ko": "툰베어",
+      "zh-Hans": "冻原熊",
+      "zh-Hant": "凍原熊"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0614",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0615",
+    "no": "0615",
+    "form": null,
+    "names": {
+      "ja": "フリージオ",
+      "en": "Cryogonal",
+      "ko": "프리지오",
+      "zh-Hans": "几何雪花",
+      "zh-Hant": "幾何雪花"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0615",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0616",
+    "no": "0616",
+    "form": null,
+    "names": {
+      "ja": "チョボマキ",
+      "en": "Shelmet",
+      "ko": "쪼마리",
+      "zh-Hans": "小嘴蜗",
+      "zh-Hant": "小嘴蝸"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0616",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0617",
+    "no": "0617",
+    "form": null,
+    "names": {
+      "ja": "アギルダー",
+      "en": "Accelgor",
+      "ko": "어지리더",
+      "zh-Hans": "敏捷虫",
+      "zh-Hant": "敏捷蟲"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0617",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0618",
+    "no": "0618",
+    "form": null,
+    "names": {
+      "ja": "マッギョ",
+      "en": "Stunfisk",
+      "ko": "메더",
+      "zh-Hans": "泥巴鱼",
+      "zh-Hant": "泥巴魚"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0618",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0618-galar",
+    "no": "0618",
+    "form": "galar",
+    "names": {
+      "ja": "マッギョ",
+      "en": "Stunfisk",
+      "ko": "메더",
+      "zh-Hans": "泥巴鱼",
+      "zh-Hant": "泥巴魚"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0618-galar",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0619",
+    "no": "0619",
+    "form": null,
+    "names": {
+      "ja": "コジョフー",
+      "en": "Mienfoo",
+      "ko": "비조푸",
+      "zh-Hans": "功夫鼬",
+      "zh-Hant": "功夫鼬"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0619",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0620",
+    "no": "0620",
+    "form": null,
+    "names": {
+      "ja": "コジョンド",
+      "en": "Mienshao",
+      "ko": "비조도",
+      "zh-Hans": "师父鼬",
+      "zh-Hant": "師父鼬"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0620",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0621",
+    "no": "0621",
+    "form": null,
+    "names": {
+      "ja": "クリムガン",
+      "en": "Druddigon",
+      "ko": "크리만",
+      "zh-Hans": "赤面龙",
+      "zh-Hant": "赤面龍"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0621",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0622",
+    "no": "0622",
+    "form": null,
+    "names": {
+      "ja": "ゴビット",
+      "en": "Golett",
+      "ko": "골비람",
+      "zh-Hans": "泥偶小人",
+      "zh-Hant": "泥偶小人"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0622",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0623",
+    "no": "0623",
+    "form": null,
+    "names": {
+      "ja": "ゴルーグ",
+      "en": "Golurk",
+      "ko": "골루그",
+      "zh-Hans": "泥偶巨人",
+      "zh-Hant": "泥偶巨人"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0623",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0624",
+    "no": "0624",
+    "form": null,
+    "names": {
+      "ja": "コマタナ",
+      "en": "Pawniard",
+      "ko": "자망칼",
+      "zh-Hans": "驹刀小兵",
+      "zh-Hant": "駒刀小兵"
+    },
+    "types": [
+      {
+        "ja": "あく",
+        "en": "Dark"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0624",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0625",
+    "no": "0625",
+    "form": null,
+    "names": {
+      "ja": "キリキザン",
+      "en": "Bisharp",
+      "ko": "절각참",
+      "zh-Hans": "劈斩司令",
+      "zh-Hant": "劈斬司令"
+    },
+    "types": [
+      {
+        "ja": "あく",
+        "en": "Dark"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0625",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0626",
+    "no": "0626",
+    "form": null,
+    "names": {
+      "ja": "バッフロン",
+      "en": "Bouffalant",
+      "ko": "버프론",
+      "zh-Hans": "爆炸头水牛",
+      "zh-Hant": "爆炸頭水牛"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0626",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0627",
+    "no": "0627",
+    "form": null,
+    "names": {
+      "ja": "ワシボン",
+      "en": "Rufflet",
+      "ko": "수리둥보",
+      "zh-Hans": "毛头小鹰",
+      "zh-Hant": "毛頭小鷹"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0627",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0628",
+    "no": "0628",
+    "form": null,
+    "names": {
+      "ja": "ウォーグル",
+      "en": "Braviary",
+      "ko": "워글",
+      "zh-Hans": "勇士雄鹰",
+      "zh-Hant": "勇士雄鷹"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0628",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0628-hisui",
+    "no": "0628",
+    "form": "hisui",
+    "names": {
+      "ja": "ウォーグル",
+      "en": "Braviary",
+      "ko": "워글",
+      "zh-Hans": "勇士雄鹰",
+      "zh-Hant": "勇士雄鷹"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0628-hisui",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0629",
+    "no": "0629",
+    "form": null,
+    "names": {
+      "ja": "バルチャイ",
+      "en": "Vullaby",
+      "ko": "벌차이",
+      "zh-Hans": "秃鹰丫头",
+      "zh-Hant": "禿鷹丫頭"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0629",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0630",
+    "no": "0630",
+    "form": null,
+    "names": {
+      "ja": "バルジーナ",
+      "en": "Mandibuzz",
+      "ko": "버랜지나",
+      "zh-Hans": "秃鹰娜",
+      "zh-Hant": "禿鷹娜"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0630",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0631",
+    "no": "0631",
+    "form": null,
+    "names": {
+      "ja": "クイタラン",
+      "en": "Heatmor",
+      "ko": "앤티골",
+      "zh-Hans": "熔蚁兽",
+      "zh-Hant": "熔蟻獸"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0631",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0632",
+    "no": "0632",
+    "form": null,
+    "names": {
+      "ja": "アイアント",
+      "en": "Durant",
+      "ko": "아이앤트",
+      "zh-Hans": "铁蚁",
+      "zh-Hant": "鐵蟻"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0632",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0633",
+    "no": "0633",
+    "form": null,
+    "names": {
+      "ja": "モノズ",
+      "en": "Deino",
+      "ko": "모노두",
+      "zh-Hans": "单首龙",
+      "zh-Hant": "單首龍"
+    },
+    "types": [
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0633",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0634",
+    "no": "0634",
+    "form": null,
+    "names": {
+      "ja": "ジヘッド",
+      "en": "Zweilous",
+      "ko": "디헤드",
+      "zh-Hans": "双首暴龙",
+      "zh-Hant": "雙首暴龍"
+    },
+    "types": [
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0634",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0635",
+    "no": "0635",
+    "form": null,
+    "names": {
+      "ja": "サザンドラ",
+      "en": "Hydreigon",
+      "ko": "삼삼드래",
+      "zh-Hans": "三首恶龙",
+      "zh-Hant": "三首惡龍"
+    },
+    "types": [
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0635",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0636",
+    "no": "0636",
+    "form": null,
+    "names": {
+      "ja": "メラルバ",
+      "en": "Larvesta",
+      "ko": "활화르바",
+      "zh-Hans": "燃烧虫",
+      "zh-Hant": "燃燒蟲"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0636",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0637",
+    "no": "0637",
+    "form": null,
+    "names": {
+      "ja": "ウルガモス",
+      "en": "Volcarona",
+      "ko": "불카모스",
+      "zh-Hans": "火神蛾",
+      "zh-Hant": "火神蛾"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0637",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0638",
+    "no": "0638",
+    "form": null,
+    "names": {
+      "ja": "コバルオン",
+      "en": "Cobalion",
+      "ko": "코바르온",
+      "zh-Hans": "勾帕路翁",
+      "zh-Hant": "勾帕路翁"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0638",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0639",
+    "no": "0639",
+    "form": null,
+    "names": {
+      "ja": "テラキオン",
+      "en": "Terrakion",
+      "ko": "테라키온",
+      "zh-Hans": "代拉基翁",
+      "zh-Hant": "代拉基翁"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0639",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0640",
+    "no": "0640",
+    "form": null,
+    "names": {
+      "ja": "ビリジオン",
+      "en": "Virizion",
+      "ko": "비리디온",
+      "zh-Hans": "毕力吉翁",
+      "zh-Hant": "畢力吉翁"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0640",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0641",
+    "no": "0641",
+    "form": null,
+    "names": {
+      "ja": "トルネロス",
+      "en": "Tornadus",
+      "ko": "토네로스",
+      "zh-Hans": "龙卷云",
+      "zh-Hant": "龍捲雲"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0641",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0642",
+    "no": "0642",
+    "form": null,
+    "names": {
+      "ja": "ボルトロス",
+      "en": "Thundurus",
+      "ko": "볼트로스",
+      "zh-Hans": "雷电云",
+      "zh-Hant": "雷電雲"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0642",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0643",
+    "no": "0643",
+    "form": null,
+    "names": {
+      "ja": "レシラム",
+      "en": "Reshiram",
+      "ko": "레시라무",
+      "zh-Hans": "莱希拉姆",
+      "zh-Hant": "萊希拉姆"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0643",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0644",
+    "no": "0644",
+    "form": null,
+    "names": {
+      "ja": "ゼクロム",
+      "en": "Zekrom",
+      "ko": "제크로무",
+      "zh-Hans": "捷克罗姆",
+      "zh-Hant": "捷克羅姆"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0644",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0645",
+    "no": "0645",
+    "form": null,
+    "names": {
+      "ja": "ランドロス",
+      "en": "Landorus",
+      "ko": "랜드로스",
+      "zh-Hans": "土地云",
+      "zh-Hant": "土地雲"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0645",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0646",
+    "no": "0646",
+    "form": null,
+    "names": {
+      "ja": "キュレム",
+      "en": "Kyurem",
+      "ko": "큐레무",
+      "zh-Hans": "酋雷姆",
+      "zh-Hant": "酋雷姆"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0646",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0647",
+    "no": "0647",
+    "form": null,
+    "names": {
+      "ja": "ケルディオ",
+      "en": "Keldeo",
+      "ko": "케르디오",
+      "zh-Hans": "凯路迪欧",
+      "zh-Hant": "凱路迪歐"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0647",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0648",
+    "no": "0648",
+    "form": null,
+    "names": {
+      "ja": "メロエッタ",
+      "en": "Meloetta",
+      "ko": "메로엣타",
+      "zh-Hans": "美洛耶塔",
+      "zh-Hant": "美洛耶塔"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0648",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0649",
+    "no": "0649",
+    "form": null,
+    "names": {
+      "ja": "ゲノセクト",
+      "en": "Genesect",
+      "ko": "게노세크트",
+      "zh-Hans": "盖诺赛克特",
+      "zh-Hant": "蓋諾賽克特"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0649",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0650",
+    "no": "0650",
+    "form": null,
+    "names": {
+      "ja": "ハリマロン",
+      "en": "Chespin",
+      "ko": "도치마론",
+      "zh-Hans": "哈力栗",
+      "zh-Hant": "哈力栗"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0650",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0651",
+    "no": "0651",
+    "form": null,
+    "names": {
+      "ja": "ハリボーグ",
+      "en": "Quilladin",
+      "ko": "도치보구",
+      "zh-Hans": "胖胖哈力",
+      "zh-Hant": "胖胖哈力"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0651",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0652",
+    "no": "0652",
+    "form": null,
+    "names": {
+      "ja": "ブリガロン",
+      "en": "Chesnaught",
+      "ko": "브리가론",
+      "zh-Hans": "布里卡隆",
+      "zh-Hant": "布里卡隆"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0652",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0653",
+    "no": "0653",
+    "form": null,
+    "names": {
+      "ja": "フォッコ",
+      "en": "Fennekin",
+      "ko": "푸호꼬",
+      "zh-Hans": "火狐狸",
+      "zh-Hant": "火狐狸"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0653",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0654",
+    "no": "0654",
+    "form": null,
+    "names": {
+      "ja": "テールナー",
+      "en": "Braixen",
+      "ko": "테르나",
+      "zh-Hans": "长尾火狐",
+      "zh-Hant": "長尾火狐"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0654",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0655",
+    "no": "0655",
+    "form": null,
+    "names": {
+      "ja": "マフォクシー",
+      "en": "Delphox",
+      "ko": "마폭시",
+      "zh-Hans": "妖火红狐",
+      "zh-Hant": "妖火紅狐"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0655",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0656",
+    "no": "0656",
+    "form": null,
+    "names": {
+      "ja": "ケロマツ",
+      "en": "Froakie",
+      "ko": "개구마르",
+      "zh-Hans": "呱呱泡蛙",
+      "zh-Hant": "呱呱泡蛙"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0656",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0657",
+    "no": "0657",
+    "form": null,
+    "names": {
+      "ja": "ゲコガシラ",
+      "en": "Frogadier",
+      "ko": "개굴반장",
+      "zh-Hans": "呱头蛙",
+      "zh-Hant": "呱頭蛙"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0657",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0658",
+    "no": "0658",
+    "form": null,
+    "names": {
+      "ja": "ゲッコウガ",
+      "en": "Greninja",
+      "ko": "개굴닌자",
+      "zh-Hans": "甲贺忍蛙",
+      "zh-Hant": "甲賀忍蛙"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0658",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0659",
+    "no": "0659",
+    "form": null,
+    "names": {
+      "ja": "ホルビー",
+      "en": "Bunnelby",
+      "ko": "파르빗",
+      "zh-Hans": "掘掘兔",
+      "zh-Hant": "掘掘兔"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0659",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0660",
+    "no": "0660",
+    "form": null,
+    "names": {
+      "ja": "ホルード",
+      "en": "Diggersby",
+      "ko": "파르토",
+      "zh-Hans": "掘地兔",
+      "zh-Hant": "掘地兔"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0660",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0661",
+    "no": "0661",
+    "form": null,
+    "names": {
+      "ja": "ヤヤコマ",
+      "en": "Fletchling",
+      "ko": "화살꼬빈",
+      "zh-Hans": "小箭雀",
+      "zh-Hant": "小箭雀"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0661",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0662",
+    "no": "0662",
+    "form": null,
+    "names": {
+      "ja": "ヒノヤコマ",
+      "en": "Fletchinder",
+      "ko": "불화살빈",
+      "zh-Hans": "火箭雀",
+      "zh-Hant": "火箭雀"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0662",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0663",
+    "no": "0663",
+    "form": null,
+    "names": {
+      "ja": "ファイアロー",
+      "en": "Talonflame",
+      "ko": "파이어로",
+      "zh-Hans": "烈箭鹰",
+      "zh-Hant": "烈箭鷹"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0663",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0664",
+    "no": "0664",
+    "form": null,
+    "names": {
+      "ja": "コフキムシ",
+      "en": "Scatterbug",
+      "ko": "분이벌레",
+      "zh-Hans": "粉蝶虫",
+      "zh-Hant": "粉蝶蟲"
+    },
+    "types": [
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0664",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0665",
+    "no": "0665",
+    "form": null,
+    "names": {
+      "ja": "コフーライ",
+      "en": "Spewpa",
+      "ko": "분떠도리",
+      "zh-Hans": "粉蝶蛹",
+      "zh-Hant": "粉蝶蛹"
+    },
+    "types": [
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0665",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0666",
+    "no": "0666",
+    "form": null,
+    "names": {
+      "ja": "ビビヨン",
+      "en": "Vivillon",
+      "ko": "비비용",
+      "zh-Hans": "彩粉蝶",
+      "zh-Hant": "彩粉蝶"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0666",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0667",
+    "no": "0667",
+    "form": null,
+    "names": {
+      "ja": "シシコ",
+      "en": "Litleo",
+      "ko": "레오꼬",
+      "zh-Hans": "小狮狮",
+      "zh-Hant": "小獅獅"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0667",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0668",
+    "no": "0668",
+    "form": null,
+    "names": {
+      "ja": "カエンジシ",
+      "en": "Pyroar",
+      "ko": "화염레오",
+      "zh-Hans": "火炎狮",
+      "zh-Hant": "火炎獅"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0668",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0669",
+    "no": "0669",
+    "form": null,
+    "names": {
+      "ja": "フラベベ",
+      "en": "Flabébé",
+      "ko": "플라베베",
+      "zh-Hans": "花蓓蓓",
+      "zh-Hant": "花蓓蓓"
+    },
+    "types": [
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0669",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0670",
+    "no": "0670",
+    "form": null,
+    "names": {
+      "ja": "フラエッテ",
+      "en": "Floette",
+      "ko": "플라엣테",
+      "zh-Hans": "花叶蒂",
+      "zh-Hant": "花葉蒂"
+    },
+    "types": [
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0670",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0671",
+    "no": "0671",
+    "form": null,
+    "names": {
+      "ja": "フラージェス",
+      "en": "Florges",
+      "ko": "플라제스",
+      "zh-Hans": "花洁夫人",
+      "zh-Hant": "花潔夫人"
+    },
+    "types": [
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0671",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0672",
+    "no": "0672",
+    "form": null,
+    "names": {
+      "ja": "メェークル",
+      "en": "Skiddo",
+      "ko": "메이클",
+      "zh-Hans": "坐骑小羊",
+      "zh-Hant": "坐騎小羊"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0672",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0673",
+    "no": "0673",
+    "form": null,
+    "names": {
+      "ja": "ゴーゴート",
+      "en": "Gogoat",
+      "ko": "고고트",
+      "zh-Hans": "坐骑山羊",
+      "zh-Hant": "坐騎山羊"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0673",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0674",
+    "no": "0674",
+    "form": null,
+    "names": {
+      "ja": "ヤンチャム",
+      "en": "Pancham",
+      "ko": "판짱",
+      "zh-Hans": "顽皮熊猫",
+      "zh-Hant": "頑皮熊貓"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0674",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0675",
+    "no": "0675",
+    "form": null,
+    "names": {
+      "ja": "ゴロンダ",
+      "en": "Pangoro",
+      "ko": "부란다",
+      "zh-Hans": "霸道熊猫",
+      "zh-Hant": "流氓熊貓"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0675",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0676",
+    "no": "0676",
+    "form": null,
+    "names": {
+      "ja": "トリミアン",
+      "en": "Furfrou",
+      "ko": "트리미앙",
+      "zh-Hans": "多丽米亚",
+      "zh-Hant": "多麗米亞"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0676",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0677",
+    "no": "0677",
+    "form": null,
+    "names": {
+      "ja": "ニャスパー",
+      "en": "Espurr",
+      "ko": "냐스퍼",
+      "zh-Hans": "妙喵",
+      "zh-Hant": "妙喵"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0677",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0678",
+    "no": "0678",
+    "form": null,
+    "names": {
+      "ja": "ニャオニクス",
+      "en": "Meowstic",
+      "ko": "냐오닉스",
+      "zh-Hans": "超能妙喵",
+      "zh-Hant": "超能妙喵"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0678",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0679",
+    "no": "0679",
+    "form": null,
+    "names": {
+      "ja": "ヒトツキ",
+      "en": "Honedge",
+      "ko": "단칼빙",
+      "zh-Hans": "独剑鞘",
+      "zh-Hant": "獨劍鞘"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0679",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0680",
+    "no": "0680",
+    "form": null,
+    "names": {
+      "ja": "ニダンギル",
+      "en": "Doublade",
+      "ko": "쌍검킬",
+      "zh-Hans": "双剑鞘",
+      "zh-Hant": "雙劍鞘"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0680",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0681",
+    "no": "0681",
+    "form": null,
+    "names": {
+      "ja": "ギルガルド",
+      "en": "Aegislash",
+      "ko": "킬가르도",
+      "zh-Hans": "坚盾剑怪",
+      "zh-Hant": "堅盾劍怪"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0681",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0682",
+    "no": "0682",
+    "form": null,
+    "names": {
+      "ja": "シュシュプ",
+      "en": "Spritzee",
+      "ko": "슈쁘",
+      "zh-Hans": "粉香香",
+      "zh-Hant": "粉香香"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0682",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0683",
+    "no": "0683",
+    "form": null,
+    "names": {
+      "ja": "フレフワン",
+      "en": "Aromatisse",
+      "ko": "프레프티르",
+      "zh-Hans": "芳香精",
+      "zh-Hant": "芳香精"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0683",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0684",
+    "no": "0684",
+    "form": null,
+    "names": {
+      "ja": "ペロッパフ",
+      "en": "Swirlix",
+      "ko": "나룸퍼프",
+      "zh-Hans": "绵绵泡芙",
+      "zh-Hant": "綿綿泡芙"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0684",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0685",
+    "no": "0685",
+    "form": null,
+    "names": {
+      "ja": "ペロリーム",
+      "en": "Slurpuff",
+      "ko": "나루림",
+      "zh-Hans": "胖甜妮",
+      "zh-Hant": "胖甜妮"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0685",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0686",
+    "no": "0686",
+    "form": null,
+    "names": {
+      "ja": "マーイーカ",
+      "en": "Inkay",
+      "ko": "오케이징",
+      "zh-Hans": "好啦鱿",
+      "zh-Hant": "好啦魷"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0686",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0687",
+    "no": "0687",
+    "form": null,
+    "names": {
+      "ja": "カラマネロ",
+      "en": "Malamar",
+      "ko": "칼라마네로",
+      "zh-Hans": "乌贼王",
+      "zh-Hant": "烏賊王"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0687",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0688",
+    "no": "0688",
+    "form": null,
+    "names": {
+      "ja": "カメテテ",
+      "en": "Binacle",
+      "ko": "거북손손",
+      "zh-Hans": "龟脚脚",
+      "zh-Hant": "龜腳腳"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0688",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0689",
+    "no": "0689",
+    "form": null,
+    "names": {
+      "ja": "ガメノデス",
+      "en": "Barbaracle",
+      "ko": "거북손데스",
+      "zh-Hans": "龟足巨铠",
+      "zh-Hant": "龜足巨鎧"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0689",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0690",
+    "no": "0690",
+    "form": null,
+    "names": {
+      "ja": "クズモー",
+      "en": "Skrelp",
+      "ko": "수레기",
+      "zh-Hans": "垃垃藻",
+      "zh-Hant": "垃垃藻"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0690",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0691",
+    "no": "0691",
+    "form": null,
+    "names": {
+      "ja": "ドラミドロ",
+      "en": "Dragalge",
+      "ko": "드래캄",
+      "zh-Hans": "毒藻龙",
+      "zh-Hant": "毒藻龍"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0691",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0692",
+    "no": "0692",
+    "form": null,
+    "names": {
+      "ja": "ウデッポウ",
+      "en": "Clauncher",
+      "ko": "완철포",
+      "zh-Hans": "铁臂枪虾",
+      "zh-Hant": "鐵臂槍蝦"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0692",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0693",
+    "no": "0693",
+    "form": null,
+    "names": {
+      "ja": "ブロスター",
+      "en": "Clawitzer",
+      "ko": "블로스터",
+      "zh-Hans": "钢炮臂虾",
+      "zh-Hant": "鋼炮臂蝦"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0693",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0694",
+    "no": "0694",
+    "form": null,
+    "names": {
+      "ja": "エリキテル",
+      "en": "Helioptile",
+      "ko": "목도리키텔",
+      "zh-Hans": "伞电蜥",
+      "zh-Hant": "傘電蜥"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0694",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0695",
+    "no": "0695",
+    "form": null,
+    "names": {
+      "ja": "エレザード",
+      "en": "Heliolisk",
+      "ko": "일레도리자드",
+      "zh-Hans": "光电伞蜥",
+      "zh-Hant": "光電傘蜥"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0695",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0696",
+    "no": "0696",
+    "form": null,
+    "names": {
+      "ja": "チゴラス",
+      "en": "Tyrunt",
+      "ko": "티고라스",
+      "zh-Hans": "宝宝暴龙",
+      "zh-Hant": "寶寶暴龍"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0696",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0697",
+    "no": "0697",
+    "form": null,
+    "names": {
+      "ja": "ガチゴラス",
+      "en": "Tyrantrum",
+      "ko": "견고라스",
+      "zh-Hans": "怪颚龙",
+      "zh-Hant": "怪顎龍"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0697",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0698",
+    "no": "0698",
+    "form": null,
+    "names": {
+      "ja": "アマルス",
+      "en": "Amaura",
+      "ko": "아마루스",
+      "zh-Hans": "冰雪龙",
+      "zh-Hant": "冰雪龍"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0698",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0699",
+    "no": "0699",
+    "form": null,
+    "names": {
+      "ja": "アマルルガ",
+      "en": "Aurorus",
+      "ko": "아마루르가",
+      "zh-Hans": "冰雪巨龙",
+      "zh-Hant": "冰雪巨龍"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0699",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0700",
+    "no": "0700",
+    "form": null,
+    "names": {
+      "ja": "ニンフィア",
+      "en": "Sylveon",
+      "ko": "님피아",
+      "zh-Hans": "仙子伊布",
+      "zh-Hant": "仙子伊布"
+    },
+    "types": [
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0700",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0701",
+    "no": "0701",
+    "form": null,
+    "names": {
+      "ja": "ルチャブル",
+      "en": "Hawlucha",
+      "ko": "루차불",
+      "zh-Hans": "摔角鹰人",
+      "zh-Hant": "摔角鷹人"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0701",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0702",
+    "no": "0702",
+    "form": null,
+    "names": {
+      "ja": "デデンネ",
+      "en": "Dedenne",
+      "ko": "데덴네",
+      "zh-Hans": "咚咚鼠",
+      "zh-Hant": "咚咚鼠"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0702",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0703",
+    "no": "0703",
+    "form": null,
+    "names": {
+      "ja": "メレシー",
+      "en": "Carbink",
+      "ko": "멜리시",
+      "zh-Hans": "小碎钻",
+      "zh-Hant": "小碎鑽"
+    },
+    "types": [
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0703",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0704",
+    "no": "0704",
+    "form": null,
+    "names": {
+      "ja": "ヌメラ",
+      "en": "Goomy",
+      "ko": "미끄메라",
+      "zh-Hans": "黏黏宝",
+      "zh-Hant": "黏黏寶"
+    },
+    "types": [
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0704",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0705",
+    "no": "0705",
+    "form": null,
+    "names": {
+      "ja": "ヌメイル",
+      "en": "Sliggoo",
+      "ko": "미끄네일",
+      "zh-Hans": "黏美儿",
+      "zh-Hant": "黏美兒"
+    },
+    "types": [
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0705",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0705-hisui",
+    "no": "0705",
+    "form": "hisui",
+    "names": {
+      "ja": "ヌメイル",
+      "en": "Sliggoo",
+      "ko": "미끄네일",
+      "zh-Hans": "黏美儿",
+      "zh-Hant": "黏美兒"
+    },
+    "types": [
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0705-hisui",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0706",
+    "no": "0706",
+    "form": null,
+    "names": {
+      "ja": "ヌメルゴン",
+      "en": "Goodra",
+      "ko": "미끄래곤",
+      "zh-Hans": "黏美龙",
+      "zh-Hant": "黏美龍"
+    },
+    "types": [
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0706",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0706-hisui",
+    "no": "0706",
+    "form": "hisui",
+    "names": {
+      "ja": "ヌメルゴン",
+      "en": "Goodra",
+      "ko": "미끄래곤",
+      "zh-Hans": "黏美龙",
+      "zh-Hant": "黏美龍"
+    },
+    "types": [
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0706-hisui",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0707",
+    "no": "0707",
+    "form": null,
+    "names": {
+      "ja": "クレッフィ",
+      "en": "Klefki",
+      "ko": "클레피",
+      "zh-Hans": "钥圈儿",
+      "zh-Hant": "鑰圈兒"
+    },
+    "types": [
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0707",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0708",
+    "no": "0708",
+    "form": null,
+    "names": {
+      "ja": "ボクレー",
+      "en": "Phantump",
+      "ko": "나목령",
+      "zh-Hans": "小木灵",
+      "zh-Hant": "小木靈"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0708",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0709",
+    "no": "0709",
+    "form": null,
+    "names": {
+      "ja": "オーロット",
+      "en": "Trevenant",
+      "ko": "대로트",
+      "zh-Hans": "朽木妖",
+      "zh-Hant": "朽木妖"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0709",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0710",
+    "no": "0710",
+    "form": null,
+    "names": {
+      "ja": "バケッチャ",
+      "en": "Pumpkaboo",
+      "ko": "호바귀",
+      "zh-Hans": "南瓜精",
+      "zh-Hant": "南瓜精"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0710",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0711",
+    "no": "0711",
+    "form": null,
+    "names": {
+      "ja": "パンプジン",
+      "en": "Gourgeist",
+      "ko": "펌킨인",
+      "zh-Hans": "南瓜怪人",
+      "zh-Hant": "南瓜怪人"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0711",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0712",
+    "no": "0712",
+    "form": null,
+    "names": {
+      "ja": "カチコール",
+      "en": "Bergmite",
+      "ko": "꽁어름",
+      "zh-Hans": "冰宝",
+      "zh-Hant": "冰寶"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0712",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0713",
+    "no": "0713",
+    "form": null,
+    "names": {
+      "ja": "クレベース",
+      "en": "Avalugg",
+      "ko": "크레베이스",
+      "zh-Hans": "冰岩怪",
+      "zh-Hant": "冰岩怪"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0713",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0713-hisui",
+    "no": "0713",
+    "form": "hisui",
+    "names": {
+      "ja": "クレベース",
+      "en": "Avalugg",
+      "ko": "크레베이스",
+      "zh-Hans": "冰岩怪",
+      "zh-Hant": "冰岩怪"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0713-hisui",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0714",
+    "no": "0714",
+    "form": null,
+    "names": {
+      "ja": "オンバット",
+      "en": "Noibat",
+      "ko": "음뱃",
+      "zh-Hans": "嗡蝠",
+      "zh-Hant": "嗡蝠"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0714",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0715",
+    "no": "0715",
+    "form": null,
+    "names": {
+      "ja": "オンバーン",
+      "en": "Noivern",
+      "ko": "음번",
+      "zh-Hans": "音波龙",
+      "zh-Hant": "音波龍"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0715",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0716",
+    "no": "0716",
+    "form": null,
+    "names": {
+      "ja": "ゼルネアス",
+      "en": "Xerneas",
+      "ko": "제르네아스",
+      "zh-Hans": "哲尔尼亚斯",
+      "zh-Hant": "哲爾尼亞斯"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0716",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0717",
+    "no": "0717",
+    "form": null,
+    "names": {
+      "ja": "イベルタル",
+      "en": "Yveltal",
+      "ko": "이벨타르",
+      "zh-Hans": "伊裴尔塔尔",
+      "zh-Hant": "伊裴爾塔爾"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0717",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0718",
+    "no": "0718",
+    "form": null,
+    "names": {
+      "ja": "ジガルデ",
+      "en": "Zygarde",
+      "ko": "지가르데",
+      "zh-Hans": "基格尔德",
+      "zh-Hant": "基格爾德"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0718",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0719",
+    "no": "0719",
+    "form": null,
+    "names": {
+      "ja": "ディアンシー",
+      "en": "Diancie",
+      "ko": "디안시",
+      "zh-Hans": "蒂安希",
+      "zh-Hant": "蒂安希"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0719",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0720",
+    "no": "0720",
+    "form": null,
+    "names": {
+      "ja": "フーパ",
+      "en": "Hoopa",
+      "ko": "후파",
+      "zh-Hans": "胡帕",
+      "zh-Hant": "胡帕"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0720",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0721",
+    "no": "0721",
+    "form": null,
+    "names": {
+      "ja": "ボルケニオン",
+      "en": "Volcanion",
+      "ko": "볼케니온",
+      "zh-Hans": "波尔凯尼恩",
+      "zh-Hant": "波爾凱尼恩"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0721",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0722",
+    "no": "0722",
+    "form": null,
+    "names": {
+      "ja": "モクロー",
+      "en": "Rowlet",
+      "ko": "나몰빼미",
+      "zh-Hans": "木木枭",
+      "zh-Hant": "木木梟"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0722",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0723",
+    "no": "0723",
+    "form": null,
+    "names": {
+      "ja": "フクスロー",
+      "en": "Dartrix",
+      "ko": "빼미스로우",
+      "zh-Hans": "投羽枭",
+      "zh-Hant": "投羽梟"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0723",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0724",
+    "no": "0724",
+    "form": null,
+    "names": {
+      "ja": "ジュナイパー",
+      "en": "Decidueye",
+      "ko": "모크나이퍼",
+      "zh-Hans": "狙射树枭",
+      "zh-Hant": "狙射樹梟"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0724",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0724-hisui",
+    "no": "0724",
+    "form": "hisui",
+    "names": {
+      "ja": "ジュナイパー",
+      "en": "Decidueye",
+      "ko": "모크나이퍼",
+      "zh-Hans": "狙射树枭",
+      "zh-Hant": "狙射樹梟"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0724-hisui",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0725",
+    "no": "0725",
+    "form": null,
+    "names": {
+      "ja": "ニャビー",
+      "en": "Litten",
+      "ko": "냐오불",
+      "zh-Hans": "火斑喵",
+      "zh-Hant": "火斑喵"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0725",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0726",
+    "no": "0726",
+    "form": null,
+    "names": {
+      "ja": "ニャヒート",
+      "en": "Torracat",
+      "ko": "냐오히트",
+      "zh-Hans": "炎热喵",
+      "zh-Hant": "炎熱喵"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0726",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0727",
+    "no": "0727",
+    "form": null,
+    "names": {
+      "ja": "ガオガエン",
+      "en": "Incineroar",
+      "ko": "어흥염",
+      "zh-Hans": "炽焰咆哮虎",
+      "zh-Hant": "熾焰咆哮虎"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0727",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0728",
+    "no": "0728",
+    "form": null,
+    "names": {
+      "ja": "アシマリ",
+      "en": "Popplio",
+      "ko": "누리공",
+      "zh-Hans": "球球海狮",
+      "zh-Hant": "球球海獅"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0728",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0729",
+    "no": "0729",
+    "form": null,
+    "names": {
+      "ja": "オシャマリ",
+      "en": "Brionne",
+      "ko": "키요공",
+      "zh-Hans": "花漾海狮",
+      "zh-Hant": "花漾海獅"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0729",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0730",
+    "no": "0730",
+    "form": null,
+    "names": {
+      "ja": "アシレーヌ",
+      "en": "Primarina",
+      "ko": "누리레느",
+      "zh-Hans": "西狮海壬",
+      "zh-Hant": "西獅海壬"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0730",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0731",
+    "no": "0731",
+    "form": null,
+    "names": {
+      "ja": "ツツケラ",
+      "en": "Pikipek",
+      "ko": "콕코구리",
+      "zh-Hans": "小笃儿",
+      "zh-Hant": "小篤兒"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0731",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0732",
+    "no": "0732",
+    "form": null,
+    "names": {
+      "ja": "ケララッパ",
+      "en": "Trumbeak",
+      "ko": "크라파",
+      "zh-Hans": "喇叭啄鸟",
+      "zh-Hant": "喇叭啄鳥"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0732",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0733",
+    "no": "0733",
+    "form": null,
+    "names": {
+      "ja": "ドデカバシ",
+      "en": "Toucannon",
+      "ko": "왕큰부리",
+      "zh-Hans": "铳嘴大鸟",
+      "zh-Hant": "銃嘴大鳥"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0733",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0734",
+    "no": "0734",
+    "form": null,
+    "names": {
+      "ja": "ヤングース",
+      "en": "Yungoos",
+      "ko": "영구스",
+      "zh-Hans": "猫鼬少",
+      "zh-Hant": "貓鼬少"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0734",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0735",
+    "no": "0735",
+    "form": null,
+    "names": {
+      "ja": "デカグース",
+      "en": "Gumshoos",
+      "ko": "형사구스",
+      "zh-Hans": "猫鼬探长",
+      "zh-Hant": "貓鼬探長"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0735",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0736",
+    "no": "0736",
+    "form": null,
+    "names": {
+      "ja": "アゴジムシ",
+      "en": "Grubbin",
+      "ko": "턱지충이",
+      "zh-Hans": "强颚鸡母虫",
+      "zh-Hant": "強顎雞母蟲"
+    },
+    "types": [
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0736",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0737",
+    "no": "0737",
+    "form": null,
+    "names": {
+      "ja": "デンヂムシ",
+      "en": "Charjabug",
+      "ko": "전지충이",
+      "zh-Hans": "虫电宝",
+      "zh-Hant": "蟲電寶"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0737",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0738",
+    "no": "0738",
+    "form": null,
+    "names": {
+      "ja": "クワガノン",
+      "en": "Vikavolt",
+      "ko": "투구뿌논",
+      "zh-Hans": "锹农炮虫",
+      "zh-Hant": "鍬農炮蟲"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0738",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0739",
+    "no": "0739",
+    "form": null,
+    "names": {
+      "ja": "マケンカニ",
+      "en": "Crabrawler",
+      "ko": "오기지게",
+      "zh-Hans": "好胜蟹",
+      "zh-Hant": "好勝蟹"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0739",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0740",
+    "no": "0740",
+    "form": null,
+    "names": {
+      "ja": "ケケンカニ",
+      "en": "Crabominable",
+      "ko": "모단단게",
+      "zh-Hans": "好胜毛蟹",
+      "zh-Hant": "好勝毛蟹"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      },
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0740",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0741",
+    "no": "0741",
+    "form": null,
+    "names": {
+      "ja": "オドリドリ",
+      "en": "Oricorio",
+      "ko": "춤추새",
+      "zh-Hans": "花舞鸟",
+      "zh-Hant": "花舞鳥"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0741",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0742",
+    "no": "0742",
+    "form": null,
+    "names": {
+      "ja": "アブリー",
+      "en": "Cutiefly",
+      "ko": "에블리",
+      "zh-Hans": "萌虻",
+      "zh-Hant": "萌虻"
+    },
+    "types": [
+      {
+        "ja": "むし",
+        "en": "Bug"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0742",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0743",
+    "no": "0743",
+    "form": null,
+    "names": {
+      "ja": "アブリボン",
+      "en": "Ribombee",
+      "ko": "에리본",
+      "zh-Hans": "蝶结萌虻",
+      "zh-Hant": "蝶結萌虻"
+    },
+    "types": [
+      {
+        "ja": "むし",
+        "en": "Bug"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0743",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0744",
+    "no": "0744",
+    "form": null,
+    "names": {
+      "ja": "イワンコ",
+      "en": "Rockruff",
+      "ko": "암멍이",
+      "zh-Hans": "岩狗狗",
+      "zh-Hant": "岩狗狗"
+    },
+    "types": [
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0744",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0745",
+    "no": "0745",
+    "form": null,
+    "names": {
+      "ja": "ルガルガン",
+      "en": "Lycanroc",
+      "ko": "루가루암",
+      "zh-Hans": "鬃岩狼人",
+      "zh-Hant": "鬃岩狼人"
+    },
+    "types": [
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0745",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0746",
+    "no": "0746",
+    "form": null,
+    "names": {
+      "ja": "ヨワシ",
+      "en": "Wishiwashi",
+      "ko": "약어리",
+      "zh-Hans": "弱丁鱼",
+      "zh-Hant": "弱丁魚"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0746",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0747",
+    "no": "0747",
+    "form": null,
+    "names": {
+      "ja": "ヒドイデ",
+      "en": "Mareanie",
+      "ko": "시마사리",
+      "zh-Hans": "好坏星",
+      "zh-Hant": "好壞星"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0747",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0748",
+    "no": "0748",
+    "form": null,
+    "names": {
+      "ja": "ドヒドイデ",
+      "en": "Toxapex",
+      "ko": "더시마사리",
+      "zh-Hans": "超坏星",
+      "zh-Hant": "超壞星"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0748",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0749",
+    "no": "0749",
+    "form": null,
+    "names": {
+      "ja": "ドロバンコ",
+      "en": "Mudbray",
+      "ko": "머드나기",
+      "zh-Hans": "泥驴仔",
+      "zh-Hant": "泥驢仔"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0749",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0750",
+    "no": "0750",
+    "form": null,
+    "names": {
+      "ja": "バンバドロ",
+      "en": "Mudsdale",
+      "ko": "만마드",
+      "zh-Hans": "重泥挽马",
+      "zh-Hant": "重泥挽馬"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0750",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0751",
+    "no": "0751",
+    "form": null,
+    "names": {
+      "ja": "シズクモ",
+      "en": "Dewpider",
+      "ko": "물거미",
+      "zh-Hans": "滴蛛",
+      "zh-Hant": "滴蛛"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0751",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0752",
+    "no": "0752",
+    "form": null,
+    "names": {
+      "ja": "オニシズクモ",
+      "en": "Araquanid",
+      "ko": "깨비물거미",
+      "zh-Hans": "滴蛛霸",
+      "zh-Hant": "滴蛛霸"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0752",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0753",
+    "no": "0753",
+    "form": null,
+    "names": {
+      "ja": "カリキリ",
+      "en": "Fomantis",
+      "ko": "짜랑랑",
+      "zh-Hans": "伪螳草",
+      "zh-Hant": "偽螳草"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0753",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0754",
+    "no": "0754",
+    "form": null,
+    "names": {
+      "ja": "ラランテス",
+      "en": "Lurantis",
+      "ko": "라란티스",
+      "zh-Hans": "兰螳花",
+      "zh-Hant": "蘭螳花"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0754",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0755",
+    "no": "0755",
+    "form": null,
+    "names": {
+      "ja": "ネマシュ",
+      "en": "Morelull",
+      "ko": "자마슈",
+      "zh-Hans": "睡睡菇",
+      "zh-Hant": "睡睡菇"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0755",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0756",
+    "no": "0756",
+    "form": null,
+    "names": {
+      "ja": "マシェード",
+      "en": "Shiinotic",
+      "ko": "마셰이드",
+      "zh-Hans": "灯罩夜菇",
+      "zh-Hant": "燈罩夜菇"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0756",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0757",
+    "no": "0757",
+    "form": null,
+    "names": {
+      "ja": "ヤトウモリ",
+      "en": "Salandit",
+      "ko": "야도뇽",
+      "zh-Hans": "夜盗火蜥",
+      "zh-Hant": "夜盜火蜥"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0757",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0758",
+    "no": "0758",
+    "form": null,
+    "names": {
+      "ja": "エンニュート",
+      "en": "Salazzle",
+      "ko": "염뉴트",
+      "zh-Hans": "焰后蜥",
+      "zh-Hant": "焰后蜥"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0758",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0759",
+    "no": "0759",
+    "form": null,
+    "names": {
+      "ja": "ヌイコグマ",
+      "en": "Stufful",
+      "ko": "포곰곰",
+      "zh-Hans": "童偶熊",
+      "zh-Hant": "童偶熊"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0759",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0760",
+    "no": "0760",
+    "form": null,
+    "names": {
+      "ja": "キテルグマ",
+      "en": "Bewear",
+      "ko": "이븐곰",
+      "zh-Hans": "穿着熊",
+      "zh-Hant": "穿著熊"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0760",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0761",
+    "no": "0761",
+    "form": null,
+    "names": {
+      "ja": "アマカジ",
+      "en": "Bounsweet",
+      "ko": "달콤아",
+      "zh-Hans": "甜竹竹",
+      "zh-Hant": "甜竹竹"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0761",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0762",
+    "no": "0762",
+    "form": null,
+    "names": {
+      "ja": "アママイコ",
+      "en": "Steenee",
+      "ko": "달무리나",
+      "zh-Hans": "甜舞妮",
+      "zh-Hant": "甜舞妮"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0762",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0763",
+    "no": "0763",
+    "form": null,
+    "names": {
+      "ja": "アマージョ",
+      "en": "Tsareena",
+      "ko": "달코퀸",
+      "zh-Hans": "甜冷美后",
+      "zh-Hant": "甜冷美后"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0763",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0764",
+    "no": "0764",
+    "form": null,
+    "names": {
+      "ja": "キュワワー",
+      "en": "Comfey",
+      "ko": "큐아링",
+      "zh-Hans": "花疗环环",
+      "zh-Hant": "花療環環"
+    },
+    "types": [
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0764",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0765",
+    "no": "0765",
+    "form": null,
+    "names": {
+      "ja": "ヤレユータン",
+      "en": "Oranguru",
+      "ko": "하랑우탄",
+      "zh-Hans": "智挥猩",
+      "zh-Hant": "智揮猩"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0765",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0766",
+    "no": "0766",
+    "form": null,
+    "names": {
+      "ja": "ナゲツケサル",
+      "en": "Passimian",
+      "ko": "내던숭이",
+      "zh-Hans": "投掷猴",
+      "zh-Hant": "投擲猴"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0766",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0767",
+    "no": "0767",
+    "form": null,
+    "names": {
+      "ja": "コソクムシ",
+      "en": "Wimpod",
+      "ko": "꼬시레",
+      "zh-Hans": "胆小虫",
+      "zh-Hant": "膽小蟲"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0767",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0768",
+    "no": "0768",
+    "form": null,
+    "names": {
+      "ja": "グソクムシャ",
+      "en": "Golisopod",
+      "ko": "갑주무사",
+      "zh-Hans": "具甲武者",
+      "zh-Hant": "具甲武者"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0768",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0769",
+    "no": "0769",
+    "form": null,
+    "names": {
+      "ja": "スナバァ",
+      "en": "Sandygast",
+      "ko": "모래꿍",
+      "zh-Hans": "沙丘娃",
+      "zh-Hant": "沙丘娃"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0769",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0770",
+    "no": "0770",
+    "form": null,
+    "names": {
+      "ja": "シロデスナ",
+      "en": "Palossand",
+      "ko": "모래성이당",
+      "zh-Hans": "噬沙堡爷",
+      "zh-Hant": "噬沙堡爺"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0770",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0771",
+    "no": "0771",
+    "form": null,
+    "names": {
+      "ja": "ナマコブシ",
+      "en": "Pyukumuku",
+      "ko": "해무기",
+      "zh-Hans": "拳海参",
+      "zh-Hant": "拳海參"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0771",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0772",
+    "no": "0772",
+    "form": null,
+    "names": {
+      "ja": "タイプ：ヌル",
+      "en": "Type: Null",
+      "ko": "타입:널",
+      "zh-Hans": "属性：空",
+      "zh-Hant": "屬性：空"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0772",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0773",
+    "no": "0773",
+    "form": null,
+    "names": {
+      "ja": "シルヴァディ",
+      "en": "Silvally",
+      "ko": "실버디",
+      "zh-Hans": "银伴战兽",
+      "zh-Hant": "銀伴戰獸"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0773",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0774",
+    "no": "0774",
+    "form": null,
+    "names": {
+      "ja": "メテノ",
+      "en": "Minior",
+      "ko": "메테노",
+      "zh-Hans": "小陨星",
+      "zh-Hant": "小隕星"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0774",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0775",
+    "no": "0775",
+    "form": null,
+    "names": {
+      "ja": "ネッコアラ",
+      "en": "Komala",
+      "ko": "자말라",
+      "zh-Hans": "树枕尾熊",
+      "zh-Hant": "樹枕尾熊"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0775",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0776",
+    "no": "0776",
+    "form": null,
+    "names": {
+      "ja": "バクガメス",
+      "en": "Turtonator",
+      "ko": "폭거북스",
+      "zh-Hans": "爆焰龟兽",
+      "zh-Hant": "爆焰龜獸"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0776",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0777",
+    "no": "0777",
+    "form": null,
+    "names": {
+      "ja": "トゲデマル",
+      "en": "Togedemaru",
+      "ko": "토게데마루",
+      "zh-Hans": "托戈德玛尔",
+      "zh-Hant": "托戈德瑪爾"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0777",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0778",
+    "no": "0778",
+    "form": null,
+    "names": {
+      "ja": "ミミッキュ",
+      "en": "Mimikyu",
+      "ko": "따라큐",
+      "zh-Hans": "谜拟丘",
+      "zh-Hant": "謎擬Ｑ"
+    },
+    "types": [
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0778",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0779",
+    "no": "0779",
+    "form": null,
+    "names": {
+      "ja": "ハギギシリ",
+      "en": "Bruxish",
+      "ko": "치갈기",
+      "zh-Hans": "磨牙彩皮鱼",
+      "zh-Hant": "磨牙彩皮魚"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0779",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0780",
+    "no": "0780",
+    "form": null,
+    "names": {
+      "ja": "ジジーロン",
+      "en": "Drampa",
+      "ko": "할비롱",
+      "zh-Hans": "老翁龙",
+      "zh-Hant": "老翁龍"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0780",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0781",
+    "no": "0781",
+    "form": null,
+    "names": {
+      "ja": "ダダリン",
+      "en": "Dhelmise",
+      "ko": "타타륜",
+      "zh-Hans": "破破舵轮",
+      "zh-Hant": "破破舵輪"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0781",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0782",
+    "no": "0782",
+    "form": null,
+    "names": {
+      "ja": "ジャラコ",
+      "en": "Jangmo-o",
+      "ko": "짜랑꼬",
+      "zh-Hans": "心鳞宝",
+      "zh-Hant": "心鱗寶"
+    },
+    "types": [
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0782",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0783",
+    "no": "0783",
+    "form": null,
+    "names": {
+      "ja": "ジャランゴ",
+      "en": "Hakamo-o",
+      "ko": "짜랑고우",
+      "zh-Hans": "鳞甲龙",
+      "zh-Hant": "鱗甲龍"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0783",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0784",
+    "no": "0784",
+    "form": null,
+    "names": {
+      "ja": "ジャラランガ",
+      "en": "Kommo-o",
+      "ko": "짜랑고우거",
+      "zh-Hans": "杖尾鳞甲龙",
+      "zh-Hant": "杖尾鱗甲龍"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0784",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0785",
+    "no": "0785",
+    "form": null,
+    "names": {
+      "ja": "カプ・コケコ",
+      "en": "Tapu Koko",
+      "ko": "카푸꼬꼬꼭",
+      "zh-Hans": "卡璞・鸣鸣",
+      "zh-Hant": "卡璞・鳴鳴"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0785",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0786",
+    "no": "0786",
+    "form": null,
+    "names": {
+      "ja": "カプ・テテフ",
+      "en": "Tapu Lele",
+      "ko": "카푸나비나",
+      "zh-Hans": "卡璞・蝶蝶",
+      "zh-Hant": "卡璞・蝶蝶"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0786",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0787",
+    "no": "0787",
+    "form": null,
+    "names": {
+      "ja": "カプ・ブルル",
+      "en": "Tapu Bulu",
+      "ko": "카푸브루루",
+      "zh-Hans": "卡璞・哞哞",
+      "zh-Hant": "卡璞・哞哞"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0787",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0788",
+    "no": "0788",
+    "form": null,
+    "names": {
+      "ja": "カプ・レヒレ",
+      "en": "Tapu Fini",
+      "ko": "카푸느지느",
+      "zh-Hans": "卡璞・鳍鳍",
+      "zh-Hant": "卡璞・鰭鰭"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0788",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0789",
+    "no": "0789",
+    "form": null,
+    "names": {
+      "ja": "コスモッグ",
+      "en": "Cosmog",
+      "ko": "코스모그",
+      "zh-Hans": "科斯莫古",
+      "zh-Hant": "科斯莫古"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0789",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0790",
+    "no": "0790",
+    "form": null,
+    "names": {
+      "ja": "コスモウム",
+      "en": "Cosmoem",
+      "ko": "코스모움",
+      "zh-Hans": "科斯莫姆",
+      "zh-Hant": "科斯莫姆"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0790",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0791",
+    "no": "0791",
+    "form": null,
+    "names": {
+      "ja": "ソルガレオ",
+      "en": "Solgaleo",
+      "ko": "솔가레오",
+      "zh-Hans": "索尔迦雷欧",
+      "zh-Hant": "索爾迦雷歐"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0791",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0792",
+    "no": "0792",
+    "form": null,
+    "names": {
+      "ja": "ルナアーラ",
+      "en": "Lunala",
+      "ko": "루나아라",
+      "zh-Hans": "露奈雅拉",
+      "zh-Hant": "露奈雅拉"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0792",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0793",
+    "no": "0793",
+    "form": null,
+    "names": {
+      "ja": "ウツロイド",
+      "en": "Nihilego",
+      "ko": "텅비드",
+      "zh-Hans": "虚吾伊德",
+      "zh-Hant": "虛吾伊德"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0793",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0794",
+    "no": "0794",
+    "form": null,
+    "names": {
+      "ja": "マッシブーン",
+      "en": "Buzzwole",
+      "ko": "매시붕",
+      "zh-Hans": "爆肌蚊",
+      "zh-Hant": "爆肌蚊"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0794",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0795",
+    "no": "0795",
+    "form": null,
+    "names": {
+      "ja": "フェローチェ",
+      "en": "Pheromosa",
+      "ko": "페로코체",
+      "zh-Hans": "费洛美螂",
+      "zh-Hant": "費洛美螂"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0795",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0796",
+    "no": "0796",
+    "form": null,
+    "names": {
+      "ja": "デンジュモク",
+      "en": "Xurkitree",
+      "ko": "전수목",
+      "zh-Hans": "电束木",
+      "zh-Hant": "電束木"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0796",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0797",
+    "no": "0797",
+    "form": null,
+    "names": {
+      "ja": "テッカグヤ",
+      "en": "Celesteela",
+      "ko": "철화구야",
+      "zh-Hans": "铁火辉夜",
+      "zh-Hant": "鐵火輝夜"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0797",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0798",
+    "no": "0798",
+    "form": null,
+    "names": {
+      "ja": "カミツルギ",
+      "en": "Kartana",
+      "ko": "종이신도",
+      "zh-Hans": "纸御剑",
+      "zh-Hant": "紙御劍"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0798",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0799",
+    "no": "0799",
+    "form": null,
+    "names": {
+      "ja": "アクジキング",
+      "en": "Guzzlord",
+      "ko": "악식킹",
+      "zh-Hans": "恶食大王",
+      "zh-Hant": "惡食大王"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0799",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0800",
+    "no": "0800",
+    "form": null,
+    "names": {
+      "ja": "ネクロズマ",
+      "en": "Necrozma",
+      "ko": "네크로즈마",
+      "zh-Hans": "奈克洛兹玛",
+      "zh-Hant": "奈克洛茲瑪"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0800",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0801",
+    "no": "0801",
+    "form": null,
+    "names": {
+      "ja": "マギアナ",
+      "en": "Magearna",
+      "ko": "마기아나",
+      "zh-Hans": "玛机雅娜",
+      "zh-Hant": "瑪機雅娜"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0801",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0802",
+    "no": "0802",
+    "form": null,
+    "names": {
+      "ja": "マーシャドー",
+      "en": "Marshadow",
+      "ko": "마샤도",
+      "zh-Hans": "玛夏多",
+      "zh-Hant": "瑪夏多"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0802",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0803",
+    "no": "0803",
+    "form": null,
+    "names": {
+      "ja": "ベベノム",
+      "en": "Poipole",
+      "ko": "베베놈",
+      "zh-Hans": "毒贝比",
+      "zh-Hant": "毒貝比"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0803",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0804",
+    "no": "0804",
+    "form": null,
+    "names": {
+      "ja": "アーゴヨン",
+      "en": "Naganadel",
+      "ko": "아고용",
+      "zh-Hans": "四颚针龙",
+      "zh-Hant": "四顎針龍"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0804",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0805",
+    "no": "0805",
+    "form": null,
+    "names": {
+      "ja": "ツンデツンデ",
+      "en": "Stakataka",
+      "ko": "차곡차곡",
+      "zh-Hans": "垒磊石",
+      "zh-Hant": "壘磊石"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0805",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0806",
+    "no": "0806",
+    "form": null,
+    "names": {
+      "ja": "ズガドーン",
+      "en": "Blacephalon",
+      "ko": "두파팡",
+      "zh-Hans": "砰头小丑",
+      "zh-Hant": "砰頭小丑"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0806",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0807",
+    "no": "0807",
+    "form": null,
+    "names": {
+      "ja": "ゼラオラ",
+      "en": "Zeraora",
+      "ko": "제라오라",
+      "zh-Hans": "捷拉奥拉",
+      "zh-Hant": "捷拉奧拉"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0807",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0808",
+    "no": "0808",
+    "form": null,
+    "names": {
+      "ja": "メルタン",
+      "en": "Meltan",
+      "ko": "멜탄",
+      "zh-Hans": "美录坦",
+      "zh-Hant": "美錄坦"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0808",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0809",
+    "no": "0809",
+    "form": null,
+    "names": {
+      "ja": "メルメタル",
+      "en": "Melmetal",
+      "ko": "멜메탈",
+      "zh-Hans": "美录梅塔",
+      "zh-Hant": "美錄梅塔"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0809",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0810",
+    "no": "0810",
+    "form": null,
+    "names": {
+      "ja": "サルノリ",
+      "en": "Grookey",
+      "ko": "흥나숭",
+      "zh-Hans": "敲音猴",
+      "zh-Hant": "敲音猴"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0810",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0811",
+    "no": "0811",
+    "form": null,
+    "names": {
+      "ja": "バチンキー",
+      "en": "Thwackey",
+      "ko": "채키몽",
+      "zh-Hans": "啪咚猴",
+      "zh-Hant": "啪咚猴"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0811",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0812",
+    "no": "0812",
+    "form": null,
+    "names": {
+      "ja": "ゴリランダー",
+      "en": "Rillaboom",
+      "ko": "고릴타",
+      "zh-Hans": "轰擂金刚猩",
+      "zh-Hant": "轟擂金剛猩"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0812",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0813",
+    "no": "0813",
+    "form": null,
+    "names": {
+      "ja": "ヒバニー",
+      "en": "Scorbunny",
+      "ko": "염버니",
+      "zh-Hans": "炎兔儿",
+      "zh-Hant": "炎兔兒"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0813",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0814",
+    "no": "0814",
+    "form": null,
+    "names": {
+      "ja": "ラビフット",
+      "en": "Raboot",
+      "ko": "래비풋",
+      "zh-Hans": "腾蹴小将",
+      "zh-Hant": "騰蹴小將"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0814",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0815",
+    "no": "0815",
+    "form": null,
+    "names": {
+      "ja": "エースバーン",
+      "en": "Cinderace",
+      "ko": "에이스번",
+      "zh-Hans": "闪焰王牌",
+      "zh-Hant": "閃焰王牌"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0815",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0816",
+    "no": "0816",
+    "form": null,
+    "names": {
+      "ja": "メッソン",
+      "en": "Sobble",
+      "ko": "울머기",
+      "zh-Hans": "泪眼蜥",
+      "zh-Hant": "淚眼蜥"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0816",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0817",
+    "no": "0817",
+    "form": null,
+    "names": {
+      "ja": "ジメレオン",
+      "en": "Drizzile",
+      "ko": "누겔레온",
+      "zh-Hans": "变涩蜥",
+      "zh-Hant": "變澀蜥"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0817",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0818",
+    "no": "0818",
+    "form": null,
+    "names": {
+      "ja": "インテレオン",
+      "en": "Inteleon",
+      "ko": "인텔리레온",
+      "zh-Hans": "千面避役",
+      "zh-Hant": "千面避役"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0818",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0819",
+    "no": "0819",
+    "form": null,
+    "names": {
+      "ja": "ホシガリス",
+      "en": "Skwovet",
+      "ko": "탐리스",
+      "zh-Hans": "贪心栗鼠",
+      "zh-Hant": "貪心栗鼠"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0819",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0820",
+    "no": "0820",
+    "form": null,
+    "names": {
+      "ja": "ヨクバリス",
+      "en": "Greedent",
+      "ko": "요씽리스",
+      "zh-Hans": "藏饱栗鼠",
+      "zh-Hant": "藏飽栗鼠"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0820",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0821",
+    "no": "0821",
+    "form": null,
+    "names": {
+      "ja": "ココガラ",
+      "en": "Rookidee",
+      "ko": "파라꼬",
+      "zh-Hans": "稚山雀",
+      "zh-Hant": "稚山雀"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0821",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0822",
+    "no": "0822",
+    "form": null,
+    "names": {
+      "ja": "アオガラス",
+      "en": "Corvisquire",
+      "ko": "파크로우",
+      "zh-Hans": "蓝鸦",
+      "zh-Hant": "藍鴉"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0822",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0823",
+    "no": "0823",
+    "form": null,
+    "names": {
+      "ja": "アーマーガア",
+      "en": "Corviknight",
+      "ko": "아머까오",
+      "zh-Hans": "钢铠鸦",
+      "zh-Hant": "鋼鎧鴉"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0823",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0824",
+    "no": "0824",
+    "form": null,
+    "names": {
+      "ja": "サッチムシ",
+      "en": "Blipbug",
+      "ko": "두루지벌레",
+      "zh-Hans": "索侦虫",
+      "zh-Hant": "索偵蟲"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0824",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0825",
+    "no": "0825",
+    "form": null,
+    "names": {
+      "ja": "レドームシ",
+      "en": "Dottler",
+      "ko": "레돔벌레",
+      "zh-Hans": "天罩虫",
+      "zh-Hant": "天罩蟲"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0825",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0826",
+    "no": "0826",
+    "form": null,
+    "names": {
+      "ja": "イオルブ",
+      "en": "Orbeetle",
+      "ko": "이올브",
+      "zh-Hans": "以欧路普",
+      "zh-Hant": "以歐路普"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0826",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0827",
+    "no": "0827",
+    "form": null,
+    "names": {
+      "ja": "クスネ",
+      "en": "Nickit",
+      "ko": "훔처우",
+      "zh-Hans": "狡小狐",
+      "zh-Hant": "偷兒狐"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0827",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0828",
+    "no": "0828",
+    "form": null,
+    "names": {
+      "ja": "フォクスライ",
+      "en": "Thievul",
+      "ko": "폭슬라이",
+      "zh-Hans": "猾大狐",
+      "zh-Hant": "狐大盜"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0828",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0829",
+    "no": "0829",
+    "form": null,
+    "names": {
+      "ja": "ヒメンカ",
+      "en": "Gossifleur",
+      "ko": "꼬모카",
+      "zh-Hans": "幼棉棉",
+      "zh-Hant": "幼棉棉"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0829",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0830",
+    "no": "0830",
+    "form": null,
+    "names": {
+      "ja": "ワタシラガ",
+      "en": "Eldegoss",
+      "ko": "백솜모카",
+      "zh-Hans": "白蓬蓬",
+      "zh-Hant": "白蓬蓬"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0830",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0831",
+    "no": "0831",
+    "form": null,
+    "names": {
+      "ja": "ウールー",
+      "en": "Wooloo",
+      "ko": "우르",
+      "zh-Hans": "毛辫羊",
+      "zh-Hant": "毛辮羊"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0831",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0832",
+    "no": "0832",
+    "form": null,
+    "names": {
+      "ja": "バイウールー",
+      "en": "Dubwool",
+      "ko": "배우르",
+      "zh-Hans": "毛毛角羊",
+      "zh-Hant": "毛毛角羊"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0832",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0833",
+    "no": "0833",
+    "form": null,
+    "names": {
+      "ja": "カムカメ",
+      "en": "Chewtle",
+      "ko": "깨물부기",
+      "zh-Hans": "咬咬龟",
+      "zh-Hant": "咬咬龜"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0833",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0834",
+    "no": "0834",
+    "form": null,
+    "names": {
+      "ja": "カジリガメ",
+      "en": "Drednaw",
+      "ko": "갈가부기",
+      "zh-Hans": "暴噬龟",
+      "zh-Hant": "暴噬龜"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0834",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0835",
+    "no": "0835",
+    "form": null,
+    "names": {
+      "ja": "ワンパチ",
+      "en": "Yamper",
+      "ko": "멍파치",
+      "zh-Hans": "来电汪",
+      "zh-Hant": "來電汪"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0835",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0836",
+    "no": "0836",
+    "form": null,
+    "names": {
+      "ja": "パルスワン",
+      "en": "Boltund",
+      "ko": "펄스멍",
+      "zh-Hans": "逐电犬",
+      "zh-Hant": "逐電犬"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0836",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0837",
+    "no": "0837",
+    "form": null,
+    "names": {
+      "ja": "タンドン",
+      "en": "Rolycoly",
+      "ko": "탄동",
+      "zh-Hans": "小炭仔",
+      "zh-Hant": "小炭仔"
+    },
+    "types": [
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0837",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0838",
+    "no": "0838",
+    "form": null,
+    "names": {
+      "ja": "トロッゴン",
+      "en": "Carkol",
+      "ko": "탄차곤",
+      "zh-Hans": "大炭车",
+      "zh-Hant": "大炭車"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0838",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0839",
+    "no": "0839",
+    "form": null,
+    "names": {
+      "ja": "セキタンザン",
+      "en": "Coalossal",
+      "ko": "석탄산",
+      "zh-Hans": "巨炭山",
+      "zh-Hant": "巨炭山"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0839",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0840",
+    "no": "0840",
+    "form": null,
+    "names": {
+      "ja": "カジッチュ",
+      "en": "Applin",
+      "ko": "과사삭벌레",
+      "zh-Hans": "啃果虫",
+      "zh-Hant": "啃果蟲"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0840",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0841",
+    "no": "0841",
+    "form": null,
+    "names": {
+      "ja": "アップリュー",
+      "en": "Flapple",
+      "ko": "애프룡",
+      "zh-Hans": "苹裹龙",
+      "zh-Hant": "蘋裹龍"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0841",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0842",
+    "no": "0842",
+    "form": null,
+    "names": {
+      "ja": "タルップル",
+      "en": "Appletun",
+      "ko": "단지래플",
+      "zh-Hans": "丰蜜龙",
+      "zh-Hant": "豐蜜龍"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0842",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0843",
+    "no": "0843",
+    "form": null,
+    "names": {
+      "ja": "スナヘビ",
+      "en": "Silicobra",
+      "ko": "모래뱀",
+      "zh-Hans": "沙包蛇",
+      "zh-Hant": "沙包蛇"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0843",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0844",
+    "no": "0844",
+    "form": null,
+    "names": {
+      "ja": "サダイジャ",
+      "en": "Sandaconda",
+      "ko": "사다이사",
+      "zh-Hans": "沙螺蟒",
+      "zh-Hant": "沙螺蟒"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0844",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0845",
+    "no": "0845",
+    "form": null,
+    "names": {
+      "ja": "ウッウ",
+      "en": "Cramorant",
+      "ko": "윽우지",
+      "zh-Hans": "古月鸟",
+      "zh-Hant": "古月鳥"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0845",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0846",
+    "no": "0846",
+    "form": null,
+    "names": {
+      "ja": "サシカマス",
+      "en": "Arrokuda",
+      "ko": "찌로꼬치",
+      "zh-Hans": "刺梭鱼",
+      "zh-Hant": "刺梭魚"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0846",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0847",
+    "no": "0847",
+    "form": null,
+    "names": {
+      "ja": "カマスジョー",
+      "en": "Barraskewda",
+      "ko": "꼬치조",
+      "zh-Hans": "戽斗尖梭",
+      "zh-Hant": "戽斗尖梭"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0847",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0848",
+    "no": "0848",
+    "form": null,
+    "names": {
+      "ja": "エレズン",
+      "en": "Toxel",
+      "ko": "일레즌",
+      "zh-Hans": "电音婴",
+      "zh-Hant": "毒電嬰"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0848",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0849",
+    "no": "0849",
+    "form": null,
+    "names": {
+      "ja": "ストリンダー",
+      "en": "Toxtricity",
+      "ko": "스트린더",
+      "zh-Hans": "颤弦蝾螈",
+      "zh-Hant": "顫弦蠑螈"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0849",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0850",
+    "no": "0850",
+    "form": null,
+    "names": {
+      "ja": "ヤクデ",
+      "en": "Sizzlipede",
+      "ko": "태우지네",
+      "zh-Hans": "烧火蚣",
+      "zh-Hant": "燒火蚣"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0850",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0851",
+    "no": "0851",
+    "form": null,
+    "names": {
+      "ja": "マルヤクデ",
+      "en": "Centiskorch",
+      "ko": "다태우지네",
+      "zh-Hans": "焚焰蚣",
+      "zh-Hant": "焚焰蚣"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0851",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0852",
+    "no": "0852",
+    "form": null,
+    "names": {
+      "ja": "タタッコ",
+      "en": "Clobbopus",
+      "ko": "때때무노",
+      "zh-Hans": "拳拳蛸",
+      "zh-Hant": "拳拳蛸"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0852",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0853",
+    "no": "0853",
+    "form": null,
+    "names": {
+      "ja": "オトスパス",
+      "en": "Grapploct",
+      "ko": "케오퍼스",
+      "zh-Hans": "八爪武师",
+      "zh-Hant": "八爪武師"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0853",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0854",
+    "no": "0854",
+    "form": null,
+    "names": {
+      "ja": "ヤバチャ",
+      "en": "Sinistea",
+      "ko": "데인차",
+      "zh-Hans": "来悲茶",
+      "zh-Hant": "來悲茶"
+    },
+    "types": [
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0854",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0855",
+    "no": "0855",
+    "form": null,
+    "names": {
+      "ja": "ポットデス",
+      "en": "Polteageist",
+      "ko": "포트데스",
+      "zh-Hans": "怖思壶",
+      "zh-Hant": "怖思壺"
+    },
+    "types": [
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0855",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0856",
+    "no": "0856",
+    "form": null,
+    "names": {
+      "ja": "ミブリム",
+      "en": "Hatenna",
+      "ko": "몸지브림",
+      "zh-Hans": "迷布莉姆",
+      "zh-Hant": "迷布莉姆"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0856",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0857",
+    "no": "0857",
+    "form": null,
+    "names": {
+      "ja": "テブリム",
+      "en": "Hattrem",
+      "ko": "손지브림",
+      "zh-Hans": "提布莉姆",
+      "zh-Hant": "提布莉姆"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0857",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0858",
+    "no": "0858",
+    "form": null,
+    "names": {
+      "ja": "ブリムオン",
+      "en": "Hatterene",
+      "ko": "브리무음",
+      "zh-Hans": "布莉姆温",
+      "zh-Hant": "布莉姆溫"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0858",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0859",
+    "no": "0859",
+    "form": null,
+    "names": {
+      "ja": "ベロバー",
+      "en": "Impidimp",
+      "ko": "메롱꿍",
+      "zh-Hans": "捣蛋小妖",
+      "zh-Hant": "搗蛋小妖"
+    },
+    "types": [
+      {
+        "ja": "あく",
+        "en": "Dark"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0859",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0860",
+    "no": "0860",
+    "form": null,
+    "names": {
+      "ja": "ギモー",
+      "en": "Morgrem",
+      "ko": "쏘겨모",
+      "zh-Hans": "诈唬魔",
+      "zh-Hant": "詐唬魔"
+    },
+    "types": [
+      {
+        "ja": "あく",
+        "en": "Dark"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0860",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0861",
+    "no": "0861",
+    "form": null,
+    "names": {
+      "ja": "オーロンゲ",
+      "en": "Grimmsnarl",
+      "ko": "오롱털",
+      "zh-Hans": "长毛巨魔",
+      "zh-Hant": "長毛巨魔"
+    },
+    "types": [
+      {
+        "ja": "あく",
+        "en": "Dark"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0861",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0862",
+    "no": "0862",
+    "form": null,
+    "names": {
+      "ja": "タチフサグマ",
+      "en": "Obstagoon",
+      "ko": "가로막구리",
+      "zh-Hans": "堵拦熊",
+      "zh-Hant": "堵攔熊"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0862",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0863",
+    "no": "0863",
+    "form": null,
+    "names": {
+      "ja": "ニャイキング",
+      "en": "Perrserker",
+      "ko": "나이킹",
+      "zh-Hans": "喵头目",
+      "zh-Hant": "喵頭目"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0863",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0864",
+    "no": "0864",
+    "form": null,
+    "names": {
+      "ja": "サニゴーン",
+      "en": "Cursola",
+      "ko": "산호르곤",
+      "zh-Hans": "魔灵珊瑚",
+      "zh-Hant": "魔靈珊瑚"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0864",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0865",
+    "no": "0865",
+    "form": null,
+    "names": {
+      "ja": "ネギガナイト",
+      "en": "Sirfetch’d",
+      "ko": "창파나이트",
+      "zh-Hans": "葱游兵",
+      "zh-Hant": "蔥遊兵"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0865",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0866",
+    "no": "0866",
+    "form": null,
+    "names": {
+      "ja": "バリコオル",
+      "en": "Mr. Rime",
+      "ko": "마임꽁꽁",
+      "zh-Hans": "踏冰人偶",
+      "zh-Hant": "踏冰人偶"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0866",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0867",
+    "no": "0867",
+    "form": null,
+    "names": {
+      "ja": "デスバーン",
+      "en": "Runerigus",
+      "ko": "데스판",
+      "zh-Hans": "迭失板",
+      "zh-Hant": "死神板"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0867",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0868",
+    "no": "0868",
+    "form": null,
+    "names": {
+      "ja": "マホミル",
+      "en": "Milcery",
+      "ko": "마빌크",
+      "zh-Hans": "小仙奶",
+      "zh-Hant": "小仙奶"
+    },
+    "types": [
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0868",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0869",
+    "no": "0869",
+    "form": null,
+    "names": {
+      "ja": "マホイップ",
+      "en": "Alcremie",
+      "ko": "마휘핑",
+      "zh-Hans": "霜奶仙",
+      "zh-Hant": "霜奶仙"
+    },
+    "types": [
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0869",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0870",
+    "no": "0870",
+    "form": null,
+    "names": {
+      "ja": "タイレーツ",
+      "en": "Falinks",
+      "ko": "대여르",
+      "zh-Hans": "列阵兵",
+      "zh-Hant": "列陣兵"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0870",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0871",
+    "no": "0871",
+    "form": null,
+    "names": {
+      "ja": "バチンウニ",
+      "en": "Pincurchin",
+      "ko": "찌르성게",
+      "zh-Hans": "啪嚓海胆",
+      "zh-Hant": "啪嚓海膽"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0871",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0872",
+    "no": "0872",
+    "form": null,
+    "names": {
+      "ja": "ユキハミ",
+      "en": "Snom",
+      "ko": "누니머기",
+      "zh-Hans": "雪吞虫",
+      "zh-Hant": "雪吞蟲"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0872",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0873",
+    "no": "0873",
+    "form": null,
+    "names": {
+      "ja": "モスノウ",
+      "en": "Frosmoth",
+      "ko": "모스노우",
+      "zh-Hans": "雪绒蛾",
+      "zh-Hant": "雪絨蛾"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0873",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0874",
+    "no": "0874",
+    "form": null,
+    "names": {
+      "ja": "イシヘンジン",
+      "en": "Stonjourner",
+      "ko": "돌헨진",
+      "zh-Hans": "巨石丁",
+      "zh-Hant": "巨石丁"
+    },
+    "types": [
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0874",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0875",
+    "no": "0875",
+    "form": null,
+    "names": {
+      "ja": "コオリッポ",
+      "en": "Eiscue",
+      "ko": "빙큐보",
+      "zh-Hans": "冰砌鹅",
+      "zh-Hant": "冰砌鵝"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0875",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0876",
+    "no": "0876",
+    "form": null,
+    "names": {
+      "ja": "イエッサン",
+      "en": "Indeedee",
+      "ko": "에써르",
+      "zh-Hans": "爱管侍",
+      "zh-Hant": "愛管侍"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0876",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0877",
+    "no": "0877",
+    "form": null,
+    "names": {
+      "ja": "モルペコ",
+      "en": "Morpeko",
+      "ko": "모르페코",
+      "zh-Hans": "莫鲁贝可",
+      "zh-Hant": "莫魯貝可"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0877",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0878",
+    "no": "0878",
+    "form": null,
+    "names": {
+      "ja": "ゾウドウ",
+      "en": "Cufant",
+      "ko": "끼리동",
+      "zh-Hans": "铜象",
+      "zh-Hant": "銅象"
+    },
+    "types": [
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0878",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0879",
+    "no": "0879",
+    "form": null,
+    "names": {
+      "ja": "ダイオウドウ",
+      "en": "Copperajah",
+      "ko": "대왕끼리동",
+      "zh-Hans": "大王铜象",
+      "zh-Hant": "大王銅象"
+    },
+    "types": [
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0879",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0880",
+    "no": "0880",
+    "form": null,
+    "names": {
+      "ja": "パッチラゴン",
+      "en": "Dracozolt",
+      "ko": "파치래곤",
+      "zh-Hans": "雷鸟龙",
+      "zh-Hant": "雷鳥龍"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0880",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0881",
+    "no": "0881",
+    "form": null,
+    "names": {
+      "ja": "パッチルドン",
+      "en": "Arctozolt",
+      "ko": "파치르돈",
+      "zh-Hans": "雷鸟海兽",
+      "zh-Hant": "雷鳥海獸"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0881",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0882",
+    "no": "0882",
+    "form": null,
+    "names": {
+      "ja": "ウオノラゴン",
+      "en": "Dracovish",
+      "ko": "어래곤",
+      "zh-Hans": "鳃鱼龙",
+      "zh-Hant": "鰓魚龍"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0882",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0883",
+    "no": "0883",
+    "form": null,
+    "names": {
+      "ja": "ウオチルドン",
+      "en": "Arctovish",
+      "ko": "어치르돈",
+      "zh-Hans": "鳃鱼海兽",
+      "zh-Hant": "鰓魚海獸"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0883",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0884",
+    "no": "0884",
+    "form": null,
+    "names": {
+      "ja": "ジュラルドン",
+      "en": "Duraludon",
+      "ko": "두랄루돈",
+      "zh-Hans": "铝钢龙",
+      "zh-Hant": "鋁鋼龍"
+    },
+    "types": [
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0884",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0885",
+    "no": "0885",
+    "form": null,
+    "names": {
+      "ja": "ドラメシヤ",
+      "en": "Dreepy",
+      "ko": "드라꼰",
+      "zh-Hans": "多龙梅西亚",
+      "zh-Hant": "多龍梅西亞"
+    },
+    "types": [
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0885",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0886",
+    "no": "0886",
+    "form": null,
+    "names": {
+      "ja": "ドロンチ",
+      "en": "Drakloak",
+      "ko": "드래런치",
+      "zh-Hans": "多龙奇",
+      "zh-Hant": "多龍奇"
+    },
+    "types": [
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0886",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0887",
+    "no": "0887",
+    "form": null,
+    "names": {
+      "ja": "ドラパルト",
+      "en": "Dragapult",
+      "ko": "드래펄트",
+      "zh-Hans": "多龙巴鲁托",
+      "zh-Hant": "多龍巴魯托"
+    },
+    "types": [
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0887",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0888",
+    "no": "0888",
+    "form": null,
+    "names": {
+      "ja": "ザシアン",
+      "en": "Zacian",
+      "ko": "자시안",
+      "zh-Hans": "苍响",
+      "zh-Hant": "蒼響"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0888",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0889",
+    "no": "0889",
+    "form": null,
+    "names": {
+      "ja": "ザマゼンタ",
+      "en": "Zamazenta",
+      "ko": "자마젠타",
+      "zh-Hans": "藏玛然特",
+      "zh-Hant": "藏瑪然特"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0889",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0890",
+    "no": "0890",
+    "form": null,
+    "names": {
+      "ja": "ムゲンダイナ",
+      "en": "Eternatus",
+      "ko": "무한다이노",
+      "zh-Hans": "无极汰那",
+      "zh-Hant": "無極汰那"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0890",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0891",
+    "no": "0891",
+    "form": null,
+    "names": {
+      "ja": "ダクマ",
+      "en": "Kubfu",
+      "ko": "치고마",
+      "zh-Hans": "熊徒弟",
+      "zh-Hant": "熊徒弟"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0891",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0892",
+    "no": "0892",
+    "form": null,
+    "names": {
+      "ja": "ウーラオス",
+      "en": "Urshifu",
+      "ko": "우라오스",
+      "zh-Hans": "武道熊师",
+      "zh-Hant": "武道熊師"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0892",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0893",
+    "no": "0893",
+    "form": null,
+    "names": {
+      "ja": "ザルード",
+      "en": "Zarude",
+      "ko": "자루도",
+      "zh-Hans": "萨戮德",
+      "zh-Hant": "薩戮德"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0893",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0894",
+    "no": "0894",
+    "form": null,
+    "names": {
+      "ja": "レジエレキ",
+      "en": "Regieleki",
+      "ko": "레지에레키",
+      "zh-Hans": "雷吉艾勒奇",
+      "zh-Hant": "雷吉艾勒奇"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0894",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0895",
+    "no": "0895",
+    "form": null,
+    "names": {
+      "ja": "レジドラゴ",
+      "en": "Regidrago",
+      "ko": "레지드래고",
+      "zh-Hans": "雷吉铎拉戈",
+      "zh-Hant": "雷吉鐸拉戈"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0895",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0896",
+    "no": "0896",
+    "form": null,
+    "names": {
+      "ja": "ブリザポス",
+      "en": "Glastrier",
+      "ko": "블리자포스",
+      "zh-Hans": "雪暴马",
+      "zh-Hant": "雪暴馬"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0896",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0897",
+    "no": "0897",
+    "form": null,
+    "names": {
+      "ja": "レイスポス",
+      "en": "Spectrier",
+      "ko": "레이스포스",
+      "zh-Hans": "灵幽马",
+      "zh-Hant": "靈幽馬"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0897",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0898",
+    "no": "0898",
+    "form": null,
+    "names": {
+      "ja": "バドレックス",
+      "en": "Calyrex",
+      "ko": "버드렉스",
+      "zh-Hans": "蕾冠王",
+      "zh-Hant": "蕾冠王"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0898",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0899",
+    "no": "0899",
+    "form": null,
+    "names": {
+      "ja": "アヤシシ",
+      "en": "Wyrdeer",
+      "ko": "신비록",
+      "zh-Hans": "诡角鹿",
+      "zh-Hant": "詭角鹿"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0899",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0900",
+    "no": "0900",
+    "form": null,
+    "names": {
+      "ja": "バサギリ",
+      "en": "Kleavor",
+      "ko": "사마자르",
+      "zh-Hans": "劈斧螳螂",
+      "zh-Hant": "劈斧螳螂"
+    },
+    "types": [
+      {
+        "ja": "むし",
+        "en": "Bug"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0900",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0901",
+    "no": "0901",
+    "form": null,
+    "names": {
+      "ja": "ガチグマ",
+      "en": "Ursaluna",
+      "ko": "다투곰",
+      "zh-Hans": "月月熊",
+      "zh-Hant": "月月熊"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0901",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0902",
+    "no": "0902",
+    "form": null,
+    "names": {
+      "ja": "イダイトウ",
+      "en": "Basculegion",
+      "ko": "대쓰여너",
+      "zh-Hans": "幽尾玄鱼",
+      "zh-Hant": "幽尾玄魚"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0902",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0903",
+    "no": "0903",
+    "form": null,
+    "names": {
+      "ja": "オオニューラ",
+      "en": "Sneasler",
+      "ko": "포푸니크",
+      "zh-Hans": "大狃拉",
+      "zh-Hant": "大狃拉"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0903",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0904",
+    "no": "0904",
+    "form": null,
+    "names": {
+      "ja": "ハリーマン",
+      "en": "Overqwil",
+      "ko": "장침바루",
+      "zh-Hans": "万针鱼",
+      "zh-Hant": "萬針魚"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0904",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0905",
+    "no": "0905",
+    "form": null,
+    "names": {
+      "ja": "ラブトロス",
+      "en": "Enamorus",
+      "ko": "러브로스",
+      "zh-Hans": "眷恋云",
+      "zh-Hant": "眷戀雲"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0905",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0906",
+    "no": "0906",
+    "form": null,
+    "names": {
+      "ja": "ニャオハ",
+      "en": "Sprigatito",
+      "ko": "나오하",
+      "zh-Hans": "新叶喵",
+      "zh-Hant": "新葉喵"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0906",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0907",
+    "no": "0907",
+    "form": null,
+    "names": {
+      "ja": "ニャローテ",
+      "en": "Floragato",
+      "ko": "나로테",
+      "zh-Hans": "蒂蕾喵",
+      "zh-Hant": "蒂蕾喵"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0907",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0908",
+    "no": "0908",
+    "form": null,
+    "names": {
+      "ja": "マスカーニャ",
+      "en": "Meowscarada",
+      "ko": "마스카나",
+      "zh-Hans": "魔幻假面喵",
+      "zh-Hant": "魔幻假面喵"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0908",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0909",
+    "no": "0909",
+    "form": null,
+    "names": {
+      "ja": "ホゲータ",
+      "en": "Fuecoco",
+      "ko": "뜨아거",
+      "zh-Hans": "呆火鳄",
+      "zh-Hant": "呆火鱷"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0909",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0910",
+    "no": "0910",
+    "form": null,
+    "names": {
+      "ja": "アチゲータ",
+      "en": "Crocalor",
+      "ko": "악뜨거",
+      "zh-Hans": "炙烫鳄",
+      "zh-Hant": "炙燙鱷"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0910",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0911",
+    "no": "0911",
+    "form": null,
+    "names": {
+      "ja": "ラウドボーン",
+      "en": "Skeledirge",
+      "ko": "라우드본",
+      "zh-Hans": "骨纹巨声鳄",
+      "zh-Hant": "骨紋巨聲鱷"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0911",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0912",
+    "no": "0912",
+    "form": null,
+    "names": {
+      "ja": "クワッス",
+      "en": "Quaxly",
+      "ko": "꾸왁스",
+      "zh-Hans": "润水鸭",
+      "zh-Hant": "潤水鴨"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0912",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0913",
+    "no": "0913",
+    "form": null,
+    "names": {
+      "ja": "ウェルカモ",
+      "en": "Quaxwell",
+      "ko": "아꾸왁",
+      "zh-Hans": "涌跃鸭",
+      "zh-Hant": "湧躍鴨"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0913",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0914",
+    "no": "0914",
+    "form": null,
+    "names": {
+      "ja": "ウェーニバル",
+      "en": "Quaquaval",
+      "ko": "웨이니발",
+      "zh-Hans": "狂欢浪舞鸭",
+      "zh-Hant": "狂歡浪舞鴨"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0914",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0915",
+    "no": "0915",
+    "form": null,
+    "names": {
+      "ja": "グルトン",
+      "en": "Lechonk",
+      "ko": "맛보돈",
+      "zh-Hans": "爱吃豚",
+      "zh-Hant": "愛吃豚"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0915",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0916",
+    "no": "0916",
+    "form": null,
+    "names": {
+      "ja": "パフュートン",
+      "en": "Oinkologne",
+      "ko": "퍼퓨돈",
+      "zh-Hans": "飘香豚",
+      "zh-Hant": "飄香豚"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0916",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0917",
+    "no": "0917",
+    "form": null,
+    "names": {
+      "ja": "タマンチュラ",
+      "en": "Tarountula",
+      "ko": "타랜툴라",
+      "zh-Hans": "团珠蛛",
+      "zh-Hant": "團珠蛛"
+    },
+    "types": [
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0917",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0918",
+    "no": "0918",
+    "form": null,
+    "names": {
+      "ja": "ワナイダー",
+      "en": "Spidops",
+      "ko": "트래피더",
+      "zh-Hans": "操陷蛛",
+      "zh-Hant": "操陷蛛"
+    },
+    "types": [
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0918",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0919",
+    "no": "0919",
+    "form": null,
+    "names": {
+      "ja": "マメバッタ",
+      "en": "Nymble",
+      "ko": "콩알뚜기",
+      "zh-Hans": "豆蟋蟀",
+      "zh-Hant": "豆蟋蟀"
+    },
+    "types": [
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0919",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0920",
+    "no": "0920",
+    "form": null,
+    "names": {
+      "ja": "エクスレッグ",
+      "en": "Lokix",
+      "ko": "엑스레그",
+      "zh-Hans": "烈腿蝗",
+      "zh-Hant": "烈腿蝗"
+    },
+    "types": [
+      {
+        "ja": "むし",
+        "en": "Bug"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0920",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0921",
+    "no": "0921",
+    "form": null,
+    "names": {
+      "ja": "パモ",
+      "en": "Pawmi",
+      "ko": "빠모",
+      "zh-Hans": "布拨",
+      "zh-Hant": "布撥"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0921",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0922",
+    "no": "0922",
+    "form": null,
+    "names": {
+      "ja": "パモット",
+      "en": "Pawmo",
+      "ko": "빠모트",
+      "zh-Hans": "布土拨",
+      "zh-Hant": "布土撥"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0922",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0923",
+    "no": "0923",
+    "form": null,
+    "names": {
+      "ja": "パーモット",
+      "en": "Pawmot",
+      "ko": "빠르모트",
+      "zh-Hans": "巴布土拨",
+      "zh-Hant": "巴布土撥"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0923",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0924",
+    "no": "0924",
+    "form": null,
+    "names": {
+      "ja": "ワッカネズミ",
+      "en": "Tandemaus",
+      "ko": "두리쥐",
+      "zh-Hans": "一对鼠",
+      "zh-Hant": "一對鼠"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0924",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0925",
+    "no": "0925",
+    "form": null,
+    "names": {
+      "ja": "イッカネズミ",
+      "en": "Maushold",
+      "ko": "파밀리쥐",
+      "zh-Hans": "一家鼠",
+      "zh-Hant": "一家鼠"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0925",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0926",
+    "no": "0926",
+    "form": null,
+    "names": {
+      "ja": "パピモッチ",
+      "en": "Fidough",
+      "ko": "쫀도기",
+      "zh-Hans": "狗仔包",
+      "zh-Hant": "狗仔包"
+    },
+    "types": [
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0926",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0927",
+    "no": "0927",
+    "form": null,
+    "names": {
+      "ja": "バウッツェル",
+      "en": "Dachsbun",
+      "ko": "바우첼",
+      "zh-Hans": "麻花犬",
+      "zh-Hant": "麻花犬"
+    },
+    "types": [
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0927",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0928",
+    "no": "0928",
+    "form": null,
+    "names": {
+      "ja": "ミニーブ",
+      "en": "Smoliv",
+      "ko": "미니브",
+      "zh-Hans": "迷你芙",
+      "zh-Hant": "迷你芙"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0928",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0929",
+    "no": "0929",
+    "form": null,
+    "names": {
+      "ja": "オリーニョ",
+      "en": "Dolliv",
+      "ko": "올리뇨",
+      "zh-Hans": "奥利纽",
+      "zh-Hant": "奧利紐"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0929",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0930",
+    "no": "0930",
+    "form": null,
+    "names": {
+      "ja": "オリーヴァ",
+      "en": "Arboliva",
+      "ko": "올리르바",
+      "zh-Hans": "奥利瓦",
+      "zh-Hant": "奧利瓦"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0930",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0931",
+    "no": "0931",
+    "form": null,
+    "names": {
+      "ja": "イキリンコ",
+      "en": "Squawkabilly",
+      "ko": "시비꼬",
+      "zh-Hans": "怒鹦哥",
+      "zh-Hant": "怒鸚哥"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0931",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0932",
+    "no": "0932",
+    "form": null,
+    "names": {
+      "ja": "コジオ",
+      "en": "Nacli",
+      "ko": "베베솔트",
+      "zh-Hans": "盐石宝",
+      "zh-Hant": "鹽石寶"
+    },
+    "types": [
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0932",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0933",
+    "no": "0933",
+    "form": null,
+    "names": {
+      "ja": "ジオヅム",
+      "en": "Naclstack",
+      "ko": "스태솔트",
+      "zh-Hans": "盐石垒",
+      "zh-Hant": "鹽石壘"
+    },
+    "types": [
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0933",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0934",
+    "no": "0934",
+    "form": null,
+    "names": {
+      "ja": "キョジオーン",
+      "en": "Garganacl",
+      "ko": "콜로솔트",
+      "zh-Hans": "盐石巨灵",
+      "zh-Hant": "鹽石巨靈"
+    },
+    "types": [
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0934",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0935",
+    "no": "0935",
+    "form": null,
+    "names": {
+      "ja": "カルボウ",
+      "en": "Charcadet",
+      "ko": "카르본",
+      "zh-Hans": "炭小侍",
+      "zh-Hant": "炭小侍"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0935",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0936",
+    "no": "0936",
+    "form": null,
+    "names": {
+      "ja": "グレンアルマ",
+      "en": "Armarouge",
+      "ko": "카디나르마",
+      "zh-Hans": "红莲铠骑",
+      "zh-Hant": "紅蓮鎧騎"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0936",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0937",
+    "no": "0937",
+    "form": null,
+    "names": {
+      "ja": "ソウブレイズ",
+      "en": "Ceruledge",
+      "ko": "파라블레이즈",
+      "zh-Hans": "苍炎刃鬼",
+      "zh-Hant": "蒼炎刃鬼"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0937",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0938",
+    "no": "0938",
+    "form": null,
+    "names": {
+      "ja": "ズピカ",
+      "en": "Tadbulb",
+      "ko": "빈나두",
+      "zh-Hans": "光蚪仔",
+      "zh-Hant": "光蚪仔"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0938",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0939",
+    "no": "0939",
+    "form": null,
+    "names": {
+      "ja": "ハラバリー",
+      "en": "Bellibolt",
+      "ko": "찌리배리",
+      "zh-Hans": "电肚蛙",
+      "zh-Hant": "電肚蛙"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0939",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0940",
+    "no": "0940",
+    "form": null,
+    "names": {
+      "ja": "カイデン",
+      "en": "Wattrel",
+      "ko": "찌리비",
+      "zh-Hans": "电海燕",
+      "zh-Hant": "電海燕"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0940",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0941",
+    "no": "0941",
+    "form": null,
+    "names": {
+      "ja": "タイカイデン",
+      "en": "Kilowattrel",
+      "ko": "찌리비크",
+      "zh-Hans": "大电海燕",
+      "zh-Hant": "大電海燕"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0941",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0942",
+    "no": "0942",
+    "form": null,
+    "names": {
+      "ja": "オラチフ",
+      "en": "Maschiff",
+      "ko": "오라티프",
+      "zh-Hans": "偶叫獒",
+      "zh-Hant": "偶叫獒"
+    },
+    "types": [
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0942",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0943",
+    "no": "0943",
+    "form": null,
+    "names": {
+      "ja": "マフィティフ",
+      "en": "Mabosstiff",
+      "ko": "마피티프",
+      "zh-Hans": "獒教父",
+      "zh-Hant": "獒教父"
+    },
+    "types": [
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0943",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0944",
+    "no": "0944",
+    "form": null,
+    "names": {
+      "ja": "シルシュルー",
+      "en": "Shroodle",
+      "ko": "땃쭈르",
+      "zh-Hans": "滋汁鼹",
+      "zh-Hant": "滋汁鼴"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0944",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0945",
+    "no": "0945",
+    "form": null,
+    "names": {
+      "ja": "タギングル",
+      "en": "Grafaiai",
+      "ko": "태깅구르",
+      "zh-Hans": "涂标客",
+      "zh-Hant": "塗標客"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0945",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0946",
+    "no": "0946",
+    "form": null,
+    "names": {
+      "ja": "アノクサ",
+      "en": "Bramblin",
+      "ko": "그푸리",
+      "zh-Hans": "纳噬草",
+      "zh-Hant": "納噬草"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0946",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0947",
+    "no": "0947",
+    "form": null,
+    "names": {
+      "ja": "アノホラグサ",
+      "en": "Brambleghast",
+      "ko": "공푸리",
+      "zh-Hans": "怖纳噬草",
+      "zh-Hant": "怖納噬草"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0947",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0948",
+    "no": "0948",
+    "form": null,
+    "names": {
+      "ja": "ノノクラゲ",
+      "en": "Toedscool",
+      "ko": "들눈해",
+      "zh-Hans": "原野水母",
+      "zh-Hant": "原野水母"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0948",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0949",
+    "no": "0949",
+    "form": null,
+    "names": {
+      "ja": "リククラゲ",
+      "en": "Toedscruel",
+      "ko": "육파리",
+      "zh-Hans": "陆地水母",
+      "zh-Hant": "陸地水母"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0949",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0950",
+    "no": "0950",
+    "form": null,
+    "names": {
+      "ja": "ガケガニ",
+      "en": "Klawf",
+      "ko": "절벼게",
+      "zh-Hans": "毛崖蟹",
+      "zh-Hant": "毛崖蟹"
+    },
+    "types": [
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0950",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0951",
+    "no": "0951",
+    "form": null,
+    "names": {
+      "ja": "カプサイジ",
+      "en": "Capsakid",
+      "ko": "캡싸이",
+      "zh-Hans": "热辣娃",
+      "zh-Hant": "熱辣娃"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0951",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0952",
+    "no": "0952",
+    "form": null,
+    "names": {
+      "ja": "スコヴィラン",
+      "en": "Scovillain",
+      "ko": "스코빌런",
+      "zh-Hans": "狠辣椒",
+      "zh-Hant": "狠辣椒"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0952",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0953",
+    "no": "0953",
+    "form": null,
+    "names": {
+      "ja": "シガロコ",
+      "en": "Rellor",
+      "ko": "구르데",
+      "zh-Hans": "虫滚泥",
+      "zh-Hant": "蟲滾泥"
+    },
+    "types": [
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0953",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0954",
+    "no": "0954",
+    "form": null,
+    "names": {
+      "ja": "ベラカス",
+      "en": "Rabsca",
+      "ko": "베라카스",
+      "zh-Hans": "虫甲圣",
+      "zh-Hant": "蟲甲聖"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0954",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0955",
+    "no": "0955",
+    "form": null,
+    "names": {
+      "ja": "ヒラヒナ",
+      "en": "Flittle",
+      "ko": "하느라기",
+      "zh-Hans": "飘飘雏",
+      "zh-Hant": "飄飄雛"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0955",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0956",
+    "no": "0956",
+    "form": null,
+    "names": {
+      "ja": "クエスパトラ",
+      "en": "Espathra",
+      "ko": "클레스퍼트라",
+      "zh-Hans": "超能艳鸵",
+      "zh-Hant": "超能豔鴕"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0956",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0957",
+    "no": "0957",
+    "form": null,
+    "names": {
+      "ja": "カヌチャン",
+      "en": "Tinkatink",
+      "ko": "어리짱",
+      "zh-Hans": "小锻匠",
+      "zh-Hant": "小鍛匠"
+    },
+    "types": [
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0957",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0958",
+    "no": "0958",
+    "form": null,
+    "names": {
+      "ja": "ナカヌチャン",
+      "en": "Tinkatuff",
+      "ko": "벼리짱",
+      "zh-Hans": "巧锻匠",
+      "zh-Hant": "巧鍛匠"
+    },
+    "types": [
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0958",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0959",
+    "no": "0959",
+    "form": null,
+    "names": {
+      "ja": "デカヌチャン",
+      "en": "Tinkaton",
+      "ko": "두드리짱",
+      "zh-Hans": "巨锻匠",
+      "zh-Hant": "巨鍛匠"
+    },
+    "types": [
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0959",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0960",
+    "no": "0960",
+    "form": null,
+    "names": {
+      "ja": "ウミディグダ",
+      "en": "Wiglett",
+      "ko": "바다그다",
+      "zh-Hans": "海地鼠",
+      "zh-Hant": "海地鼠"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0960",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0961",
+    "no": "0961",
+    "form": null,
+    "names": {
+      "ja": "ウミトリオ",
+      "en": "Wugtrio",
+      "ko": "바닥트리오",
+      "zh-Hans": "三海地鼠",
+      "zh-Hant": "三海地鼠"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0961",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0962",
+    "no": "0962",
+    "form": null,
+    "names": {
+      "ja": "オトシドリ",
+      "en": "Bombirdier",
+      "ko": "떨구새",
+      "zh-Hans": "下石鸟",
+      "zh-Hant": "下石鳥"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0962",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0963",
+    "no": "0963",
+    "form": null,
+    "names": {
+      "ja": "ナミイルカ",
+      "en": "Finizen",
+      "ko": "맨돌핀",
+      "zh-Hans": "波普海豚",
+      "zh-Hant": "波普海豚"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0963",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0964",
+    "no": "0964",
+    "form": null,
+    "names": {
+      "ja": "イルカマン",
+      "en": "Palafin",
+      "ko": "돌핀맨",
+      "zh-Hans": "海豚侠",
+      "zh-Hant": "海豚俠"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0964",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0965",
+    "no": "0965",
+    "form": null,
+    "names": {
+      "ja": "ブロロン",
+      "en": "Varoom",
+      "ko": "부르롱",
+      "zh-Hans": "噗隆隆",
+      "zh-Hant": "噗隆隆"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0965",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0966",
+    "no": "0966",
+    "form": null,
+    "names": {
+      "ja": "ブロロローム",
+      "en": "Revavroom",
+      "ko": "부르르룸",
+      "zh-Hans": "普隆隆姆",
+      "zh-Hant": "普隆隆姆"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0966",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0967",
+    "no": "0967",
+    "form": null,
+    "names": {
+      "ja": "モトトカゲ",
+      "en": "Cyclizar",
+      "ko": "모토마",
+      "zh-Hans": "摩托蜥",
+      "zh-Hant": "摩托蜥"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0967",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0968",
+    "no": "0968",
+    "form": null,
+    "names": {
+      "ja": "ミミズズ",
+      "en": "Orthworm",
+      "ko": "꿈트렁",
+      "zh-Hans": "拖拖蚓",
+      "zh-Hant": "拖拖蚓"
+    },
+    "types": [
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0968",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0969",
+    "no": "0969",
+    "form": null,
+    "names": {
+      "ja": "キラーメ",
+      "en": "Glimmet",
+      "ko": "초롱순",
+      "zh-Hans": "晶光芽",
+      "zh-Hant": "晶光芽"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0969",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0970",
+    "no": "0970",
+    "form": null,
+    "names": {
+      "ja": "キラフロル",
+      "en": "Glimmora",
+      "ko": "킬라플로르",
+      "zh-Hans": "晶光花",
+      "zh-Hant": "晶光花"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0970",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0971",
+    "no": "0971",
+    "form": null,
+    "names": {
+      "ja": "ボチ",
+      "en": "Greavard",
+      "ko": "망망이",
+      "zh-Hans": "墓仔狗",
+      "zh-Hant": "墓仔狗"
+    },
+    "types": [
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0971",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0972",
+    "no": "0972",
+    "form": null,
+    "names": {
+      "ja": "ハカドッグ",
+      "en": "Houndstone",
+      "ko": "묘두기",
+      "zh-Hans": "墓扬犬",
+      "zh-Hant": "墓揚犬"
+    },
+    "types": [
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0972",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0973",
+    "no": "0973",
+    "form": null,
+    "names": {
+      "ja": "カラミンゴ",
+      "en": "Flamigo",
+      "ko": "꼬이밍고",
+      "zh-Hans": "缠红鹤",
+      "zh-Hant": "纏紅鶴"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0973",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0974",
+    "no": "0974",
+    "form": null,
+    "names": {
+      "ja": "アルクジラ",
+      "en": "Cetoddle",
+      "ko": "터벅고래",
+      "zh-Hans": "走鲸",
+      "zh-Hant": "走鯨"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0974",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0975",
+    "no": "0975",
+    "form": null,
+    "names": {
+      "ja": "ハルクジラ",
+      "en": "Cetitan",
+      "ko": "우락고래",
+      "zh-Hans": "浩大鲸",
+      "zh-Hant": "浩大鯨"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0975",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0976",
+    "no": "0976",
+    "form": null,
+    "names": {
+      "ja": "ミガルーサ",
+      "en": "Veluza",
+      "ko": "가비루사",
+      "zh-Hans": "轻身鳕",
+      "zh-Hant": "輕身鱈"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0976",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0977",
+    "no": "0977",
+    "form": null,
+    "names": {
+      "ja": "ヘイラッシャ",
+      "en": "Dondozo",
+      "ko": "어써러셔",
+      "zh-Hans": "吃吼霸",
+      "zh-Hant": "吃吼霸"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0977",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0978",
+    "no": "0978",
+    "form": null,
+    "names": {
+      "ja": "シャリタツ",
+      "en": "Tatsugiri",
+      "ko": "싸리용",
+      "zh-Hans": "米立龙",
+      "zh-Hant": "米立龍"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0978",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0979",
+    "no": "0979",
+    "form": null,
+    "names": {
+      "ja": "コノヨザル",
+      "en": "Annihilape",
+      "ko": "저승갓숭",
+      "zh-Hans": "弃世猴",
+      "zh-Hant": "棄世猴"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0979",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0980",
+    "no": "0980",
+    "form": null,
+    "names": {
+      "ja": "ドオー",
+      "en": "Clodsire",
+      "ko": "토오",
+      "zh-Hans": "土王",
+      "zh-Hant": "土王"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0980",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0981",
+    "no": "0981",
+    "form": null,
+    "names": {
+      "ja": "リキキリン",
+      "en": "Farigiraf",
+      "ko": "키키링",
+      "zh-Hans": "奇麒麟",
+      "zh-Hant": "奇麒麟"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0981",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0982",
+    "no": "0982",
+    "form": null,
+    "names": {
+      "ja": "ノココッチ",
+      "en": "Dudunsparce",
+      "ko": "노고고치",
+      "zh-Hans": "土龙节节",
+      "zh-Hant": "土龍節節"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0982",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0983",
+    "no": "0983",
+    "form": null,
+    "names": {
+      "ja": "ドドゲザン",
+      "en": "Kingambit",
+      "ko": "대도각참",
+      "zh-Hans": "仆刀将军",
+      "zh-Hant": "仆斬將軍"
+    },
+    "types": [
+      {
+        "ja": "あく",
+        "en": "Dark"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0983",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0984",
+    "no": "0984",
+    "form": null,
+    "names": {
+      "ja": "イダイナキバ",
+      "en": "Great Tusk",
+      "ko": "위대한엄니",
+      "zh-Hans": "雄伟牙",
+      "zh-Hant": "雄偉牙"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      },
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0984",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0985",
+    "no": "0985",
+    "form": null,
+    "names": {
+      "ja": "サケブシッポ",
+      "en": "Scream Tail",
+      "ko": "우렁찬꼬리",
+      "zh-Hans": "吼叫尾",
+      "zh-Hant": "吼叫尾"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0985",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0986",
+    "no": "0986",
+    "form": null,
+    "names": {
+      "ja": "アラブルタケ",
+      "en": "Brute Bonnet",
+      "ko": "사나운버섯",
+      "zh-Hans": "猛恶菇",
+      "zh-Hant": "猛惡菇"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0986",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0987",
+    "no": "0987",
+    "form": null,
+    "names": {
+      "ja": "ハバタクカミ",
+      "en": "Flutter Mane",
+      "ko": "날개치는머리",
+      "zh-Hans": "振翼发",
+      "zh-Hant": "振翼髮"
+    },
+    "types": [
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0987",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0988",
+    "no": "0988",
+    "form": null,
+    "names": {
+      "ja": "チヲハウハネ",
+      "en": "Slither Wing",
+      "ko": "땅을기는날개",
+      "zh-Hans": "爬地翅",
+      "zh-Hant": "爬地翅"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0988",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0989",
+    "no": "0989",
+    "form": null,
+    "names": {
+      "ja": "スナノケガワ",
+      "en": "Sandy Shocks",
+      "ko": "모래털가죽",
+      "zh-Hans": "沙铁皮",
+      "zh-Hant": "沙鐵皮"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0989",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0990",
+    "no": "0990",
+    "form": null,
+    "names": {
+      "ja": "テツノワダチ",
+      "en": "Iron Treads",
+      "ko": "무쇠바퀴",
+      "zh-Hans": "铁辙迹",
+      "zh-Hant": "鐵轍跡"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0990",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0991",
+    "no": "0991",
+    "form": null,
+    "names": {
+      "ja": "テツノツツミ",
+      "en": "Iron Bundle",
+      "ko": "무쇠보따리",
+      "zh-Hans": "铁包袱",
+      "zh-Hant": "鐵包袱"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0991",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0992",
+    "no": "0992",
+    "form": null,
+    "names": {
+      "ja": "テツノカイナ",
+      "en": "Iron Hands",
+      "ko": "무쇠손",
+      "zh-Hans": "铁臂膀",
+      "zh-Hant": "鐵臂膀"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0992",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0993",
+    "no": "0993",
+    "form": null,
+    "names": {
+      "ja": "テツノコウベ",
+      "en": "Iron Jugulis",
+      "ko": "무쇠머리",
+      "zh-Hans": "铁脖颈",
+      "zh-Hant": "鐵脖頸"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0993",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0994",
+    "no": "0994",
+    "form": null,
+    "names": {
+      "ja": "テツノドクガ",
+      "en": "Iron Moth",
+      "ko": "무쇠독나방",
+      "zh-Hans": "铁毒蛾",
+      "zh-Hant": "鐵毒蛾"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0994",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0995",
+    "no": "0995",
+    "form": null,
+    "names": {
+      "ja": "テツノイバラ",
+      "en": "Iron Thorns",
+      "ko": "무쇠가시",
+      "zh-Hans": "铁荆棘",
+      "zh-Hant": "鐵荊棘"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0995",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0996",
+    "no": "0996",
+    "form": null,
+    "names": {
+      "ja": "セビエ",
+      "en": "Frigibax",
+      "ko": "드니차",
+      "zh-Hans": "凉脊龙",
+      "zh-Hant": "涼脊龍"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0996",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0997",
+    "no": "0997",
+    "form": null,
+    "names": {
+      "ja": "セゴール",
+      "en": "Arctibax",
+      "ko": "드니꽁",
+      "zh-Hans": "冻脊龙",
+      "zh-Hant": "凍脊龍"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0997",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0998",
+    "no": "0998",
+    "form": null,
+    "names": {
+      "ja": "セグレイブ",
+      "en": "Baxcalibur",
+      "ko": "드닐레이브",
+      "zh-Hans": "戟脊龙",
+      "zh-Hant": "戟脊龍"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0998",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0999",
+    "no": "0999",
+    "form": null,
+    "names": {
+      "ja": "コレクレー",
+      "en": "Gimmighoul",
+      "ko": "모으령",
+      "zh-Hans": "索财灵",
+      "zh-Hant": "索財靈"
+    },
+    "types": [
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0999",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1000",
+    "no": "1000",
+    "form": null,
+    "names": {
+      "ja": "サーフゴー",
+      "en": "Gholdengo",
+      "ko": "타부자고",
+      "zh-Hans": "赛富豪",
+      "zh-Hant": "賽富豪"
+    },
+    "types": [
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1000",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1001",
+    "no": "1001",
+    "form": null,
+    "names": {
+      "ja": "チオンジェン",
+      "en": "Wo-Chien",
+      "ko": "총지엔",
+      "zh-Hans": "古简蜗",
+      "zh-Hant": "古簡蝸"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1001",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1002",
+    "no": "1002",
+    "form": null,
+    "names": {
+      "ja": "パオジアン",
+      "en": "Chien-Pao",
+      "ko": "파오젠",
+      "zh-Hans": "古剑豹",
+      "zh-Hant": "古劍豹"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1002",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1003",
+    "no": "1003",
+    "form": null,
+    "names": {
+      "ja": "ディンルー",
+      "en": "Ting-Lu",
+      "ko": "딩루",
+      "zh-Hans": "古鼎鹿",
+      "zh-Hant": "古鼎鹿"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1003",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1004",
+    "no": "1004",
+    "form": null,
+    "names": {
+      "ja": "イーユイ",
+      "en": "Chi-Yu",
+      "ko": "위유이",
+      "zh-Hans": "古玉鱼",
+      "zh-Hant": "古玉魚"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1004",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1005",
+    "no": "1005",
+    "form": null,
+    "names": {
+      "ja": "トドロクツキ",
+      "en": "Roaring Moon",
+      "ko": "고동치는달",
+      "zh-Hans": "轰鸣月",
+      "zh-Hant": "轟鳴月"
+    },
+    "types": [
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1005",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1006",
+    "no": "1006",
+    "form": null,
+    "names": {
+      "ja": "テツノブジン",
+      "en": "Iron Valiant",
+      "ko": "무쇠무인",
+      "zh-Hans": "铁武者",
+      "zh-Hant": "鐵武者"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1006",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1007",
+    "no": "1007",
+    "form": null,
+    "names": {
+      "ja": "コライドン",
+      "en": "Koraidon",
+      "ko": "코라이돈",
+      "zh-Hans": "故勒顿",
+      "zh-Hant": "故勒頓"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1007",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1008",
+    "no": "1008",
+    "form": null,
+    "names": {
+      "ja": "ミライドン",
+      "en": "Miraidon",
+      "ko": "미라이돈",
+      "zh-Hans": "密勒顿",
+      "zh-Hant": "密勒頓"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1008",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1009",
+    "no": "1009",
+    "form": null,
+    "names": {
+      "ja": "ウネルミナモ",
+      "en": "Walking Wake",
+      "ko": "굽이치는물결",
+      "zh-Hans": "波荡水",
+      "zh-Hant": "波盪水"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1009",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1010",
+    "no": "1010",
+    "form": null,
+    "names": {
+      "ja": "テツノイサハ",
+      "en": "Iron Leaves",
+      "ko": "무쇠잎새",
+      "zh-Hans": "铁斑叶",
+      "zh-Hant": "鐵斑葉"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1010",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1011",
+    "no": "1011",
+    "form": null,
+    "names": {
+      "ja": "カミッチュ",
+      "en": "Dipplin",
+      "ko": "과미르",
+      "zh-Hans": "裹蜜虫",
+      "zh-Hant": "裹蜜蟲"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1011",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1012",
+    "no": "1012",
+    "form": null,
+    "names": {
+      "ja": "チャデス",
+      "en": "Poltchageist",
+      "ko": "차데스",
+      "zh-Hans": "斯魔茶",
+      "zh-Hant": "斯魔茶"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1012",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1013",
+    "no": "1013",
+    "form": null,
+    "names": {
+      "ja": "ヤバソチャ",
+      "en": "Sinistcha",
+      "ko": "그우린차",
+      "zh-Hans": "来悲粗茶",
+      "zh-Hant": "來悲粗茶"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1013",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1014",
+    "no": "1014",
+    "form": null,
+    "names": {
+      "ja": "イイネイヌ",
+      "en": "Okidogi",
+      "ko": "조타구",
+      "zh-Hans": "够赞狗",
+      "zh-Hant": "夠讚狗"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1014",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1015",
+    "no": "1015",
+    "form": null,
+    "names": {
+      "ja": "マシマシラ",
+      "en": "Munkidori",
+      "ko": "이야후",
+      "zh-Hans": "愿增猿",
+      "zh-Hant": "願增猿"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1015",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1016",
+    "no": "1016",
+    "form": null,
+    "names": {
+      "ja": "キチキギス",
+      "en": "Fezandipiti",
+      "ko": "기로치",
+      "zh-Hans": "吉雉鸡",
+      "zh-Hant": "吉雉雞"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1016",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1017",
+    "no": "1017",
+    "form": null,
+    "names": {
+      "ja": "オーガポン",
+      "en": "Ogerpon",
+      "ko": "오거폰",
+      "zh-Hans": "厄诡椪",
+      "zh-Hant": "厄鬼椪"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1017",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1018",
+    "no": "1018",
+    "form": null,
+    "names": {
+      "ja": "ブリジュラス",
+      "en": "Archaludon",
+      "ko": "브리두라스",
+      "zh-Hans": "铝钢桥龙",
+      "zh-Hant": "鋁鋼橋龍"
+    },
+    "types": [
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1018",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1019",
+    "no": "1019",
+    "form": null,
+    "names": {
+      "ja": "カミツオロチ",
+      "en": "Hydrapple",
+      "ko": "과미드라",
+      "zh-Hans": "蜜集大蛇",
+      "zh-Hant": "蜜集大蛇"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1019",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1020",
+    "no": "1020",
+    "form": null,
+    "names": {
+      "ja": "ウガツホムラ",
+      "en": "Gouging Fire",
+      "ko": "꿰뚫는화염",
+      "zh-Hans": "破空焰",
+      "zh-Hant": "破空焰"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1020",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1021",
+    "no": "1021",
+    "form": null,
+    "names": {
+      "ja": "タケルライコ",
+      "en": "Raging Bolt",
+      "ko": "날뛰는우레",
+      "zh-Hans": "猛雷鼓",
+      "zh-Hant": "猛雷鼓"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1021",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1022",
+    "no": "1022",
+    "form": null,
+    "names": {
+      "ja": "テツノイワオ",
+      "en": "Iron Boulder",
+      "ko": "무쇠암석",
+      "zh-Hans": "铁磐岩",
+      "zh-Hant": "鐵磐岩"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1022",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1023",
+    "no": "1023",
+    "form": null,
+    "names": {
+      "ja": "テツノカシラ",
+      "en": "Iron Crown",
+      "ko": "무쇠감투",
+      "zh-Hans": "铁头壳",
+      "zh-Hant": "鐵頭殼"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1023",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1024",
+    "no": "1024",
+    "form": null,
+    "names": {
+      "ja": "テラパゴス",
+      "en": "Terapagos",
+      "ko": "테라파고스",
+      "zh-Hans": "太乐巴戈斯",
+      "zh-Hant": "太樂巴戈斯"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1024",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1025",
+    "no": "1025",
+    "form": null,
+    "names": {
+      "ja": "モモワロウ",
+      "en": "Pecharunt",
+      "ko": "복숭악동",
+      "zh-Hans": "桃歹郎",
+      "zh-Hant": "桃歹郎"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1025",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  }
+]

--- a/docs/pokemon_metadata.json
+++ b/docs/pokemon_metadata.json
@@ -1,0 +1,26561 @@
+[
+  {
+    "id": "0001",
+    "no": "0001",
+    "form": null,
+    "names": {
+      "ja": "フシギダネ",
+      "en": "Bulbasaur",
+      "ko": "이상해씨",
+      "zh-Hans": "妙蛙种子",
+      "zh-Hant": "妙蛙種子"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0001",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0002",
+    "no": "0002",
+    "form": null,
+    "names": {
+      "ja": "フシギソウ",
+      "en": "Ivysaur",
+      "ko": "이상해풀",
+      "zh-Hans": "妙蛙草",
+      "zh-Hant": "妙蛙草"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0002",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0003",
+    "no": "0003",
+    "form": null,
+    "names": {
+      "ja": "フシギバナ",
+      "en": "Venusaur",
+      "ko": "이상해꽃",
+      "zh-Hans": "妙蛙花",
+      "zh-Hant": "妙蛙花"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0003",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0004",
+    "no": "0004",
+    "form": null,
+    "names": {
+      "ja": "ヒトカゲ",
+      "en": "Charmander",
+      "ko": "파이리",
+      "zh-Hans": "小火龙",
+      "zh-Hant": "小火龍"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0004",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0005",
+    "no": "0005",
+    "form": null,
+    "names": {
+      "ja": "リザード",
+      "en": "Charmeleon",
+      "ko": "리자드",
+      "zh-Hans": "火恐龙",
+      "zh-Hant": "火恐龍"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0005",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0006",
+    "no": "0006",
+    "form": null,
+    "names": {
+      "ja": "リザードン",
+      "en": "Charizard",
+      "ko": "리자몽",
+      "zh-Hans": "喷火龙",
+      "zh-Hant": "噴火龍"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0006",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0007",
+    "no": "0007",
+    "form": null,
+    "names": {
+      "ja": "ゼニガメ",
+      "en": "Squirtle",
+      "ko": "꼬부기",
+      "zh-Hans": "杰尼龟",
+      "zh-Hant": "傑尼龜"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0007",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0008",
+    "no": "0008",
+    "form": null,
+    "names": {
+      "ja": "カメール",
+      "en": "Wartortle",
+      "ko": "어니부기",
+      "zh-Hans": "卡咪龟",
+      "zh-Hant": "卡咪龜"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0008",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0009",
+    "no": "0009",
+    "form": null,
+    "names": {
+      "ja": "カメックス",
+      "en": "Blastoise",
+      "ko": "거북왕",
+      "zh-Hans": "水箭龟",
+      "zh-Hant": "水箭龜"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0009",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0010",
+    "no": "0010",
+    "form": null,
+    "names": {
+      "ja": "キャタピー",
+      "en": "Caterpie",
+      "ko": "캐터피",
+      "zh-Hans": "绿毛虫",
+      "zh-Hant": "綠毛蟲"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0010",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0011",
+    "no": "0011",
+    "form": null,
+    "names": {
+      "ja": "トランセル",
+      "en": "Metapod",
+      "ko": "단데기",
+      "zh-Hans": "铁甲蛹",
+      "zh-Hant": "鐵甲蛹"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0011",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0012",
+    "no": "0012",
+    "form": null,
+    "names": {
+      "ja": "バタフリー",
+      "en": "Butterfree",
+      "ko": "버터플",
+      "zh-Hans": "巴大蝶",
+      "zh-Hant": "巴大蝶"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0012",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0013",
+    "no": "0013",
+    "form": null,
+    "names": {
+      "ja": "ビードル",
+      "en": "Weedle",
+      "ko": "뿔충이",
+      "zh-Hans": "独角虫",
+      "zh-Hant": "獨角蟲"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0013",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0014",
+    "no": "0014",
+    "form": null,
+    "names": {
+      "ja": "コクーン",
+      "en": "Kakuna",
+      "ko": "딱충이",
+      "zh-Hans": "铁壳蛹",
+      "zh-Hant": "鐵殼蛹"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0014",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0015",
+    "no": "0015",
+    "form": null,
+    "names": {
+      "ja": "スピアー",
+      "en": "Beedrill",
+      "ko": "독침붕",
+      "zh-Hans": "大针蜂",
+      "zh-Hant": "大針蜂"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0015",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0016",
+    "no": "0016",
+    "form": null,
+    "names": {
+      "ja": "ポッポ",
+      "en": "Pidgey",
+      "ko": "구구",
+      "zh-Hans": "波波",
+      "zh-Hant": "波波"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0016",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0017",
+    "no": "0017",
+    "form": null,
+    "names": {
+      "ja": "ピジョン",
+      "en": "Pidgeotto",
+      "ko": "피죤",
+      "zh-Hans": "比比鸟",
+      "zh-Hant": "比比鳥"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0017",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0018",
+    "no": "0018",
+    "form": null,
+    "names": {
+      "ja": "ピジョット",
+      "en": "Pidgeot",
+      "ko": "피죤투",
+      "zh-Hans": "大比鸟",
+      "zh-Hant": "大比鳥"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0018",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0019",
+    "no": "0019",
+    "form": null,
+    "names": {
+      "ja": "コラッタ",
+      "en": "Rattata",
+      "ko": "꼬렛",
+      "zh-Hans": "小拉达",
+      "zh-Hant": "小拉達"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0019",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0019-alola",
+    "no": "0019",
+    "form": "alola",
+    "names": {
+      "ja": "コラッタ",
+      "en": "Rattata",
+      "ko": "꼬렛",
+      "zh-Hans": "小拉达",
+      "zh-Hant": "小拉達"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0019-alola",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0020",
+    "no": "0020",
+    "form": null,
+    "names": {
+      "ja": "ラッタ",
+      "en": "Raticate",
+      "ko": "레트라",
+      "zh-Hans": "拉达",
+      "zh-Hant": "拉達"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0020",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0020-alola",
+    "no": "0020",
+    "form": "alola",
+    "names": {
+      "ja": "ラッタ",
+      "en": "Raticate",
+      "ko": "레트라",
+      "zh-Hans": "拉达",
+      "zh-Hant": "拉達"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0020-alola",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0021",
+    "no": "0021",
+    "form": null,
+    "names": {
+      "ja": "オニスズメ",
+      "en": "Spearow",
+      "ko": "깨비참",
+      "zh-Hans": "烈雀",
+      "zh-Hant": "烈雀"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0021",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0022",
+    "no": "0022",
+    "form": null,
+    "names": {
+      "ja": "オニドリル",
+      "en": "Fearow",
+      "ko": "깨비드릴조",
+      "zh-Hans": "大嘴雀",
+      "zh-Hant": "大嘴雀"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0022",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0023",
+    "no": "0023",
+    "form": null,
+    "names": {
+      "ja": "アーボ",
+      "en": "Ekans",
+      "ko": "아보",
+      "zh-Hans": "阿柏蛇",
+      "zh-Hant": "阿柏蛇"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0023",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0024",
+    "no": "0024",
+    "form": null,
+    "names": {
+      "ja": "アーボック",
+      "en": "Arbok",
+      "ko": "아보크",
+      "zh-Hans": "阿柏怪",
+      "zh-Hant": "阿柏怪"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0024",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0025",
+    "no": "0025",
+    "form": null,
+    "names": {
+      "ja": "ピカチュウ",
+      "en": "Pikachu",
+      "ko": "피카츄",
+      "zh-Hans": "皮卡丘",
+      "zh-Hant": "皮卡丘"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0025",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0025-alola",
+    "no": "0025",
+    "form": "alola",
+    "names": {
+      "ja": "ピカチュウ",
+      "en": "Pikachu",
+      "ko": "피카츄",
+      "zh-Hans": "皮卡丘",
+      "zh-Hant": "皮卡丘"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0025-alola",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0026",
+    "no": "0026",
+    "form": null,
+    "names": {
+      "ja": "ライチュウ",
+      "en": "Raichu",
+      "ko": "라이츄",
+      "zh-Hans": "雷丘",
+      "zh-Hant": "雷丘"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0026",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0026-alola",
+    "no": "0026",
+    "form": "alola",
+    "names": {
+      "ja": "ライチュウ",
+      "en": "Raichu",
+      "ko": "라이츄",
+      "zh-Hans": "雷丘",
+      "zh-Hant": "雷丘"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0026-alola",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0027",
+    "no": "0027",
+    "form": null,
+    "names": {
+      "ja": "サンド",
+      "en": "Sandshrew",
+      "ko": "모래두지",
+      "zh-Hans": "穿山鼠",
+      "zh-Hant": "穿山鼠"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0027",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0027-alola",
+    "no": "0027",
+    "form": "alola",
+    "names": {
+      "ja": "サンド",
+      "en": "Sandshrew",
+      "ko": "모래두지",
+      "zh-Hans": "穿山鼠",
+      "zh-Hant": "穿山鼠"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0027-alola",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0028",
+    "no": "0028",
+    "form": null,
+    "names": {
+      "ja": "サンドパン",
+      "en": "Sandslash",
+      "ko": "고지",
+      "zh-Hans": "穿山王",
+      "zh-Hant": "穿山王"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0028",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0028-alola",
+    "no": "0028",
+    "form": "alola",
+    "names": {
+      "ja": "サンドパン",
+      "en": "Sandslash",
+      "ko": "고지",
+      "zh-Hans": "穿山王",
+      "zh-Hant": "穿山王"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0028-alola",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0029",
+    "no": "0029",
+    "form": null,
+    "names": {
+      "ja": "ニドラン♀",
+      "en": "Nidoran♀",
+      "ko": "니드런♀",
+      "zh-Hans": "尼多兰",
+      "zh-Hant": "尼多蘭"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0029",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0030",
+    "no": "0030",
+    "form": null,
+    "names": {
+      "ja": "ニドリーナ",
+      "en": "Nidorina",
+      "ko": "니드리나",
+      "zh-Hans": "尼多娜",
+      "zh-Hant": "尼多娜"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0030",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0031",
+    "no": "0031",
+    "form": null,
+    "names": {
+      "ja": "ニドクイン",
+      "en": "Nidoqueen",
+      "ko": "니드퀸",
+      "zh-Hans": "尼多后",
+      "zh-Hant": "尼多后"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0031",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0032",
+    "no": "0032",
+    "form": null,
+    "names": {
+      "ja": "ニドラン♂",
+      "en": "Nidoran♂",
+      "ko": "니드런♂",
+      "zh-Hans": "尼多朗",
+      "zh-Hant": "尼多朗"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0032",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0033",
+    "no": "0033",
+    "form": null,
+    "names": {
+      "ja": "ニドリーノ",
+      "en": "Nidorino",
+      "ko": "니드리노",
+      "zh-Hans": "尼多力诺",
+      "zh-Hant": "尼多力諾"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0033",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0034",
+    "no": "0034",
+    "form": null,
+    "names": {
+      "ja": "ニドキング",
+      "en": "Nidoking",
+      "ko": "니드킹",
+      "zh-Hans": "尼多王",
+      "zh-Hant": "尼多王"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0034",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0035",
+    "no": "0035",
+    "form": null,
+    "names": {
+      "ja": "ピッピ",
+      "en": "Clefairy",
+      "ko": "삐삐",
+      "zh-Hans": "皮皮",
+      "zh-Hant": "皮皮"
+    },
+    "types": [
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0035",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0036",
+    "no": "0036",
+    "form": null,
+    "names": {
+      "ja": "ピクシー",
+      "en": "Clefable",
+      "ko": "픽시",
+      "zh-Hans": "皮可西",
+      "zh-Hant": "皮可西"
+    },
+    "types": [
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0036",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0037",
+    "no": "0037",
+    "form": null,
+    "names": {
+      "ja": "ロコン",
+      "en": "Vulpix",
+      "ko": "식스테일",
+      "zh-Hans": "六尾",
+      "zh-Hant": "六尾"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0037",
+      "evolves_from": null,
+      "evolves_to": [
+        "0038"
+      ]
+    },
+    "color": null
+  },
+  {
+    "id": "0037-alola",
+    "no": "0037",
+    "form": "alola",
+    "names": {
+      "ja": "ロコン",
+      "en": "Vulpix",
+      "ko": "식스테일",
+      "zh-Hans": "六尾",
+      "zh-Hant": "六尾"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0037-alola",
+      "evolves_from": null,
+      "evolves_to": [
+        "0038-alola"
+      ]
+    },
+    "color": null
+  },
+  {
+    "id": "0038",
+    "no": "0038",
+    "form": null,
+    "names": {
+      "ja": "キュウコン",
+      "en": "Ninetales",
+      "ko": "나인테일",
+      "zh-Hans": "九尾",
+      "zh-Hant": "九尾"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0037",
+      "evolves_from": "0037",
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0038-alola",
+    "no": "0038",
+    "form": "alola",
+    "names": {
+      "ja": "キュウコン",
+      "en": "Ninetales",
+      "ko": "나인테일",
+      "zh-Hans": "九尾",
+      "zh-Hant": "九尾"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0037-alola",
+      "evolves_from": "0037-alola",
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0039",
+    "no": "0039",
+    "form": null,
+    "names": {
+      "ja": "プリン",
+      "en": "Jigglypuff",
+      "ko": "푸린",
+      "zh-Hans": "胖丁",
+      "zh-Hant": "胖丁"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0039",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0040",
+    "no": "0040",
+    "form": null,
+    "names": {
+      "ja": "プクリン",
+      "en": "Wigglytuff",
+      "ko": "푸크린",
+      "zh-Hans": "胖可丁",
+      "zh-Hant": "胖可丁"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0040",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0041",
+    "no": "0041",
+    "form": null,
+    "names": {
+      "ja": "ズバット",
+      "en": "Zubat",
+      "ko": "주뱃",
+      "zh-Hans": "超音蝠",
+      "zh-Hant": "超音蝠"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0041",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0042",
+    "no": "0042",
+    "form": null,
+    "names": {
+      "ja": "ゴルバット",
+      "en": "Golbat",
+      "ko": "골뱃",
+      "zh-Hans": "大嘴蝠",
+      "zh-Hant": "大嘴蝠"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0042",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0043",
+    "no": "0043",
+    "form": null,
+    "names": {
+      "ja": "ナゾノクサ",
+      "en": "Oddish",
+      "ko": "뚜벅쵸",
+      "zh-Hans": "走路草",
+      "zh-Hant": "走路草"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0043",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0044",
+    "no": "0044",
+    "form": null,
+    "names": {
+      "ja": "クサイハナ",
+      "en": "Gloom",
+      "ko": "냄새꼬",
+      "zh-Hans": "臭臭花",
+      "zh-Hant": "臭臭花"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0044",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0045",
+    "no": "0045",
+    "form": null,
+    "names": {
+      "ja": "ラフレシア",
+      "en": "Vileplume",
+      "ko": "라플레시아",
+      "zh-Hans": "霸王花",
+      "zh-Hant": "霸王花"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0045",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0046",
+    "no": "0046",
+    "form": null,
+    "names": {
+      "ja": "パラス",
+      "en": "Paras",
+      "ko": "파라스",
+      "zh-Hans": "派拉斯",
+      "zh-Hant": "派拉斯"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0046",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0047",
+    "no": "0047",
+    "form": null,
+    "names": {
+      "ja": "パラセクト",
+      "en": "Parasect",
+      "ko": "파라섹트",
+      "zh-Hans": "派拉斯特",
+      "zh-Hant": "派拉斯特"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0047",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0048",
+    "no": "0048",
+    "form": null,
+    "names": {
+      "ja": "コンパン",
+      "en": "Venonat",
+      "ko": "콘팡",
+      "zh-Hans": "毛球",
+      "zh-Hant": "毛球"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0048",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0049",
+    "no": "0049",
+    "form": null,
+    "names": {
+      "ja": "モルフォン",
+      "en": "Venomoth",
+      "ko": "도나리",
+      "zh-Hans": "摩鲁蛾",
+      "zh-Hant": "摩魯蛾"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0049",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0050",
+    "no": "0050",
+    "form": null,
+    "names": {
+      "ja": "ディグダ",
+      "en": "Diglett",
+      "ko": "디그다",
+      "zh-Hans": "地鼠",
+      "zh-Hant": "地鼠"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0050",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0050-alola",
+    "no": "0050",
+    "form": "alola",
+    "names": {
+      "ja": "ディグダ",
+      "en": "Diglett",
+      "ko": "디그다",
+      "zh-Hans": "地鼠",
+      "zh-Hant": "地鼠"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0050-alola",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0051",
+    "no": "0051",
+    "form": null,
+    "names": {
+      "ja": "ダグトリオ",
+      "en": "Dugtrio",
+      "ko": "닥트리오",
+      "zh-Hans": "三地鼠",
+      "zh-Hant": "三地鼠"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0051",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0051-alola",
+    "no": "0051",
+    "form": "alola",
+    "names": {
+      "ja": "ダグトリオ",
+      "en": "Dugtrio",
+      "ko": "닥트리오",
+      "zh-Hans": "三地鼠",
+      "zh-Hant": "三地鼠"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0051-alola",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0052",
+    "no": "0052",
+    "form": null,
+    "names": {
+      "ja": "ニャース",
+      "en": "Meowth",
+      "ko": "나옹",
+      "zh-Hans": "喵喵",
+      "zh-Hant": "喵喵"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0052",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0052-alola",
+    "no": "0052",
+    "form": "alola",
+    "names": {
+      "ja": "ニャース",
+      "en": "Meowth",
+      "ko": "나옹",
+      "zh-Hans": "喵喵",
+      "zh-Hant": "喵喵"
+    },
+    "types": [
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0052-alola",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0052-galar",
+    "no": "0052",
+    "form": "galar",
+    "names": {
+      "ja": "ニャース",
+      "en": "Meowth",
+      "ko": "나옹",
+      "zh-Hans": "喵喵",
+      "zh-Hant": "喵喵"
+    },
+    "types": [
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0052-galar",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0053",
+    "no": "0053",
+    "form": null,
+    "names": {
+      "ja": "ペルシアン",
+      "en": "Persian",
+      "ko": "페르시온",
+      "zh-Hans": "猫老大",
+      "zh-Hant": "貓老大"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0053",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0053-alola",
+    "no": "0053",
+    "form": "alola",
+    "names": {
+      "ja": "ペルシアン",
+      "en": "Persian",
+      "ko": "페르시온",
+      "zh-Hans": "猫老大",
+      "zh-Hant": "貓老大"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0053-alola",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0054",
+    "no": "0054",
+    "form": null,
+    "names": {
+      "ja": "コダック",
+      "en": "Psyduck",
+      "ko": "고라파덕",
+      "zh-Hans": "可达鸭",
+      "zh-Hant": "可達鴨"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0054",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0055",
+    "no": "0055",
+    "form": null,
+    "names": {
+      "ja": "ゴルダック",
+      "en": "Golduck",
+      "ko": "골덕",
+      "zh-Hans": "哥达鸭",
+      "zh-Hant": "哥達鴨"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0055",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0056",
+    "no": "0056",
+    "form": null,
+    "names": {
+      "ja": "マンキー",
+      "en": "Mankey",
+      "ko": "망키",
+      "zh-Hans": "猴怪",
+      "zh-Hant": "猴怪"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0056",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0057",
+    "no": "0057",
+    "form": null,
+    "names": {
+      "ja": "オコリザル",
+      "en": "Primeape",
+      "ko": "성원숭",
+      "zh-Hans": "火暴猴",
+      "zh-Hant": "火爆猴"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0057",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0058",
+    "no": "0058",
+    "form": null,
+    "names": {
+      "ja": "ガーディ",
+      "en": "Growlithe",
+      "ko": "가디",
+      "zh-Hans": "卡蒂狗",
+      "zh-Hant": "卡蒂狗"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0058",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0058-hisui",
+    "no": "0058",
+    "form": "hisui",
+    "names": {
+      "ja": "ガーディ",
+      "en": "Growlithe",
+      "ko": "가디",
+      "zh-Hans": "卡蒂狗",
+      "zh-Hant": "卡蒂狗"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0058-hisui",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0059",
+    "no": "0059",
+    "form": null,
+    "names": {
+      "ja": "ウインディ",
+      "en": "Arcanine",
+      "ko": "윈디",
+      "zh-Hans": "风速狗",
+      "zh-Hant": "風速狗"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0059",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0059-hisui",
+    "no": "0059",
+    "form": "hisui",
+    "names": {
+      "ja": "ウインディ",
+      "en": "Arcanine",
+      "ko": "윈디",
+      "zh-Hans": "风速狗",
+      "zh-Hant": "風速狗"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0059-hisui",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0060",
+    "no": "0060",
+    "form": null,
+    "names": {
+      "ja": "ニョロモ",
+      "en": "Poliwag",
+      "ko": "발챙이",
+      "zh-Hans": "蚊香蝌蚪",
+      "zh-Hant": "蚊香蝌蚪"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0060",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0061",
+    "no": "0061",
+    "form": null,
+    "names": {
+      "ja": "ニョロゾ",
+      "en": "Poliwhirl",
+      "ko": "슈륙챙이",
+      "zh-Hans": "蚊香君",
+      "zh-Hant": "蚊香君"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0061",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0062",
+    "no": "0062",
+    "form": null,
+    "names": {
+      "ja": "ニョロボン",
+      "en": "Poliwrath",
+      "ko": "강챙이",
+      "zh-Hans": "蚊香泳士",
+      "zh-Hant": "蚊香泳士"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0062",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0063",
+    "no": "0063",
+    "form": null,
+    "names": {
+      "ja": "ケーシィ",
+      "en": "Abra",
+      "ko": "캐이시",
+      "zh-Hans": "凯西",
+      "zh-Hant": "凱西"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0063",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0064",
+    "no": "0064",
+    "form": null,
+    "names": {
+      "ja": "ユンゲラー",
+      "en": "Kadabra",
+      "ko": "윤겔라",
+      "zh-Hans": "勇基拉",
+      "zh-Hant": "勇基拉"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0064",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0065",
+    "no": "0065",
+    "form": null,
+    "names": {
+      "ja": "フーディン",
+      "en": "Alakazam",
+      "ko": "후딘",
+      "zh-Hans": "胡地",
+      "zh-Hant": "胡地"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0065",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0066",
+    "no": "0066",
+    "form": null,
+    "names": {
+      "ja": "ワンリキー",
+      "en": "Machop",
+      "ko": "알통몬",
+      "zh-Hans": "腕力",
+      "zh-Hant": "腕力"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0066",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0067",
+    "no": "0067",
+    "form": null,
+    "names": {
+      "ja": "ゴーリキー",
+      "en": "Machoke",
+      "ko": "근육몬",
+      "zh-Hans": "豪力",
+      "zh-Hant": "豪力"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0067",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0068",
+    "no": "0068",
+    "form": null,
+    "names": {
+      "ja": "カイリキー",
+      "en": "Machamp",
+      "ko": "괴력몬",
+      "zh-Hans": "怪力",
+      "zh-Hant": "怪力"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0068",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0069",
+    "no": "0069",
+    "form": null,
+    "names": {
+      "ja": "マダツボミ",
+      "en": "Bellsprout",
+      "ko": "모다피",
+      "zh-Hans": "喇叭芽",
+      "zh-Hant": "喇叭芽"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0069",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0070",
+    "no": "0070",
+    "form": null,
+    "names": {
+      "ja": "ウツドン",
+      "en": "Weepinbell",
+      "ko": "우츠동",
+      "zh-Hans": "口呆花",
+      "zh-Hant": "口呆花"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0070",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0071",
+    "no": "0071",
+    "form": null,
+    "names": {
+      "ja": "ウツボット",
+      "en": "Victreebel",
+      "ko": "우츠보트",
+      "zh-Hans": "大食花",
+      "zh-Hant": "大食花"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0071",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0072",
+    "no": "0072",
+    "form": null,
+    "names": {
+      "ja": "メノクラゲ",
+      "en": "Tentacool",
+      "ko": "왕눈해",
+      "zh-Hans": "玛瑙水母",
+      "zh-Hant": "瑪瑙水母"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0072",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0073",
+    "no": "0073",
+    "form": null,
+    "names": {
+      "ja": "ドククラゲ",
+      "en": "Tentacruel",
+      "ko": "독파리",
+      "zh-Hans": "毒刺水母",
+      "zh-Hant": "毒刺水母"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0073",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0074",
+    "no": "0074",
+    "form": null,
+    "names": {
+      "ja": "イシツブテ",
+      "en": "Geodude",
+      "ko": "꼬마돌",
+      "zh-Hans": "小拳石",
+      "zh-Hant": "小拳石"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0074",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0074-alola",
+    "no": "0074",
+    "form": "alola",
+    "names": {
+      "ja": "イシツブテ",
+      "en": "Geodude",
+      "ko": "꼬마돌",
+      "zh-Hans": "小拳石",
+      "zh-Hant": "小拳石"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0074-alola",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0075",
+    "no": "0075",
+    "form": null,
+    "names": {
+      "ja": "ゴローン",
+      "en": "Graveler",
+      "ko": "데구리",
+      "zh-Hans": "隆隆石",
+      "zh-Hant": "隆隆石"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0075",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0075-alola",
+    "no": "0075",
+    "form": "alola",
+    "names": {
+      "ja": "ゴローン",
+      "en": "Graveler",
+      "ko": "데구리",
+      "zh-Hans": "隆隆石",
+      "zh-Hant": "隆隆石"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0075-alola",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0076",
+    "no": "0076",
+    "form": null,
+    "names": {
+      "ja": "ゴローニャ",
+      "en": "Golem",
+      "ko": "딱구리",
+      "zh-Hans": "隆隆岩",
+      "zh-Hant": "隆隆岩"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0076",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0076-alola",
+    "no": "0076",
+    "form": "alola",
+    "names": {
+      "ja": "ゴローニャ",
+      "en": "Golem",
+      "ko": "딱구리",
+      "zh-Hans": "隆隆岩",
+      "zh-Hant": "隆隆岩"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0076-alola",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0077",
+    "no": "0077",
+    "form": null,
+    "names": {
+      "ja": "ポニータ",
+      "en": "Ponyta",
+      "ko": "포니타",
+      "zh-Hans": "小火马",
+      "zh-Hant": "小火馬"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0077",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0077-galar",
+    "no": "0077",
+    "form": "galar",
+    "names": {
+      "ja": "ポニータ",
+      "en": "Ponyta",
+      "ko": "포니타",
+      "zh-Hans": "小火马",
+      "zh-Hant": "小火馬"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0077-galar",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0078",
+    "no": "0078",
+    "form": null,
+    "names": {
+      "ja": "ギャロップ",
+      "en": "Rapidash",
+      "ko": "날쌩마",
+      "zh-Hans": "烈焰马",
+      "zh-Hant": "烈焰馬"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0078",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0078-galar",
+    "no": "0078",
+    "form": "galar",
+    "names": {
+      "ja": "ギャロップ",
+      "en": "Rapidash",
+      "ko": "날쌩마",
+      "zh-Hans": "烈焰马",
+      "zh-Hant": "烈焰馬"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0078-galar",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0079",
+    "no": "0079",
+    "form": null,
+    "names": {
+      "ja": "ヤドン",
+      "en": "Slowpoke",
+      "ko": "야돈",
+      "zh-Hans": "呆呆兽",
+      "zh-Hant": "呆呆獸"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0079",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0079-galar",
+    "no": "0079",
+    "form": "galar",
+    "names": {
+      "ja": "ヤドン",
+      "en": "Slowpoke",
+      "ko": "야돈",
+      "zh-Hans": "呆呆兽",
+      "zh-Hant": "呆呆獸"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0079-galar",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0080",
+    "no": "0080",
+    "form": null,
+    "names": {
+      "ja": "ヤドラン",
+      "en": "Slowbro",
+      "ko": "야도란",
+      "zh-Hans": "呆壳兽",
+      "zh-Hant": "呆殼獸"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0080",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0080-galar",
+    "no": "0080",
+    "form": "galar",
+    "names": {
+      "ja": "ヤドラン",
+      "en": "Slowbro",
+      "ko": "야도란",
+      "zh-Hans": "呆壳兽",
+      "zh-Hant": "呆殼獸"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0080-galar",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0081",
+    "no": "0081",
+    "form": null,
+    "names": {
+      "ja": "コイル",
+      "en": "Magnemite",
+      "ko": "코일",
+      "zh-Hans": "小磁怪",
+      "zh-Hant": "小磁怪"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0081",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0082",
+    "no": "0082",
+    "form": null,
+    "names": {
+      "ja": "レアコイル",
+      "en": "Magneton",
+      "ko": "레어코일",
+      "zh-Hans": "三合一磁怪",
+      "zh-Hant": "三合一磁怪"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0082",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0083",
+    "no": "0083",
+    "form": null,
+    "names": {
+      "ja": "カモネギ",
+      "en": "Farfetch’d",
+      "ko": "파오리",
+      "zh-Hans": "大葱鸭",
+      "zh-Hant": "大蔥鴨"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0083",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0083-galar",
+    "no": "0083",
+    "form": "galar",
+    "names": {
+      "ja": "カモネギ",
+      "en": "Farfetch’d",
+      "ko": "파오리",
+      "zh-Hans": "大葱鸭",
+      "zh-Hant": "大蔥鴨"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0083-galar",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0084",
+    "no": "0084",
+    "form": null,
+    "names": {
+      "ja": "ドードー",
+      "en": "Doduo",
+      "ko": "두두",
+      "zh-Hans": "嘟嘟",
+      "zh-Hant": "嘟嘟"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0084",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0085",
+    "no": "0085",
+    "form": null,
+    "names": {
+      "ja": "ドードリオ",
+      "en": "Dodrio",
+      "ko": "두트리오",
+      "zh-Hans": "嘟嘟利",
+      "zh-Hant": "嘟嘟利"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0085",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0086",
+    "no": "0086",
+    "form": null,
+    "names": {
+      "ja": "パウワウ",
+      "en": "Seel",
+      "ko": "쥬쥬",
+      "zh-Hans": "小海狮",
+      "zh-Hant": "小海獅"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0086",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0087",
+    "no": "0087",
+    "form": null,
+    "names": {
+      "ja": "ジュゴン",
+      "en": "Dewgong",
+      "ko": "쥬레곤",
+      "zh-Hans": "白海狮",
+      "zh-Hant": "白海獅"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0087",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0088",
+    "no": "0088",
+    "form": null,
+    "names": {
+      "ja": "ベトベター",
+      "en": "Grimer",
+      "ko": "질퍽이",
+      "zh-Hans": "臭泥",
+      "zh-Hant": "臭泥"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0088",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0088-alola",
+    "no": "0088",
+    "form": "alola",
+    "names": {
+      "ja": "ベトベター",
+      "en": "Grimer",
+      "ko": "질퍽이",
+      "zh-Hans": "臭泥",
+      "zh-Hant": "臭泥"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0088-alola",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0089",
+    "no": "0089",
+    "form": null,
+    "names": {
+      "ja": "ベトベトン",
+      "en": "Muk",
+      "ko": "질뻐기",
+      "zh-Hans": "臭臭泥",
+      "zh-Hant": "臭臭泥"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0089",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0089-alola",
+    "no": "0089",
+    "form": "alola",
+    "names": {
+      "ja": "ベトベトン",
+      "en": "Muk",
+      "ko": "질뻐기",
+      "zh-Hans": "臭臭泥",
+      "zh-Hant": "臭臭泥"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0089-alola",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0090",
+    "no": "0090",
+    "form": null,
+    "names": {
+      "ja": "シェルダー",
+      "en": "Shellder",
+      "ko": "셀러",
+      "zh-Hans": "大舌贝",
+      "zh-Hant": "大舌貝"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0090",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0091",
+    "no": "0091",
+    "form": null,
+    "names": {
+      "ja": "パルシェン",
+      "en": "Cloyster",
+      "ko": "파르셀",
+      "zh-Hans": "刺甲贝",
+      "zh-Hant": "刺甲貝"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0091",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0092",
+    "no": "0092",
+    "form": null,
+    "names": {
+      "ja": "ゴース",
+      "en": "Gastly",
+      "ko": "고오스",
+      "zh-Hans": "鬼斯",
+      "zh-Hant": "鬼斯"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0092",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0093",
+    "no": "0093",
+    "form": null,
+    "names": {
+      "ja": "ゴースト",
+      "en": "Haunter",
+      "ko": "고우스트",
+      "zh-Hans": "鬼斯通",
+      "zh-Hant": "鬼斯通"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0093",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0094",
+    "no": "0094",
+    "form": null,
+    "names": {
+      "ja": "ゲンガー",
+      "en": "Gengar",
+      "ko": "팬텀",
+      "zh-Hans": "耿鬼",
+      "zh-Hant": "耿鬼"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0094",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0095",
+    "no": "0095",
+    "form": null,
+    "names": {
+      "ja": "イワーク",
+      "en": "Onix",
+      "ko": "롱스톤",
+      "zh-Hans": "大岩蛇",
+      "zh-Hant": "大岩蛇"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0095",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0096",
+    "no": "0096",
+    "form": null,
+    "names": {
+      "ja": "スリープ",
+      "en": "Drowzee",
+      "ko": "슬리프",
+      "zh-Hans": "催眠貘",
+      "zh-Hant": "催眠貘"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0096",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0097",
+    "no": "0097",
+    "form": null,
+    "names": {
+      "ja": "スリーパー",
+      "en": "Hypno",
+      "ko": "슬리퍼",
+      "zh-Hans": "引梦貘人",
+      "zh-Hant": "引夢貘人"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0097",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0098",
+    "no": "0098",
+    "form": null,
+    "names": {
+      "ja": "クラブ",
+      "en": "Krabby",
+      "ko": "크랩",
+      "zh-Hans": "大钳蟹",
+      "zh-Hant": "大鉗蟹"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0098",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0099",
+    "no": "0099",
+    "form": null,
+    "names": {
+      "ja": "キングラー",
+      "en": "Kingler",
+      "ko": "킹크랩",
+      "zh-Hans": "巨钳蟹",
+      "zh-Hant": "巨鉗蟹"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0099",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0100",
+    "no": "0100",
+    "form": null,
+    "names": {
+      "ja": "ビリリダマ",
+      "en": "Voltorb",
+      "ko": "찌리리공",
+      "zh-Hans": "霹雳电球",
+      "zh-Hant": "霹靂電球"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0100",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0100-hisui",
+    "no": "0100",
+    "form": "hisui",
+    "names": {
+      "ja": "ビリリダマ",
+      "en": "Voltorb",
+      "ko": "찌리리공",
+      "zh-Hans": "霹雳电球",
+      "zh-Hant": "霹靂電球"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0100-hisui",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0101",
+    "no": "0101",
+    "form": null,
+    "names": {
+      "ja": "マルマイン",
+      "en": "Electrode",
+      "ko": "붐볼",
+      "zh-Hans": "顽皮雷弹",
+      "zh-Hant": "頑皮雷彈"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0101",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0101-hisui",
+    "no": "0101",
+    "form": "hisui",
+    "names": {
+      "ja": "マルマイン",
+      "en": "Electrode",
+      "ko": "붐볼",
+      "zh-Hans": "顽皮雷弹",
+      "zh-Hant": "頑皮雷彈"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0101-hisui",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0102",
+    "no": "0102",
+    "form": null,
+    "names": {
+      "ja": "タマタマ",
+      "en": "Exeggcute",
+      "ko": "아라리",
+      "zh-Hans": "蛋蛋",
+      "zh-Hant": "蛋蛋"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0102",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0103",
+    "no": "0103",
+    "form": null,
+    "names": {
+      "ja": "ナッシー",
+      "en": "Exeggutor",
+      "ko": "나시",
+      "zh-Hans": "椰蛋树",
+      "zh-Hant": "椰蛋樹"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0103",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0103-alola",
+    "no": "0103",
+    "form": "alola",
+    "names": {
+      "ja": "ナッシー",
+      "en": "Exeggutor",
+      "ko": "나시",
+      "zh-Hans": "椰蛋树",
+      "zh-Hant": "椰蛋樹"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0103-alola",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0104",
+    "no": "0104",
+    "form": null,
+    "names": {
+      "ja": "カラカラ",
+      "en": "Cubone",
+      "ko": "탕구리",
+      "zh-Hans": "卡拉卡拉",
+      "zh-Hant": "卡拉卡拉"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0104",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0105",
+    "no": "0105",
+    "form": null,
+    "names": {
+      "ja": "ガラガラ",
+      "en": "Marowak",
+      "ko": "텅구리",
+      "zh-Hans": "嘎啦嘎啦",
+      "zh-Hant": "嘎啦嘎啦"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0105",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0105-alola",
+    "no": "0105",
+    "form": "alola",
+    "names": {
+      "ja": "ガラガラ",
+      "en": "Marowak",
+      "ko": "텅구리",
+      "zh-Hans": "嘎啦嘎啦",
+      "zh-Hant": "嘎啦嘎啦"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0105-alola",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0106",
+    "no": "0106",
+    "form": null,
+    "names": {
+      "ja": "サワムラー",
+      "en": "Hitmonlee",
+      "ko": "시라소몬",
+      "zh-Hans": "飞腿郎",
+      "zh-Hant": "飛腿郎"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0106",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0107",
+    "no": "0107",
+    "form": null,
+    "names": {
+      "ja": "エビワラー",
+      "en": "Hitmonchan",
+      "ko": "홍수몬",
+      "zh-Hans": "快拳郎",
+      "zh-Hant": "快拳郎"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0107",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0108",
+    "no": "0108",
+    "form": null,
+    "names": {
+      "ja": "ベロリンガ",
+      "en": "Lickitung",
+      "ko": "내루미",
+      "zh-Hans": "大舌头",
+      "zh-Hant": "大舌頭"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0108",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0109",
+    "no": "0109",
+    "form": null,
+    "names": {
+      "ja": "ドガース",
+      "en": "Koffing",
+      "ko": "또가스",
+      "zh-Hans": "瓦斯弹",
+      "zh-Hant": "瓦斯彈"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0109",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0110",
+    "no": "0110",
+    "form": null,
+    "names": {
+      "ja": "マタドガス",
+      "en": "Weezing",
+      "ko": "또도가스",
+      "zh-Hans": "双弹瓦斯",
+      "zh-Hant": "雙彈瓦斯"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0110",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0110-galar",
+    "no": "0110",
+    "form": "galar",
+    "names": {
+      "ja": "マタドガス",
+      "en": "Weezing",
+      "ko": "또도가스",
+      "zh-Hans": "双弹瓦斯",
+      "zh-Hant": "雙彈瓦斯"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0110-galar",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0111",
+    "no": "0111",
+    "form": null,
+    "names": {
+      "ja": "サイホーン",
+      "en": "Rhyhorn",
+      "ko": "뿔카노",
+      "zh-Hans": "独角犀牛",
+      "zh-Hant": "獨角犀牛"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0111",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0112",
+    "no": "0112",
+    "form": null,
+    "names": {
+      "ja": "サイドン",
+      "en": "Rhydon",
+      "ko": "코뿌리",
+      "zh-Hans": "钻角犀兽",
+      "zh-Hant": "鑽角犀獸"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0112",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0113",
+    "no": "0113",
+    "form": null,
+    "names": {
+      "ja": "ラッキー",
+      "en": "Chansey",
+      "ko": "럭키",
+      "zh-Hans": "吉利蛋",
+      "zh-Hant": "吉利蛋"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0113",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0114",
+    "no": "0114",
+    "form": null,
+    "names": {
+      "ja": "モンジャラ",
+      "en": "Tangela",
+      "ko": "덩쿠리",
+      "zh-Hans": "蔓藤怪",
+      "zh-Hant": "蔓藤怪"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0114",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0115",
+    "no": "0115",
+    "form": null,
+    "names": {
+      "ja": "ガルーラ",
+      "en": "Kangaskhan",
+      "ko": "캥카",
+      "zh-Hans": "袋兽",
+      "zh-Hant": "袋獸"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0115",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0116",
+    "no": "0116",
+    "form": null,
+    "names": {
+      "ja": "タッツー",
+      "en": "Horsea",
+      "ko": "쏘드라",
+      "zh-Hans": "墨海马",
+      "zh-Hant": "墨海馬"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0116",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0117",
+    "no": "0117",
+    "form": null,
+    "names": {
+      "ja": "シードラ",
+      "en": "Seadra",
+      "ko": "시드라",
+      "zh-Hans": "海刺龙",
+      "zh-Hant": "海刺龍"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0117",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0118",
+    "no": "0118",
+    "form": null,
+    "names": {
+      "ja": "トサキント",
+      "en": "Goldeen",
+      "ko": "콘치",
+      "zh-Hans": "角金鱼",
+      "zh-Hant": "角金魚"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0118",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0119",
+    "no": "0119",
+    "form": null,
+    "names": {
+      "ja": "アズマオウ",
+      "en": "Seaking",
+      "ko": "왕콘치",
+      "zh-Hans": "金鱼王",
+      "zh-Hant": "金魚王"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0119",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0120",
+    "no": "0120",
+    "form": null,
+    "names": {
+      "ja": "ヒトデマン",
+      "en": "Staryu",
+      "ko": "별가사리",
+      "zh-Hans": "海星星",
+      "zh-Hant": "海星星"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0120",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0121",
+    "no": "0121",
+    "form": null,
+    "names": {
+      "ja": "スターミー",
+      "en": "Starmie",
+      "ko": "아쿠스타",
+      "zh-Hans": "宝石海星",
+      "zh-Hant": "寶石海星"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0121",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0122",
+    "no": "0122",
+    "form": null,
+    "names": {
+      "ja": "バリヤード",
+      "en": "Mr. Mime",
+      "ko": "마임맨",
+      "zh-Hans": "魔墙人偶",
+      "zh-Hant": "魔牆人偶"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0122",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0122-galar",
+    "no": "0122",
+    "form": "galar",
+    "names": {
+      "ja": "バリヤード",
+      "en": "Mr. Mime",
+      "ko": "마임맨",
+      "zh-Hans": "魔墙人偶",
+      "zh-Hant": "魔牆人偶"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0122-galar",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0123",
+    "no": "0123",
+    "form": null,
+    "names": {
+      "ja": "ストライク",
+      "en": "Scyther",
+      "ko": "스라크",
+      "zh-Hans": "飞天螳螂",
+      "zh-Hant": "飛天螳螂"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0123",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0124",
+    "no": "0124",
+    "form": null,
+    "names": {
+      "ja": "ルージュラ",
+      "en": "Jynx",
+      "ko": "루주라",
+      "zh-Hans": "迷唇姐",
+      "zh-Hant": "迷唇姐"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0124",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0125",
+    "no": "0125",
+    "form": null,
+    "names": {
+      "ja": "エレブー",
+      "en": "Electabuzz",
+      "ko": "에레브",
+      "zh-Hans": "电击兽",
+      "zh-Hant": "電擊獸"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0125",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0126",
+    "no": "0126",
+    "form": null,
+    "names": {
+      "ja": "ブーバー",
+      "en": "Magmar",
+      "ko": "마그마",
+      "zh-Hans": "鸭嘴火兽",
+      "zh-Hant": "鴨嘴火獸"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0126",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0127",
+    "no": "0127",
+    "form": null,
+    "names": {
+      "ja": "カイロス",
+      "en": "Pinsir",
+      "ko": "쁘사이저",
+      "zh-Hans": "凯罗斯",
+      "zh-Hant": "凱羅斯"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0127",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0128",
+    "no": "0128",
+    "form": null,
+    "names": {
+      "ja": "ケンタロス",
+      "en": "Tauros",
+      "ko": "켄타로스",
+      "zh-Hans": "肯泰罗",
+      "zh-Hant": "肯泰羅"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0128",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0128-paldea",
+    "no": "0128",
+    "form": "paldea",
+    "names": {
+      "ja": "ケンタロス",
+      "en": "Tauros",
+      "ko": "켄타로스",
+      "zh-Hans": "肯泰罗",
+      "zh-Hant": "肯泰羅"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0128-paldea",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0129",
+    "no": "0129",
+    "form": null,
+    "names": {
+      "ja": "コイキング",
+      "en": "Magikarp",
+      "ko": "잉어킹",
+      "zh-Hans": "鲤鱼王",
+      "zh-Hant": "鯉魚王"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0129",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0130",
+    "no": "0130",
+    "form": null,
+    "names": {
+      "ja": "ギャラドス",
+      "en": "Gyarados",
+      "ko": "갸라도스",
+      "zh-Hans": "暴鲤龙",
+      "zh-Hant": "暴鯉龍"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0130",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0131",
+    "no": "0131",
+    "form": null,
+    "names": {
+      "ja": "ラプラス",
+      "en": "Lapras",
+      "ko": "라프라스",
+      "zh-Hans": "拉普拉斯",
+      "zh-Hant": "拉普拉斯"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0131",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0132",
+    "no": "0132",
+    "form": null,
+    "names": {
+      "ja": "メタモン",
+      "en": "Ditto",
+      "ko": "메타몽",
+      "zh-Hans": "百变怪",
+      "zh-Hant": "百變怪"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0132",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0133",
+    "no": "0133",
+    "form": null,
+    "names": {
+      "ja": "イーブイ",
+      "en": "Eevee",
+      "ko": "이브이",
+      "zh-Hans": "伊布",
+      "zh-Hant": "伊布"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0133",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0134",
+    "no": "0134",
+    "form": null,
+    "names": {
+      "ja": "シャワーズ",
+      "en": "Vaporeon",
+      "ko": "샤미드",
+      "zh-Hans": "水伊布",
+      "zh-Hant": "水伊布"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0134",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0135",
+    "no": "0135",
+    "form": null,
+    "names": {
+      "ja": "サンダース",
+      "en": "Jolteon",
+      "ko": "쥬피썬더",
+      "zh-Hans": "雷伊布",
+      "zh-Hant": "雷伊布"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0135",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0136",
+    "no": "0136",
+    "form": null,
+    "names": {
+      "ja": "ブースター",
+      "en": "Flareon",
+      "ko": "부스터",
+      "zh-Hans": "火伊布",
+      "zh-Hant": "火伊布"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0136",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0137",
+    "no": "0137",
+    "form": null,
+    "names": {
+      "ja": "ポリゴン",
+      "en": "Porygon",
+      "ko": "폴리곤",
+      "zh-Hans": "多边兽",
+      "zh-Hant": "多邊獸"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0137",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0138",
+    "no": "0138",
+    "form": null,
+    "names": {
+      "ja": "オムナイト",
+      "en": "Omanyte",
+      "ko": "암나이트",
+      "zh-Hans": "菊石兽",
+      "zh-Hant": "菊石獸"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0138",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0139",
+    "no": "0139",
+    "form": null,
+    "names": {
+      "ja": "オムスター",
+      "en": "Omastar",
+      "ko": "암스타",
+      "zh-Hans": "多刺菊石兽",
+      "zh-Hant": "多刺菊石獸"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0139",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0140",
+    "no": "0140",
+    "form": null,
+    "names": {
+      "ja": "カブト",
+      "en": "Kabuto",
+      "ko": "투구",
+      "zh-Hans": "化石盔",
+      "zh-Hant": "化石盔"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0140",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0141",
+    "no": "0141",
+    "form": null,
+    "names": {
+      "ja": "カブトプス",
+      "en": "Kabutops",
+      "ko": "투구푸스",
+      "zh-Hans": "镰刀盔",
+      "zh-Hant": "鐮刀盔"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0141",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0142",
+    "no": "0142",
+    "form": null,
+    "names": {
+      "ja": "プテラ",
+      "en": "Aerodactyl",
+      "ko": "프테라",
+      "zh-Hans": "化石翼龙",
+      "zh-Hant": "化石翼龍"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0142",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0143",
+    "no": "0143",
+    "form": null,
+    "names": {
+      "ja": "カビゴン",
+      "en": "Snorlax",
+      "ko": "잠만보",
+      "zh-Hans": "卡比兽",
+      "zh-Hant": "卡比獸"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0143",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0144",
+    "no": "0144",
+    "form": null,
+    "names": {
+      "ja": "フリーザー",
+      "en": "Articuno",
+      "ko": "프리져",
+      "zh-Hans": "急冻鸟",
+      "zh-Hant": "急凍鳥"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0144",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0144-galar",
+    "no": "0144",
+    "form": "galar",
+    "names": {
+      "ja": "フリーザー",
+      "en": "Articuno",
+      "ko": "프리져",
+      "zh-Hans": "急冻鸟",
+      "zh-Hant": "急凍鳥"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0144-galar",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0145",
+    "no": "0145",
+    "form": null,
+    "names": {
+      "ja": "サンダー",
+      "en": "Zapdos",
+      "ko": "썬더",
+      "zh-Hans": "闪电鸟",
+      "zh-Hant": "閃電鳥"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0145",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0145-galar",
+    "no": "0145",
+    "form": "galar",
+    "names": {
+      "ja": "サンダー",
+      "en": "Zapdos",
+      "ko": "썬더",
+      "zh-Hans": "闪电鸟",
+      "zh-Hant": "閃電鳥"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0145-galar",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0146",
+    "no": "0146",
+    "form": null,
+    "names": {
+      "ja": "ファイヤー",
+      "en": "Moltres",
+      "ko": "파이어",
+      "zh-Hans": "火焰鸟",
+      "zh-Hant": "火焰鳥"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0146",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0146-galar",
+    "no": "0146",
+    "form": "galar",
+    "names": {
+      "ja": "ファイヤー",
+      "en": "Moltres",
+      "ko": "파이어",
+      "zh-Hans": "火焰鸟",
+      "zh-Hant": "火焰鳥"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0146-galar",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0147",
+    "no": "0147",
+    "form": null,
+    "names": {
+      "ja": "ミニリュウ",
+      "en": "Dratini",
+      "ko": "미뇽",
+      "zh-Hans": "迷你龙",
+      "zh-Hant": "迷你龍"
+    },
+    "types": [
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0147",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0148",
+    "no": "0148",
+    "form": null,
+    "names": {
+      "ja": "ハクリュー",
+      "en": "Dragonair",
+      "ko": "신뇽",
+      "zh-Hans": "哈克龙",
+      "zh-Hant": "哈克龍"
+    },
+    "types": [
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0148",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0149",
+    "no": "0149",
+    "form": null,
+    "names": {
+      "ja": "カイリュー",
+      "en": "Dragonite",
+      "ko": "망나뇽",
+      "zh-Hans": "快龙",
+      "zh-Hant": "快龍"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0149",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0150",
+    "no": "0150",
+    "form": null,
+    "names": {
+      "ja": "ミュウツー",
+      "en": "Mewtwo",
+      "ko": "뮤츠",
+      "zh-Hans": "超梦",
+      "zh-Hant": "超夢"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0150",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0151",
+    "no": "0151",
+    "form": null,
+    "names": {
+      "ja": "ミュウ",
+      "en": "Mew",
+      "ko": "뮤",
+      "zh-Hans": "梦幻",
+      "zh-Hant": "夢幻"
+    },
+    "types": [],
+    "generation": 1,
+    "evolution": {
+      "family_id": "0151",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0152",
+    "no": "0152",
+    "form": null,
+    "names": {
+      "ja": "チコリータ",
+      "en": "Chikorita",
+      "ko": "치코리타",
+      "zh-Hans": "菊草叶",
+      "zh-Hant": "菊草葉"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0152",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0153",
+    "no": "0153",
+    "form": null,
+    "names": {
+      "ja": "ベイリーフ",
+      "en": "Bayleef",
+      "ko": "베이리프",
+      "zh-Hans": "月桂叶",
+      "zh-Hant": "月桂葉"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0153",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0154",
+    "no": "0154",
+    "form": null,
+    "names": {
+      "ja": "メガニウム",
+      "en": "Meganium",
+      "ko": "메가니움",
+      "zh-Hans": "大竺葵",
+      "zh-Hant": "大竺葵"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0154",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0155",
+    "no": "0155",
+    "form": null,
+    "names": {
+      "ja": "ヒノアラシ",
+      "en": "Cyndaquil",
+      "ko": "브케인",
+      "zh-Hans": "火球鼠",
+      "zh-Hant": "火球鼠"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0155",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0156",
+    "no": "0156",
+    "form": null,
+    "names": {
+      "ja": "マグマラシ",
+      "en": "Quilava",
+      "ko": "마그케인",
+      "zh-Hans": "火岩鼠",
+      "zh-Hant": "火岩鼠"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0156",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0157",
+    "no": "0157",
+    "form": null,
+    "names": {
+      "ja": "バクフーン",
+      "en": "Typhlosion",
+      "ko": "블레이범",
+      "zh-Hans": "火暴兽",
+      "zh-Hant": "火爆獸"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0157",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0157-hisui",
+    "no": "0157",
+    "form": "hisui",
+    "names": {
+      "ja": "バクフーン",
+      "en": "Typhlosion",
+      "ko": "블레이범",
+      "zh-Hans": "火暴兽",
+      "zh-Hant": "火爆獸"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0157-hisui",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0158",
+    "no": "0158",
+    "form": null,
+    "names": {
+      "ja": "ワニノコ",
+      "en": "Totodile",
+      "ko": "리아코",
+      "zh-Hans": "小锯鳄",
+      "zh-Hant": "小鋸鱷"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0158",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0159",
+    "no": "0159",
+    "form": null,
+    "names": {
+      "ja": "アリゲイツ",
+      "en": "Croconaw",
+      "ko": "엘리게이",
+      "zh-Hans": "蓝鳄",
+      "zh-Hant": "藍鱷"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0159",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0160",
+    "no": "0160",
+    "form": null,
+    "names": {
+      "ja": "オーダイル",
+      "en": "Feraligatr",
+      "ko": "장크로다일",
+      "zh-Hans": "大力鳄",
+      "zh-Hant": "大力鱷"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0160",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0161",
+    "no": "0161",
+    "form": null,
+    "names": {
+      "ja": "オタチ",
+      "en": "Sentret",
+      "ko": "꼬리선",
+      "zh-Hans": "尾立",
+      "zh-Hant": "尾立"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0161",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0162",
+    "no": "0162",
+    "form": null,
+    "names": {
+      "ja": "オオタチ",
+      "en": "Furret",
+      "ko": "다꼬리",
+      "zh-Hans": "大尾立",
+      "zh-Hant": "大尾立"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0162",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0163",
+    "no": "0163",
+    "form": null,
+    "names": {
+      "ja": "ホーホー",
+      "en": "Hoothoot",
+      "ko": "부우부",
+      "zh-Hans": "咕咕",
+      "zh-Hant": "咕咕"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0163",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0164",
+    "no": "0164",
+    "form": null,
+    "names": {
+      "ja": "ヨルノズク",
+      "en": "Noctowl",
+      "ko": "야부엉",
+      "zh-Hans": "猫头夜鹰",
+      "zh-Hant": "貓頭夜鷹"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0164",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0165",
+    "no": "0165",
+    "form": null,
+    "names": {
+      "ja": "レディバ",
+      "en": "Ledyba",
+      "ko": "레디바",
+      "zh-Hans": "芭瓢虫",
+      "zh-Hant": "芭瓢蟲"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0165",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0166",
+    "no": "0166",
+    "form": null,
+    "names": {
+      "ja": "レディアン",
+      "en": "Ledian",
+      "ko": "레디안",
+      "zh-Hans": "安瓢虫",
+      "zh-Hant": "安瓢蟲"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0166",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0167",
+    "no": "0167",
+    "form": null,
+    "names": {
+      "ja": "イトマル",
+      "en": "Spinarak",
+      "ko": "페이검",
+      "zh-Hans": "圆丝蛛",
+      "zh-Hant": "圓絲蛛"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0167",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0168",
+    "no": "0168",
+    "form": null,
+    "names": {
+      "ja": "アリアドス",
+      "en": "Ariados",
+      "ko": "아리아도스",
+      "zh-Hans": "阿利多斯",
+      "zh-Hant": "阿利多斯"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0168",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0169",
+    "no": "0169",
+    "form": null,
+    "names": {
+      "ja": "クロバット",
+      "en": "Crobat",
+      "ko": "크로뱃",
+      "zh-Hans": "叉字蝠",
+      "zh-Hant": "叉字蝠"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0169",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0170",
+    "no": "0170",
+    "form": null,
+    "names": {
+      "ja": "チョンチー",
+      "en": "Chinchou",
+      "ko": "초라기",
+      "zh-Hans": "灯笼鱼",
+      "zh-Hant": "燈籠魚"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0170",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0171",
+    "no": "0171",
+    "form": null,
+    "names": {
+      "ja": "ランターン",
+      "en": "Lanturn",
+      "ko": "랜턴",
+      "zh-Hans": "电灯怪",
+      "zh-Hant": "電燈怪"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0171",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0172",
+    "no": "0172",
+    "form": null,
+    "names": {
+      "ja": "ピチュー",
+      "en": "Pichu",
+      "ko": "피츄",
+      "zh-Hans": "皮丘",
+      "zh-Hant": "皮丘"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0172",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0173",
+    "no": "0173",
+    "form": null,
+    "names": {
+      "ja": "ピィ",
+      "en": "Cleffa",
+      "ko": "삐",
+      "zh-Hans": "皮宝宝",
+      "zh-Hant": "皮寶寶"
+    },
+    "types": [
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0173",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0174",
+    "no": "0174",
+    "form": null,
+    "names": {
+      "ja": "ププリン",
+      "en": "Igglybuff",
+      "ko": "푸푸린",
+      "zh-Hans": "宝宝丁",
+      "zh-Hant": "寶寶丁"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0174",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0175",
+    "no": "0175",
+    "form": null,
+    "names": {
+      "ja": "トゲピー",
+      "en": "Togepi",
+      "ko": "토게피",
+      "zh-Hans": "波克比",
+      "zh-Hant": "波克比"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0175",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0176",
+    "no": "0176",
+    "form": null,
+    "names": {
+      "ja": "トゲチック",
+      "en": "Togetic",
+      "ko": "토게틱",
+      "zh-Hans": "波克基古",
+      "zh-Hant": "波克基古"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0176",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0177",
+    "no": "0177",
+    "form": null,
+    "names": {
+      "ja": "ネイティ",
+      "en": "Natu",
+      "ko": "네이티",
+      "zh-Hans": "天然雀",
+      "zh-Hant": "天然雀"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0177",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0178",
+    "no": "0178",
+    "form": null,
+    "names": {
+      "ja": "ネイティオ",
+      "en": "Xatu",
+      "ko": "네이티오",
+      "zh-Hans": "天然鸟",
+      "zh-Hant": "天然鳥"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0178",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0179",
+    "no": "0179",
+    "form": null,
+    "names": {
+      "ja": "メリープ",
+      "en": "Mareep",
+      "ko": "메리프",
+      "zh-Hans": "咩利羊",
+      "zh-Hant": "咩利羊"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0179",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0180",
+    "no": "0180",
+    "form": null,
+    "names": {
+      "ja": "モココ",
+      "en": "Flaaffy",
+      "ko": "보송송",
+      "zh-Hans": "茸茸羊",
+      "zh-Hant": "茸茸羊"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0180",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0181",
+    "no": "0181",
+    "form": null,
+    "names": {
+      "ja": "デンリュウ",
+      "en": "Ampharos",
+      "ko": "전룡",
+      "zh-Hans": "电龙",
+      "zh-Hant": "電龍"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0181",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0182",
+    "no": "0182",
+    "form": null,
+    "names": {
+      "ja": "キレイハナ",
+      "en": "Bellossom",
+      "ko": "아르코",
+      "zh-Hans": "美丽花",
+      "zh-Hant": "美麗花"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0182",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0183",
+    "no": "0183",
+    "form": null,
+    "names": {
+      "ja": "マリル",
+      "en": "Marill",
+      "ko": "마릴",
+      "zh-Hans": "玛力露",
+      "zh-Hant": "瑪力露"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0183",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0184",
+    "no": "0184",
+    "form": null,
+    "names": {
+      "ja": "マリルリ",
+      "en": "Azumarill",
+      "ko": "마릴리",
+      "zh-Hans": "玛力露丽",
+      "zh-Hant": "瑪力露麗"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0184",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0185",
+    "no": "0185",
+    "form": null,
+    "names": {
+      "ja": "ウソッキー",
+      "en": "Sudowoodo",
+      "ko": "꼬지모",
+      "zh-Hans": "树才怪",
+      "zh-Hant": "樹才怪"
+    },
+    "types": [
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0185",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0186",
+    "no": "0186",
+    "form": null,
+    "names": {
+      "ja": "ニョロトノ",
+      "en": "Politoed",
+      "ko": "왕구리",
+      "zh-Hans": "蚊香蛙皇",
+      "zh-Hant": "蚊香蛙皇"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0186",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0187",
+    "no": "0187",
+    "form": null,
+    "names": {
+      "ja": "ハネッコ",
+      "en": "Hoppip",
+      "ko": "통통코",
+      "zh-Hans": "毽子草",
+      "zh-Hant": "毽子草"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0187",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0188",
+    "no": "0188",
+    "form": null,
+    "names": {
+      "ja": "ポポッコ",
+      "en": "Skiploom",
+      "ko": "두코",
+      "zh-Hans": "毽子花",
+      "zh-Hant": "毽子花"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0188",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0189",
+    "no": "0189",
+    "form": null,
+    "names": {
+      "ja": "ワタッコ",
+      "en": "Jumpluff",
+      "ko": "솜솜코",
+      "zh-Hans": "毽子棉",
+      "zh-Hant": "毽子棉"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0189",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0190",
+    "no": "0190",
+    "form": null,
+    "names": {
+      "ja": "エイパム",
+      "en": "Aipom",
+      "ko": "에이팜",
+      "zh-Hans": "长尾怪手",
+      "zh-Hant": "長尾怪手"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0190",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0191",
+    "no": "0191",
+    "form": null,
+    "names": {
+      "ja": "ヒマナッツ",
+      "en": "Sunkern",
+      "ko": "해너츠",
+      "zh-Hans": "向日种子",
+      "zh-Hant": "向日種子"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0191",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0192",
+    "no": "0192",
+    "form": null,
+    "names": {
+      "ja": "キマワリ",
+      "en": "Sunflora",
+      "ko": "해루미",
+      "zh-Hans": "向日花怪",
+      "zh-Hant": "向日花怪"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0192",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0193",
+    "no": "0193",
+    "form": null,
+    "names": {
+      "ja": "ヤンヤンマ",
+      "en": "Yanma",
+      "ko": "왕자리",
+      "zh-Hans": "蜻蜻蜓",
+      "zh-Hant": "蜻蜻蜓"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0193",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0194",
+    "no": "0194",
+    "form": null,
+    "names": {
+      "ja": "ウパー",
+      "en": "Wooper",
+      "ko": "우파",
+      "zh-Hans": "乌波",
+      "zh-Hant": "烏波"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0194",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0194-paldea",
+    "no": "0194",
+    "form": "paldea",
+    "names": {
+      "ja": "ウパー",
+      "en": "Wooper",
+      "ko": "우파",
+      "zh-Hans": "乌波",
+      "zh-Hant": "烏波"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0194-paldea",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0195",
+    "no": "0195",
+    "form": null,
+    "names": {
+      "ja": "ヌオー",
+      "en": "Quagsire",
+      "ko": "누오",
+      "zh-Hans": "沼王",
+      "zh-Hant": "沼王"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0195",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0196",
+    "no": "0196",
+    "form": null,
+    "names": {
+      "ja": "エーフィ",
+      "en": "Espeon",
+      "ko": "에브이",
+      "zh-Hans": "太阳伊布",
+      "zh-Hant": "太陽伊布"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0196",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0197",
+    "no": "0197",
+    "form": null,
+    "names": {
+      "ja": "ブラッキー",
+      "en": "Umbreon",
+      "ko": "블래키",
+      "zh-Hans": "月亮伊布",
+      "zh-Hant": "月亮伊布"
+    },
+    "types": [
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0197",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0198",
+    "no": "0198",
+    "form": null,
+    "names": {
+      "ja": "ヤミカラス",
+      "en": "Murkrow",
+      "ko": "니로우",
+      "zh-Hans": "黑暗鸦",
+      "zh-Hant": "黑暗鴉"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0198",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0199",
+    "no": "0199",
+    "form": null,
+    "names": {
+      "ja": "ヤドキング",
+      "en": "Slowking",
+      "ko": "야도킹",
+      "zh-Hans": "呆呆王",
+      "zh-Hant": "呆呆王"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0199",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0199-galar",
+    "no": "0199",
+    "form": "galar",
+    "names": {
+      "ja": "ヤドキング",
+      "en": "Slowking",
+      "ko": "야도킹",
+      "zh-Hans": "呆呆王",
+      "zh-Hant": "呆呆王"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0199-galar",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0200",
+    "no": "0200",
+    "form": null,
+    "names": {
+      "ja": "ムウマ",
+      "en": "Misdreavus",
+      "ko": "무우마",
+      "zh-Hans": "梦妖",
+      "zh-Hant": "夢妖"
+    },
+    "types": [
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0200",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0201",
+    "no": "0201",
+    "form": null,
+    "names": {
+      "ja": "アンノーン",
+      "en": "Unown",
+      "ko": "안농",
+      "zh-Hans": "未知图腾",
+      "zh-Hant": "未知圖騰"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0201",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0202",
+    "no": "0202",
+    "form": null,
+    "names": {
+      "ja": "ソーナンス",
+      "en": "Wobbuffet",
+      "ko": "마자용",
+      "zh-Hans": "果然翁",
+      "zh-Hant": "果然翁"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0202",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0203",
+    "no": "0203",
+    "form": null,
+    "names": {
+      "ja": "キリンリキ",
+      "en": "Girafarig",
+      "ko": "키링키",
+      "zh-Hans": "麒麟奇",
+      "zh-Hant": "麒麟奇"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0203",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0204",
+    "no": "0204",
+    "form": null,
+    "names": {
+      "ja": "クヌギダマ",
+      "en": "Pineco",
+      "ko": "피콘",
+      "zh-Hans": "榛果球",
+      "zh-Hant": "榛果球"
+    },
+    "types": [
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0204",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0205",
+    "no": "0205",
+    "form": null,
+    "names": {
+      "ja": "フォレトス",
+      "en": "Forretress",
+      "ko": "쏘콘",
+      "zh-Hans": "佛烈托斯",
+      "zh-Hant": "佛烈托斯"
+    },
+    "types": [
+      {
+        "ja": "むし",
+        "en": "Bug"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0205",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0206",
+    "no": "0206",
+    "form": null,
+    "names": {
+      "ja": "ノコッチ",
+      "en": "Dunsparce",
+      "ko": "노고치",
+      "zh-Hans": "土龙弟弟",
+      "zh-Hant": "土龍弟弟"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0206",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0207",
+    "no": "0207",
+    "form": null,
+    "names": {
+      "ja": "グライガー",
+      "en": "Gligar",
+      "ko": "글라이거",
+      "zh-Hans": "天蝎",
+      "zh-Hant": "天蠍"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0207",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0208",
+    "no": "0208",
+    "form": null,
+    "names": {
+      "ja": "ハガネール",
+      "en": "Steelix",
+      "ko": "강철톤",
+      "zh-Hans": "大钢蛇",
+      "zh-Hant": "大鋼蛇"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0208",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0209",
+    "no": "0209",
+    "form": null,
+    "names": {
+      "ja": "ブルー",
+      "en": "Snubbull",
+      "ko": "블루",
+      "zh-Hans": "布鲁",
+      "zh-Hant": "布魯"
+    },
+    "types": [
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0209",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0210",
+    "no": "0210",
+    "form": null,
+    "names": {
+      "ja": "グランブル",
+      "en": "Granbull",
+      "ko": "그랑블루",
+      "zh-Hans": "布鲁皇",
+      "zh-Hant": "布魯皇"
+    },
+    "types": [
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0210",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0211",
+    "no": "0211",
+    "form": null,
+    "names": {
+      "ja": "ハリーセン",
+      "en": "Qwilfish",
+      "ko": "침바루",
+      "zh-Hans": "千针鱼",
+      "zh-Hant": "千針魚"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0211",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0211-hisui",
+    "no": "0211",
+    "form": "hisui",
+    "names": {
+      "ja": "ハリーセン",
+      "en": "Qwilfish",
+      "ko": "침바루",
+      "zh-Hans": "千针鱼",
+      "zh-Hant": "千針魚"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0211-hisui",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0212",
+    "no": "0212",
+    "form": null,
+    "names": {
+      "ja": "ハッサム",
+      "en": "Scizor",
+      "ko": "핫삼",
+      "zh-Hans": "巨钳螳螂",
+      "zh-Hant": "巨鉗螳螂"
+    },
+    "types": [
+      {
+        "ja": "むし",
+        "en": "Bug"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0212",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0213",
+    "no": "0213",
+    "form": null,
+    "names": {
+      "ja": "ツボツボ",
+      "en": "Shuckle",
+      "ko": "단단지",
+      "zh-Hans": "壶壶",
+      "zh-Hant": "壺壺"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0213",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0214",
+    "no": "0214",
+    "form": null,
+    "names": {
+      "ja": "ヘラクロス",
+      "en": "Heracross",
+      "ko": "헤라크로스",
+      "zh-Hans": "赫拉克罗斯",
+      "zh-Hant": "赫拉克羅斯"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0214",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0215",
+    "no": "0215",
+    "form": null,
+    "names": {
+      "ja": "ニューラ",
+      "en": "Sneasel",
+      "ko": "포푸니",
+      "zh-Hans": "狃拉",
+      "zh-Hant": "狃拉"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0215",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0215-hisui",
+    "no": "0215",
+    "form": "hisui",
+    "names": {
+      "ja": "ニューラ",
+      "en": "Sneasel",
+      "ko": "포푸니",
+      "zh-Hans": "狃拉",
+      "zh-Hant": "狃拉"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0215-hisui",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0216",
+    "no": "0216",
+    "form": null,
+    "names": {
+      "ja": "ヒメグマ",
+      "en": "Teddiursa",
+      "ko": "깜지곰",
+      "zh-Hans": "熊宝宝",
+      "zh-Hant": "熊寶寶"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0216",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0217",
+    "no": "0217",
+    "form": null,
+    "names": {
+      "ja": "リングマ",
+      "en": "Ursaring",
+      "ko": "링곰",
+      "zh-Hans": "圈圈熊",
+      "zh-Hant": "圈圈熊"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0217",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0218",
+    "no": "0218",
+    "form": null,
+    "names": {
+      "ja": "マグマッグ",
+      "en": "Slugma",
+      "ko": "마그마그",
+      "zh-Hans": "熔岩虫",
+      "zh-Hant": "熔岩蟲"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0218",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0219",
+    "no": "0219",
+    "form": null,
+    "names": {
+      "ja": "マグカルゴ",
+      "en": "Magcargo",
+      "ko": "마그카르고",
+      "zh-Hans": "熔岩蜗牛",
+      "zh-Hant": "熔岩蝸牛"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0219",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0220",
+    "no": "0220",
+    "form": null,
+    "names": {
+      "ja": "ウリムー",
+      "en": "Swinub",
+      "ko": "꾸꾸리",
+      "zh-Hans": "小山猪",
+      "zh-Hant": "小山豬"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      },
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0220",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0221",
+    "no": "0221",
+    "form": null,
+    "names": {
+      "ja": "イノムー",
+      "en": "Piloswine",
+      "ko": "메꾸리",
+      "zh-Hans": "长毛猪",
+      "zh-Hant": "長毛豬"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      },
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0221",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0222",
+    "no": "0222",
+    "form": null,
+    "names": {
+      "ja": "サニーゴ",
+      "en": "Corsola",
+      "ko": "코산호",
+      "zh-Hans": "太阳珊瑚",
+      "zh-Hant": "太陽珊瑚"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0222",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0222-galar",
+    "no": "0222",
+    "form": "galar",
+    "names": {
+      "ja": "サニーゴ",
+      "en": "Corsola",
+      "ko": "코산호",
+      "zh-Hans": "太阳珊瑚",
+      "zh-Hant": "太陽珊瑚"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0222-galar",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0223",
+    "no": "0223",
+    "form": null,
+    "names": {
+      "ja": "テッポウオ",
+      "en": "Remoraid",
+      "ko": "총어",
+      "zh-Hans": "铁炮鱼",
+      "zh-Hant": "鐵炮魚"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0223",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0224",
+    "no": "0224",
+    "form": null,
+    "names": {
+      "ja": "オクタン",
+      "en": "Octillery",
+      "ko": "대포무노",
+      "zh-Hans": "章鱼桶",
+      "zh-Hant": "章魚桶"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0224",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0225",
+    "no": "0225",
+    "form": null,
+    "names": {
+      "ja": "デリバード",
+      "en": "Delibird",
+      "ko": "딜리버드",
+      "zh-Hans": "信使鸟",
+      "zh-Hant": "信使鳥"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0225",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0226",
+    "no": "0226",
+    "form": null,
+    "names": {
+      "ja": "マンタイン",
+      "en": "Mantine",
+      "ko": "만타인",
+      "zh-Hans": "巨翅飞鱼",
+      "zh-Hant": "巨翅飛魚"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0226",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0227",
+    "no": "0227",
+    "form": null,
+    "names": {
+      "ja": "エアームド",
+      "en": "Skarmory",
+      "ko": "무장조",
+      "zh-Hans": "盔甲鸟",
+      "zh-Hant": "盔甲鳥"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0227",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0228",
+    "no": "0228",
+    "form": null,
+    "names": {
+      "ja": "デルビル",
+      "en": "Houndour",
+      "ko": "델빌",
+      "zh-Hans": "戴鲁比",
+      "zh-Hant": "戴魯比"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0228",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0229",
+    "no": "0229",
+    "form": null,
+    "names": {
+      "ja": "ヘルガー",
+      "en": "Houndoom",
+      "ko": "헬가",
+      "zh-Hans": "黑鲁加",
+      "zh-Hant": "黑魯加"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0229",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0230",
+    "no": "0230",
+    "form": null,
+    "names": {
+      "ja": "キングドラ",
+      "en": "Kingdra",
+      "ko": "킹드라",
+      "zh-Hans": "刺龙王",
+      "zh-Hant": "刺龍王"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0230",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0231",
+    "no": "0231",
+    "form": null,
+    "names": {
+      "ja": "ゴマゾウ",
+      "en": "Phanpy",
+      "ko": "코코리",
+      "zh-Hans": "小小象",
+      "zh-Hant": "小小象"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0231",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0232",
+    "no": "0232",
+    "form": null,
+    "names": {
+      "ja": "ドンファン",
+      "en": "Donphan",
+      "ko": "코리갑",
+      "zh-Hans": "顿甲",
+      "zh-Hant": "頓甲"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0232",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0233",
+    "no": "0233",
+    "form": null,
+    "names": {
+      "ja": "ポリゴン２",
+      "en": "Porygon2",
+      "ko": "폴리곤2",
+      "zh-Hans": "多边兽２型",
+      "zh-Hant": "多邊獸Ⅱ"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0233",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0234",
+    "no": "0234",
+    "form": null,
+    "names": {
+      "ja": "オドシシ",
+      "en": "Stantler",
+      "ko": "노라키",
+      "zh-Hans": "惊角鹿",
+      "zh-Hant": "驚角鹿"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0234",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0235",
+    "no": "0235",
+    "form": null,
+    "names": {
+      "ja": "ドーブル",
+      "en": "Smeargle",
+      "ko": "루브도",
+      "zh-Hans": "图图犬",
+      "zh-Hant": "圖圖犬"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0235",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0236",
+    "no": "0236",
+    "form": null,
+    "names": {
+      "ja": "バルキー",
+      "en": "Tyrogue",
+      "ko": "배루키",
+      "zh-Hans": "无畏小子",
+      "zh-Hant": "無畏小子"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0236",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0237",
+    "no": "0237",
+    "form": null,
+    "names": {
+      "ja": "カポエラー",
+      "en": "Hitmontop",
+      "ko": "카포에라",
+      "zh-Hans": "战舞郎",
+      "zh-Hant": "戰舞郎"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0237",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0238",
+    "no": "0238",
+    "form": null,
+    "names": {
+      "ja": "ムチュール",
+      "en": "Smoochum",
+      "ko": "뽀뽀라",
+      "zh-Hans": "迷唇娃",
+      "zh-Hant": "迷唇娃"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0238",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0239",
+    "no": "0239",
+    "form": null,
+    "names": {
+      "ja": "エレキッド",
+      "en": "Elekid",
+      "ko": "에레키드",
+      "zh-Hans": "电击怪",
+      "zh-Hant": "電擊怪"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0239",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0240",
+    "no": "0240",
+    "form": null,
+    "names": {
+      "ja": "ブビィ",
+      "en": "Magby",
+      "ko": "마그비",
+      "zh-Hans": "鸭嘴宝宝",
+      "zh-Hant": "鴨嘴寶寶"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0240",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0241",
+    "no": "0241",
+    "form": null,
+    "names": {
+      "ja": "ミルタンク",
+      "en": "Miltank",
+      "ko": "밀탱크",
+      "zh-Hans": "大奶罐",
+      "zh-Hant": "大奶罐"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0241",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0242",
+    "no": "0242",
+    "form": null,
+    "names": {
+      "ja": "ハピナス",
+      "en": "Blissey",
+      "ko": "해피너스",
+      "zh-Hans": "幸福蛋",
+      "zh-Hant": "幸福蛋"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0242",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0243",
+    "no": "0243",
+    "form": null,
+    "names": {
+      "ja": "ライコウ",
+      "en": "Raikou",
+      "ko": "라이코",
+      "zh-Hans": "雷公",
+      "zh-Hant": "雷公"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0243",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0244",
+    "no": "0244",
+    "form": null,
+    "names": {
+      "ja": "エンテイ",
+      "en": "Entei",
+      "ko": "앤테이",
+      "zh-Hans": "炎帝",
+      "zh-Hant": "炎帝"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0244",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0245",
+    "no": "0245",
+    "form": null,
+    "names": {
+      "ja": "スイクン",
+      "en": "Suicune",
+      "ko": "스이쿤",
+      "zh-Hans": "水君",
+      "zh-Hant": "水君"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0245",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0246",
+    "no": "0246",
+    "form": null,
+    "names": {
+      "ja": "ヨーギラス",
+      "en": "Larvitar",
+      "ko": "애버라스",
+      "zh-Hans": "幼基拉斯",
+      "zh-Hant": "幼基拉斯"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0246",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0247",
+    "no": "0247",
+    "form": null,
+    "names": {
+      "ja": "サナギラス",
+      "en": "Pupitar",
+      "ko": "데기라스",
+      "zh-Hans": "沙基拉斯",
+      "zh-Hant": "沙基拉斯"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0247",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0248",
+    "no": "0248",
+    "form": null,
+    "names": {
+      "ja": "バンギラス",
+      "en": "Tyranitar",
+      "ko": "마기라스",
+      "zh-Hans": "班基拉斯",
+      "zh-Hant": "班基拉斯"
+    },
+    "types": [
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0248",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0249",
+    "no": "0249",
+    "form": null,
+    "names": {
+      "ja": "ルギア",
+      "en": "Lugia",
+      "ko": "루기아",
+      "zh-Hans": "洛奇亚",
+      "zh-Hant": "洛奇亞"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0249",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0250",
+    "no": "0250",
+    "form": null,
+    "names": {
+      "ja": "ホウオウ",
+      "en": "Ho-Oh",
+      "ko": "칠색조",
+      "zh-Hans": "凤王",
+      "zh-Hant": "鳳王"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0250",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0251",
+    "no": "0251",
+    "form": null,
+    "names": {
+      "ja": "セレビィ",
+      "en": "Celebi",
+      "ko": "세레비",
+      "zh-Hans": "时拉比",
+      "zh-Hant": "時拉比"
+    },
+    "types": [],
+    "generation": 2,
+    "evolution": {
+      "family_id": "0251",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0252",
+    "no": "0252",
+    "form": null,
+    "names": {
+      "ja": "キモリ",
+      "en": "Treecko",
+      "ko": "나무지기",
+      "zh-Hans": "木守宫",
+      "zh-Hant": "木守宮"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0252",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0253",
+    "no": "0253",
+    "form": null,
+    "names": {
+      "ja": "ジュプトル",
+      "en": "Grovyle",
+      "ko": "나무돌이",
+      "zh-Hans": "森林蜥蜴",
+      "zh-Hant": "森林蜥蜴"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0253",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0254",
+    "no": "0254",
+    "form": null,
+    "names": {
+      "ja": "ジュカイン",
+      "en": "Sceptile",
+      "ko": "나무킹",
+      "zh-Hans": "蜥蜴王",
+      "zh-Hant": "蜥蜴王"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0254",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0255",
+    "no": "0255",
+    "form": null,
+    "names": {
+      "ja": "アチャモ",
+      "en": "Torchic",
+      "ko": "아차모",
+      "zh-Hans": "火稚鸡",
+      "zh-Hant": "火稚雞"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0255",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0256",
+    "no": "0256",
+    "form": null,
+    "names": {
+      "ja": "ワカシャモ",
+      "en": "Combusken",
+      "ko": "영치코",
+      "zh-Hans": "力壮鸡",
+      "zh-Hant": "力壯雞"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0256",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0257",
+    "no": "0257",
+    "form": null,
+    "names": {
+      "ja": "バシャーモ",
+      "en": "Blaziken",
+      "ko": "번치코",
+      "zh-Hans": "火焰鸡",
+      "zh-Hant": "火焰雞"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0257",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0258",
+    "no": "0258",
+    "form": null,
+    "names": {
+      "ja": "ミズゴロウ",
+      "en": "Mudkip",
+      "ko": "물짱이",
+      "zh-Hans": "水跃鱼",
+      "zh-Hant": "水躍魚"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0258",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0259",
+    "no": "0259",
+    "form": null,
+    "names": {
+      "ja": "ヌマクロー",
+      "en": "Marshtomp",
+      "ko": "늪짱이",
+      "zh-Hans": "沼跃鱼",
+      "zh-Hant": "沼躍魚"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0259",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0260",
+    "no": "0260",
+    "form": null,
+    "names": {
+      "ja": "ラグラージ",
+      "en": "Swampert",
+      "ko": "대짱이",
+      "zh-Hans": "巨沼怪",
+      "zh-Hant": "巨沼怪"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0260",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0261",
+    "no": "0261",
+    "form": null,
+    "names": {
+      "ja": "ポチエナ",
+      "en": "Poochyena",
+      "ko": "포챠나",
+      "zh-Hans": "土狼犬",
+      "zh-Hant": "土狼犬"
+    },
+    "types": [
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0261",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0262",
+    "no": "0262",
+    "form": null,
+    "names": {
+      "ja": "グラエナ",
+      "en": "Mightyena",
+      "ko": "그라에나",
+      "zh-Hans": "大狼犬",
+      "zh-Hant": "大狼犬"
+    },
+    "types": [
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0262",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0263",
+    "no": "0263",
+    "form": null,
+    "names": {
+      "ja": "ジグザグマ",
+      "en": "Zigzagoon",
+      "ko": "지그제구리",
+      "zh-Hans": "蛇纹熊",
+      "zh-Hant": "蛇紋熊"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0263",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0263-galar",
+    "no": "0263",
+    "form": "galar",
+    "names": {
+      "ja": "ジグザグマ",
+      "en": "Zigzagoon",
+      "ko": "지그제구리",
+      "zh-Hans": "蛇纹熊",
+      "zh-Hant": "蛇紋熊"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0263-galar",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0264",
+    "no": "0264",
+    "form": null,
+    "names": {
+      "ja": "マッスグマ",
+      "en": "Linoone",
+      "ko": "직구리",
+      "zh-Hans": "直冲熊",
+      "zh-Hant": "直衝熊"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0264",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0264-galar",
+    "no": "0264",
+    "form": "galar",
+    "names": {
+      "ja": "マッスグマ",
+      "en": "Linoone",
+      "ko": "직구리",
+      "zh-Hans": "直冲熊",
+      "zh-Hant": "直衝熊"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0264-galar",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0265",
+    "no": "0265",
+    "form": null,
+    "names": {
+      "ja": "ケムッソ",
+      "en": "Wurmple",
+      "ko": "개무소",
+      "zh-Hans": "刺尾虫",
+      "zh-Hant": "刺尾蟲"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0265",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0266",
+    "no": "0266",
+    "form": null,
+    "names": {
+      "ja": "カラサリス",
+      "en": "Silcoon",
+      "ko": "실쿤",
+      "zh-Hans": "甲壳茧",
+      "zh-Hant": "甲殼繭"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0266",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0267",
+    "no": "0267",
+    "form": null,
+    "names": {
+      "ja": "アゲハント",
+      "en": "Beautifly",
+      "ko": "뷰티플라이",
+      "zh-Hans": "狩猎凤蝶",
+      "zh-Hant": "狩獵鳳蝶"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0267",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0268",
+    "no": "0268",
+    "form": null,
+    "names": {
+      "ja": "マユルド",
+      "en": "Cascoon",
+      "ko": "카스쿤",
+      "zh-Hans": "盾甲茧",
+      "zh-Hant": "盾甲繭"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0268",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0269",
+    "no": "0269",
+    "form": null,
+    "names": {
+      "ja": "ドクケイル",
+      "en": "Dustox",
+      "ko": "독케일",
+      "zh-Hans": "毒粉蛾",
+      "zh-Hant": "毒粉蛾"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0269",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0270",
+    "no": "0270",
+    "form": null,
+    "names": {
+      "ja": "ハスボー",
+      "en": "Lotad",
+      "ko": "연꽃몬",
+      "zh-Hans": "莲叶童子",
+      "zh-Hant": "蓮葉童子"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0270",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0271",
+    "no": "0271",
+    "form": null,
+    "names": {
+      "ja": "ハスブレロ",
+      "en": "Lombre",
+      "ko": "로토스",
+      "zh-Hans": "莲帽小童",
+      "zh-Hant": "蓮帽小童"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0271",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0272",
+    "no": "0272",
+    "form": null,
+    "names": {
+      "ja": "ルンパッパ",
+      "en": "Ludicolo",
+      "ko": "로파파",
+      "zh-Hans": "乐天河童",
+      "zh-Hant": "樂天河童"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0272",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0273",
+    "no": "0273",
+    "form": null,
+    "names": {
+      "ja": "タネボー",
+      "en": "Seedot",
+      "ko": "도토링",
+      "zh-Hans": "橡实果",
+      "zh-Hant": "橡實果"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0273",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0274",
+    "no": "0274",
+    "form": null,
+    "names": {
+      "ja": "コノハナ",
+      "en": "Nuzleaf",
+      "ko": "잎새코",
+      "zh-Hans": "长鼻叶",
+      "zh-Hant": "長鼻葉"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0274",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0275",
+    "no": "0275",
+    "form": null,
+    "names": {
+      "ja": "ダーテング",
+      "en": "Shiftry",
+      "ko": "다탱구",
+      "zh-Hans": "狡猾天狗",
+      "zh-Hant": "狡猾天狗"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0275",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0276",
+    "no": "0276",
+    "form": null,
+    "names": {
+      "ja": "スバメ",
+      "en": "Taillow",
+      "ko": "테일로",
+      "zh-Hans": "傲骨燕",
+      "zh-Hant": "傲骨燕"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0276",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0277",
+    "no": "0277",
+    "form": null,
+    "names": {
+      "ja": "オオスバメ",
+      "en": "Swellow",
+      "ko": "스왈로",
+      "zh-Hans": "大王燕",
+      "zh-Hant": "大王燕"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0277",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0278",
+    "no": "0278",
+    "form": null,
+    "names": {
+      "ja": "キャモメ",
+      "en": "Wingull",
+      "ko": "갈모매",
+      "zh-Hans": "长翅鸥",
+      "zh-Hant": "長翅鷗"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0278",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0279",
+    "no": "0279",
+    "form": null,
+    "names": {
+      "ja": "ペリッパー",
+      "en": "Pelipper",
+      "ko": "패리퍼",
+      "zh-Hans": "大嘴鸥",
+      "zh-Hant": "大嘴鷗"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0279",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0280",
+    "no": "0280",
+    "form": null,
+    "names": {
+      "ja": "ラルトス",
+      "en": "Ralts",
+      "ko": "랄토스",
+      "zh-Hans": "拉鲁拉丝",
+      "zh-Hant": "拉魯拉絲"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0280",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0281",
+    "no": "0281",
+    "form": null,
+    "names": {
+      "ja": "キルリア",
+      "en": "Kirlia",
+      "ko": "킬리아",
+      "zh-Hans": "奇鲁莉安",
+      "zh-Hant": "奇魯莉安"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0281",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0282",
+    "no": "0282",
+    "form": null,
+    "names": {
+      "ja": "サーナイト",
+      "en": "Gardevoir",
+      "ko": "가디안",
+      "zh-Hans": "沙奈朵",
+      "zh-Hant": "沙奈朵"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0282",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0283",
+    "no": "0283",
+    "form": null,
+    "names": {
+      "ja": "アメタマ",
+      "en": "Surskit",
+      "ko": "비구술",
+      "zh-Hans": "溜溜糖球",
+      "zh-Hant": "溜溜糖球"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0283",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0284",
+    "no": "0284",
+    "form": null,
+    "names": {
+      "ja": "アメモース",
+      "en": "Masquerain",
+      "ko": "비나방",
+      "zh-Hans": "雨翅蛾",
+      "zh-Hant": "雨翅蛾"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0284",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0285",
+    "no": "0285",
+    "form": null,
+    "names": {
+      "ja": "キノココ",
+      "en": "Shroomish",
+      "ko": "버섯꼬",
+      "zh-Hans": "蘑蘑菇",
+      "zh-Hant": "蘑蘑菇"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0285",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0286",
+    "no": "0286",
+    "form": null,
+    "names": {
+      "ja": "キノガッサ",
+      "en": "Breloom",
+      "ko": "버섯모",
+      "zh-Hans": "斗笠菇",
+      "zh-Hant": "斗笠菇"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0286",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0287",
+    "no": "0287",
+    "form": null,
+    "names": {
+      "ja": "ナマケロ",
+      "en": "Slakoth",
+      "ko": "게을로",
+      "zh-Hans": "懒人獭",
+      "zh-Hant": "懶人獺"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0287",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0288",
+    "no": "0288",
+    "form": null,
+    "names": {
+      "ja": "ヤルキモノ",
+      "en": "Vigoroth",
+      "ko": "발바로",
+      "zh-Hans": "过动猿",
+      "zh-Hant": "過動猿"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0288",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0289",
+    "no": "0289",
+    "form": null,
+    "names": {
+      "ja": "ケッキング",
+      "en": "Slaking",
+      "ko": "게을킹",
+      "zh-Hans": "请假王",
+      "zh-Hant": "請假王"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0289",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0290",
+    "no": "0290",
+    "form": null,
+    "names": {
+      "ja": "ツチニン",
+      "en": "Nincada",
+      "ko": "토중몬",
+      "zh-Hans": "土居忍士",
+      "zh-Hant": "土居忍士"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0290",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0291",
+    "no": "0291",
+    "form": null,
+    "names": {
+      "ja": "テッカニン",
+      "en": "Ninjask",
+      "ko": "아이스크",
+      "zh-Hans": "铁面忍者",
+      "zh-Hant": "鐵面忍者"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0291",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0292",
+    "no": "0292",
+    "form": null,
+    "names": {
+      "ja": "ヌケニン",
+      "en": "Shedinja",
+      "ko": "껍질몬",
+      "zh-Hans": "脱壳忍者",
+      "zh-Hant": "脫殼忍者"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0292",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0293",
+    "no": "0293",
+    "form": null,
+    "names": {
+      "ja": "ゴニョニョ",
+      "en": "Whismur",
+      "ko": "소곤룡",
+      "zh-Hans": "咕妞妞",
+      "zh-Hant": "咕妞妞"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0293",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0294",
+    "no": "0294",
+    "form": null,
+    "names": {
+      "ja": "ドゴーム",
+      "en": "Loudred",
+      "ko": "노공룡",
+      "zh-Hans": "吼爆弹",
+      "zh-Hant": "吼爆彈"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0294",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0295",
+    "no": "0295",
+    "form": null,
+    "names": {
+      "ja": "バクオング",
+      "en": "Exploud",
+      "ko": "폭음룡",
+      "zh-Hans": "爆音怪",
+      "zh-Hant": "爆音怪"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0295",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0296",
+    "no": "0296",
+    "form": null,
+    "names": {
+      "ja": "マクノシタ",
+      "en": "Makuhita",
+      "ko": "마크탕",
+      "zh-Hans": "幕下力士",
+      "zh-Hant": "幕下力士"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0296",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0297",
+    "no": "0297",
+    "form": null,
+    "names": {
+      "ja": "ハリテヤマ",
+      "en": "Hariyama",
+      "ko": "하리뭉",
+      "zh-Hans": "铁掌力士",
+      "zh-Hant": "鐵掌力士"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0297",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0298",
+    "no": "0298",
+    "form": null,
+    "names": {
+      "ja": "ルリリ",
+      "en": "Azurill",
+      "ko": "루리리",
+      "zh-Hans": "露力丽",
+      "zh-Hant": "露力麗"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0298",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0299",
+    "no": "0299",
+    "form": null,
+    "names": {
+      "ja": "ノズパス",
+      "en": "Nosepass",
+      "ko": "코코파스",
+      "zh-Hans": "朝北鼻",
+      "zh-Hant": "朝北鼻"
+    },
+    "types": [
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0299",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0300",
+    "no": "0300",
+    "form": null,
+    "names": {
+      "ja": "エネコ",
+      "en": "Skitty",
+      "ko": "에나비",
+      "zh-Hans": "向尾喵",
+      "zh-Hant": "向尾喵"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0300",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0301",
+    "no": "0301",
+    "form": null,
+    "names": {
+      "ja": "エネコロロ",
+      "en": "Delcatty",
+      "ko": "델케티",
+      "zh-Hans": "优雅猫",
+      "zh-Hant": "優雅貓"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0301",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0302",
+    "no": "0302",
+    "form": null,
+    "names": {
+      "ja": "ヤミラミ",
+      "en": "Sableye",
+      "ko": "깜까미",
+      "zh-Hans": "勾魂眼",
+      "zh-Hant": "勾魂眼"
+    },
+    "types": [
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0302",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0303",
+    "no": "0303",
+    "form": null,
+    "names": {
+      "ja": "クチート",
+      "en": "Mawile",
+      "ko": "입치트",
+      "zh-Hans": "大嘴娃",
+      "zh-Hant": "大嘴娃"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0303",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0304",
+    "no": "0304",
+    "form": null,
+    "names": {
+      "ja": "ココドラ",
+      "en": "Aron",
+      "ko": "가보리",
+      "zh-Hans": "可可多拉",
+      "zh-Hant": "可可多拉"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0304",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0305",
+    "no": "0305",
+    "form": null,
+    "names": {
+      "ja": "コドラ",
+      "en": "Lairon",
+      "ko": "갱도라",
+      "zh-Hans": "可多拉",
+      "zh-Hant": "可多拉"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0305",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0306",
+    "no": "0306",
+    "form": null,
+    "names": {
+      "ja": "ボスゴドラ",
+      "en": "Aggron",
+      "ko": "보스로라",
+      "zh-Hans": "波士可多拉",
+      "zh-Hant": "波士可多拉"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0306",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0307",
+    "no": "0307",
+    "form": null,
+    "names": {
+      "ja": "アサナン",
+      "en": "Meditite",
+      "ko": "요가랑",
+      "zh-Hans": "玛沙那",
+      "zh-Hant": "瑪沙那"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      },
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0307",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0308",
+    "no": "0308",
+    "form": null,
+    "names": {
+      "ja": "チャーレム",
+      "en": "Medicham",
+      "ko": "요가램",
+      "zh-Hans": "恰雷姆",
+      "zh-Hant": "恰雷姆"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      },
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0308",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0309",
+    "no": "0309",
+    "form": null,
+    "names": {
+      "ja": "ラクライ",
+      "en": "Electrike",
+      "ko": "썬더라이",
+      "zh-Hans": "落雷兽",
+      "zh-Hant": "落雷獸"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0309",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0310",
+    "no": "0310",
+    "form": null,
+    "names": {
+      "ja": "ライボルト",
+      "en": "Manectric",
+      "ko": "썬더볼트",
+      "zh-Hans": "雷电兽",
+      "zh-Hant": "雷電獸"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0310",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0311",
+    "no": "0311",
+    "form": null,
+    "names": {
+      "ja": "プラスル",
+      "en": "Plusle",
+      "ko": "플러시",
+      "zh-Hans": "正电拍拍",
+      "zh-Hant": "正電拍拍"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0311",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0312",
+    "no": "0312",
+    "form": null,
+    "names": {
+      "ja": "マイナン",
+      "en": "Minun",
+      "ko": "마이농",
+      "zh-Hans": "负电拍拍",
+      "zh-Hant": "負電拍拍"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0312",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0313",
+    "no": "0313",
+    "form": null,
+    "names": {
+      "ja": "バルビート",
+      "en": "Volbeat",
+      "ko": "볼비트",
+      "zh-Hans": "电萤虫",
+      "zh-Hant": "電螢蟲"
+    },
+    "types": [
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0313",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0314",
+    "no": "0314",
+    "form": null,
+    "names": {
+      "ja": "イルミーゼ",
+      "en": "Illumise",
+      "ko": "네오비트",
+      "zh-Hans": "甜甜萤",
+      "zh-Hant": "甜甜螢"
+    },
+    "types": [
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0314",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0315",
+    "no": "0315",
+    "form": null,
+    "names": {
+      "ja": "ロゼリア",
+      "en": "Roselia",
+      "ko": "로젤리아",
+      "zh-Hans": "毒蔷薇",
+      "zh-Hant": "毒薔薇"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0315",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0316",
+    "no": "0316",
+    "form": null,
+    "names": {
+      "ja": "ゴクリン",
+      "en": "Gulpin",
+      "ko": "꼴깍몬",
+      "zh-Hans": "溶食兽",
+      "zh-Hant": "溶食獸"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0316",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0317",
+    "no": "0317",
+    "form": null,
+    "names": {
+      "ja": "マルノーム",
+      "en": "Swalot",
+      "ko": "꿀꺽몬",
+      "zh-Hans": "吞食兽",
+      "zh-Hant": "吞食獸"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0317",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0318",
+    "no": "0318",
+    "form": null,
+    "names": {
+      "ja": "キバニア",
+      "en": "Carvanha",
+      "ko": "샤프니아",
+      "zh-Hans": "利牙鱼",
+      "zh-Hant": "利牙魚"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0318",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0319",
+    "no": "0319",
+    "form": null,
+    "names": {
+      "ja": "サメハダー",
+      "en": "Sharpedo",
+      "ko": "샤크니아",
+      "zh-Hans": "巨牙鲨",
+      "zh-Hant": "巨牙鯊"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0319",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0320",
+    "no": "0320",
+    "form": null,
+    "names": {
+      "ja": "ホエルコ",
+      "en": "Wailmer",
+      "ko": "고래왕자",
+      "zh-Hans": "吼吼鲸",
+      "zh-Hant": "吼吼鯨"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0320",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0321",
+    "no": "0321",
+    "form": null,
+    "names": {
+      "ja": "ホエルオー",
+      "en": "Wailord",
+      "ko": "고래왕",
+      "zh-Hans": "吼鲸王",
+      "zh-Hant": "吼鯨王"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0321",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0322",
+    "no": "0322",
+    "form": null,
+    "names": {
+      "ja": "ドンメル",
+      "en": "Numel",
+      "ko": "둔타",
+      "zh-Hans": "呆火驼",
+      "zh-Hant": "呆火駝"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0322",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0323",
+    "no": "0323",
+    "form": null,
+    "names": {
+      "ja": "バクーダ",
+      "en": "Camerupt",
+      "ko": "폭타",
+      "zh-Hans": "喷火驼",
+      "zh-Hant": "噴火駝"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0323",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0324",
+    "no": "0324",
+    "form": null,
+    "names": {
+      "ja": "コータス",
+      "en": "Torkoal",
+      "ko": "코터스",
+      "zh-Hans": "煤炭龟",
+      "zh-Hant": "煤炭龜"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0324",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0325",
+    "no": "0325",
+    "form": null,
+    "names": {
+      "ja": "バネブー",
+      "en": "Spoink",
+      "ko": "피그점프",
+      "zh-Hans": "跳跳猪",
+      "zh-Hant": "跳跳豬"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0325",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0326",
+    "no": "0326",
+    "form": null,
+    "names": {
+      "ja": "ブーピッグ",
+      "en": "Grumpig",
+      "ko": "피그킹",
+      "zh-Hans": "噗噗猪",
+      "zh-Hant": "噗噗豬"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0326",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0327",
+    "no": "0327",
+    "form": null,
+    "names": {
+      "ja": "パッチール",
+      "en": "Spinda",
+      "ko": "얼루기",
+      "zh-Hans": "晃晃斑",
+      "zh-Hant": "晃晃斑"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0327",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0328",
+    "no": "0328",
+    "form": null,
+    "names": {
+      "ja": "ナックラー",
+      "en": "Trapinch",
+      "ko": "톱치",
+      "zh-Hans": "大颚蚁",
+      "zh-Hant": "大顎蟻"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0328",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0329",
+    "no": "0329",
+    "form": null,
+    "names": {
+      "ja": "ビブラーバ",
+      "en": "Vibrava",
+      "ko": "비브라바",
+      "zh-Hans": "超音波幼虫",
+      "zh-Hant": "超音波幼蟲"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0329",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0330",
+    "no": "0330",
+    "form": null,
+    "names": {
+      "ja": "フライゴン",
+      "en": "Flygon",
+      "ko": "플라이곤",
+      "zh-Hans": "沙漠蜻蜓",
+      "zh-Hant": "沙漠蜻蜓"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0330",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0331",
+    "no": "0331",
+    "form": null,
+    "names": {
+      "ja": "サボネア",
+      "en": "Cacnea",
+      "ko": "선인왕",
+      "zh-Hans": "刺球仙人掌",
+      "zh-Hant": "刺球仙人掌"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0331",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0332",
+    "no": "0332",
+    "form": null,
+    "names": {
+      "ja": "ノクタス",
+      "en": "Cacturne",
+      "ko": "밤선인",
+      "zh-Hans": "梦歌仙人掌",
+      "zh-Hant": "夢歌仙人掌"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0332",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0333",
+    "no": "0333",
+    "form": null,
+    "names": {
+      "ja": "チルット",
+      "en": "Swablu",
+      "ko": "파비코",
+      "zh-Hans": "青绵鸟",
+      "zh-Hant": "青綿鳥"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0333",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0334",
+    "no": "0334",
+    "form": null,
+    "names": {
+      "ja": "チルタリス",
+      "en": "Altaria",
+      "ko": "파비코리",
+      "zh-Hans": "七夕青鸟",
+      "zh-Hant": "七夕青鳥"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0334",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0335",
+    "no": "0335",
+    "form": null,
+    "names": {
+      "ja": "ザングース",
+      "en": "Zangoose",
+      "ko": "쟝고",
+      "zh-Hans": "猫鼬斩",
+      "zh-Hant": "貓鼬斬"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0335",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0336",
+    "no": "0336",
+    "form": null,
+    "names": {
+      "ja": "ハブネーク",
+      "en": "Seviper",
+      "ko": "세비퍼",
+      "zh-Hans": "饭匙蛇",
+      "zh-Hant": "飯匙蛇"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0336",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0337",
+    "no": "0337",
+    "form": null,
+    "names": {
+      "ja": "ルナトーン",
+      "en": "Lunatone",
+      "ko": "루나톤",
+      "zh-Hans": "月石",
+      "zh-Hant": "月石"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0337",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0338",
+    "no": "0338",
+    "form": null,
+    "names": {
+      "ja": "ソルロック",
+      "en": "Solrock",
+      "ko": "솔록",
+      "zh-Hans": "太阳岩",
+      "zh-Hant": "太陽岩"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0338",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0339",
+    "no": "0339",
+    "form": null,
+    "names": {
+      "ja": "ドジョッチ",
+      "en": "Barboach",
+      "ko": "미꾸리",
+      "zh-Hans": "泥泥鳅",
+      "zh-Hant": "泥泥鰍"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0339",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0340",
+    "no": "0340",
+    "form": null,
+    "names": {
+      "ja": "ナマズン",
+      "en": "Whiscash",
+      "ko": "메깅",
+      "zh-Hans": "鲶鱼王",
+      "zh-Hant": "鯰魚王"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0340",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0341",
+    "no": "0341",
+    "form": null,
+    "names": {
+      "ja": "ヘイガニ",
+      "en": "Corphish",
+      "ko": "가재군",
+      "zh-Hans": "龙虾小兵",
+      "zh-Hant": "龍蝦小兵"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0341",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0342",
+    "no": "0342",
+    "form": null,
+    "names": {
+      "ja": "シザリガー",
+      "en": "Crawdaunt",
+      "ko": "가재장군",
+      "zh-Hans": "铁螯龙虾",
+      "zh-Hant": "鐵螯龍蝦"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0342",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0343",
+    "no": "0343",
+    "form": null,
+    "names": {
+      "ja": "ヤジロン",
+      "en": "Baltoy",
+      "ko": "오뚝군",
+      "zh-Hans": "天秤偶",
+      "zh-Hant": "天秤偶"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0343",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0344",
+    "no": "0344",
+    "form": null,
+    "names": {
+      "ja": "ネンドール",
+      "en": "Claydol",
+      "ko": "점토도리",
+      "zh-Hans": "念力土偶",
+      "zh-Hant": "念力土偶"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0344",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0345",
+    "no": "0345",
+    "form": null,
+    "names": {
+      "ja": "リリーラ",
+      "en": "Lileep",
+      "ko": "릴링",
+      "zh-Hans": "触手百合",
+      "zh-Hant": "觸手百合"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0345",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0346",
+    "no": "0346",
+    "form": null,
+    "names": {
+      "ja": "ユレイドル",
+      "en": "Cradily",
+      "ko": "릴리요",
+      "zh-Hans": "摇篮百合",
+      "zh-Hant": "搖籃百合"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0346",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0347",
+    "no": "0347",
+    "form": null,
+    "names": {
+      "ja": "アノプス",
+      "en": "Anorith",
+      "ko": "아노딥스",
+      "zh-Hans": "太古羽虫",
+      "zh-Hant": "太古羽蟲"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0347",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0348",
+    "no": "0348",
+    "form": null,
+    "names": {
+      "ja": "アーマルド",
+      "en": "Armaldo",
+      "ko": "아말도",
+      "zh-Hans": "太古盔甲",
+      "zh-Hant": "太古盔甲"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0348",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0349",
+    "no": "0349",
+    "form": null,
+    "names": {
+      "ja": "ヒンバス",
+      "en": "Feebas",
+      "ko": "빈티나",
+      "zh-Hans": "丑丑鱼",
+      "zh-Hant": "醜醜魚"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0349",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0350",
+    "no": "0350",
+    "form": null,
+    "names": {
+      "ja": "ミロカロス",
+      "en": "Milotic",
+      "ko": "밀로틱",
+      "zh-Hans": "美纳斯",
+      "zh-Hant": "美納斯"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0350",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0351",
+    "no": "0351",
+    "form": null,
+    "names": {
+      "ja": "ポワルン",
+      "en": "Castform",
+      "ko": "캐스퐁",
+      "zh-Hans": "飘浮泡泡",
+      "zh-Hant": "飄浮泡泡"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0351",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0352",
+    "no": "0352",
+    "form": null,
+    "names": {
+      "ja": "カクレオン",
+      "en": "Kecleon",
+      "ko": "켈리몬",
+      "zh-Hans": "变隐龙",
+      "zh-Hant": "變隱龍"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0352",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0353",
+    "no": "0353",
+    "form": null,
+    "names": {
+      "ja": "カゲボウズ",
+      "en": "Shuppet",
+      "ko": "어둠대신",
+      "zh-Hans": "怨影娃娃",
+      "zh-Hant": "怨影娃娃"
+    },
+    "types": [
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0353",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0354",
+    "no": "0354",
+    "form": null,
+    "names": {
+      "ja": "ジュペッタ",
+      "en": "Banette",
+      "ko": "다크펫",
+      "zh-Hans": "诅咒娃娃",
+      "zh-Hant": "詛咒娃娃"
+    },
+    "types": [
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0354",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0355",
+    "no": "0355",
+    "form": null,
+    "names": {
+      "ja": "ヨマワル",
+      "en": "Duskull",
+      "ko": "해골몽",
+      "zh-Hans": "夜巡灵",
+      "zh-Hant": "夜巡靈"
+    },
+    "types": [
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0355",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0356",
+    "no": "0356",
+    "form": null,
+    "names": {
+      "ja": "サマヨール",
+      "en": "Dusclops",
+      "ko": "미라몽",
+      "zh-Hans": "彷徨夜灵",
+      "zh-Hant": "彷徨夜靈"
+    },
+    "types": [
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0356",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0357",
+    "no": "0357",
+    "form": null,
+    "names": {
+      "ja": "トロピウス",
+      "en": "Tropius",
+      "ko": "트로피우스",
+      "zh-Hans": "热带龙",
+      "zh-Hant": "熱帶龍"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0357",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0358",
+    "no": "0358",
+    "form": null,
+    "names": {
+      "ja": "チリーン",
+      "en": "Chimecho",
+      "ko": "치렁",
+      "zh-Hans": "风铃铃",
+      "zh-Hant": "風鈴鈴"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0358",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0359",
+    "no": "0359",
+    "form": null,
+    "names": {
+      "ja": "アブソル",
+      "en": "Absol",
+      "ko": "앱솔",
+      "zh-Hans": "阿勃梭鲁",
+      "zh-Hant": "阿勃梭魯"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0359",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0360",
+    "no": "0360",
+    "form": null,
+    "names": {
+      "ja": "ソーナノ",
+      "en": "Wynaut",
+      "ko": "마자",
+      "zh-Hans": "小果然",
+      "zh-Hant": "小果然"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0360",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0361",
+    "no": "0361",
+    "form": null,
+    "names": {
+      "ja": "ユキワラシ",
+      "en": "Snorunt",
+      "ko": "눈꼬마",
+      "zh-Hans": "雪童子",
+      "zh-Hant": "雪童子"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0361",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0362",
+    "no": "0362",
+    "form": null,
+    "names": {
+      "ja": "オニゴーリ",
+      "en": "Glalie",
+      "ko": "얼음귀신",
+      "zh-Hans": "冰鬼护",
+      "zh-Hant": "冰鬼護"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0362",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0363",
+    "no": "0363",
+    "form": null,
+    "names": {
+      "ja": "タマザラシ",
+      "en": "Spheal",
+      "ko": "대굴레오",
+      "zh-Hans": "海豹球",
+      "zh-Hant": "海豹球"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0363",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0364",
+    "no": "0364",
+    "form": null,
+    "names": {
+      "ja": "トドグラー",
+      "en": "Sealeo",
+      "ko": "씨레오",
+      "zh-Hans": "海魔狮",
+      "zh-Hant": "海魔獅"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0364",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0365",
+    "no": "0365",
+    "form": null,
+    "names": {
+      "ja": "トドゼルガ",
+      "en": "Walrein",
+      "ko": "씨카이저",
+      "zh-Hans": "帝牙海狮",
+      "zh-Hant": "帝牙海獅"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0365",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0366",
+    "no": "0366",
+    "form": null,
+    "names": {
+      "ja": "パールル",
+      "en": "Clamperl",
+      "ko": "진주몽",
+      "zh-Hans": "珍珠贝",
+      "zh-Hant": "珍珠貝"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0366",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0367",
+    "no": "0367",
+    "form": null,
+    "names": {
+      "ja": "ハンテール",
+      "en": "Huntail",
+      "ko": "헌테일",
+      "zh-Hans": "猎斑鱼",
+      "zh-Hant": "獵斑魚"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0367",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0368",
+    "no": "0368",
+    "form": null,
+    "names": {
+      "ja": "サクラビス",
+      "en": "Gorebyss",
+      "ko": "분홍장이",
+      "zh-Hans": "樱花鱼",
+      "zh-Hant": "櫻花魚"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0368",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0369",
+    "no": "0369",
+    "form": null,
+    "names": {
+      "ja": "ジーランス",
+      "en": "Relicanth",
+      "ko": "시라칸",
+      "zh-Hans": "古空棘鱼",
+      "zh-Hant": "古空棘魚"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0369",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0370",
+    "no": "0370",
+    "form": null,
+    "names": {
+      "ja": "ラブカス",
+      "en": "Luvdisc",
+      "ko": "사랑동이",
+      "zh-Hans": "爱心鱼",
+      "zh-Hant": "愛心魚"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0370",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0371",
+    "no": "0371",
+    "form": null,
+    "names": {
+      "ja": "タツベイ",
+      "en": "Bagon",
+      "ko": "아공이",
+      "zh-Hans": "宝贝龙",
+      "zh-Hant": "寶貝龍"
+    },
+    "types": [
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0371",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0372",
+    "no": "0372",
+    "form": null,
+    "names": {
+      "ja": "コモルー",
+      "en": "Shelgon",
+      "ko": "쉘곤",
+      "zh-Hans": "甲壳龙",
+      "zh-Hant": "甲殼龍"
+    },
+    "types": [
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0372",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0373",
+    "no": "0373",
+    "form": null,
+    "names": {
+      "ja": "ボーマンダ",
+      "en": "Salamence",
+      "ko": "보만다",
+      "zh-Hans": "暴飞龙",
+      "zh-Hant": "暴飛龍"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0373",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0374",
+    "no": "0374",
+    "form": null,
+    "names": {
+      "ja": "ダンバル",
+      "en": "Beldum",
+      "ko": "메탕",
+      "zh-Hans": "铁哑铃",
+      "zh-Hant": "鐵啞鈴"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0374",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0375",
+    "no": "0375",
+    "form": null,
+    "names": {
+      "ja": "メタング",
+      "en": "Metang",
+      "ko": "메탕구",
+      "zh-Hans": "金属怪",
+      "zh-Hant": "金屬怪"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0375",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0376",
+    "no": "0376",
+    "form": null,
+    "names": {
+      "ja": "メタグロス",
+      "en": "Metagross",
+      "ko": "메타그로스",
+      "zh-Hans": "巨金怪",
+      "zh-Hant": "巨金怪"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0376",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0377",
+    "no": "0377",
+    "form": null,
+    "names": {
+      "ja": "レジロック",
+      "en": "Regirock",
+      "ko": "레지락",
+      "zh-Hans": "雷吉洛克",
+      "zh-Hant": "雷吉洛克"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0377",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0378",
+    "no": "0378",
+    "form": null,
+    "names": {
+      "ja": "レジアイス",
+      "en": "Regice",
+      "ko": "레지아이스",
+      "zh-Hans": "雷吉艾斯",
+      "zh-Hant": "雷吉艾斯"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0378",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0379",
+    "no": "0379",
+    "form": null,
+    "names": {
+      "ja": "レジスチル",
+      "en": "Registeel",
+      "ko": "레지스틸",
+      "zh-Hans": "雷吉斯奇鲁",
+      "zh-Hant": "雷吉斯奇魯"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0379",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0380",
+    "no": "0380",
+    "form": null,
+    "names": {
+      "ja": "ラティアス",
+      "en": "Latias",
+      "ko": "라티아스",
+      "zh-Hans": "拉帝亚斯",
+      "zh-Hant": "拉帝亞斯"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0380",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0381",
+    "no": "0381",
+    "form": null,
+    "names": {
+      "ja": "ラティオス",
+      "en": "Latios",
+      "ko": "라티오스",
+      "zh-Hans": "拉帝欧斯",
+      "zh-Hant": "拉帝歐斯"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0381",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0382",
+    "no": "0382",
+    "form": null,
+    "names": {
+      "ja": "カイオーガ",
+      "en": "Kyogre",
+      "ko": "가이오가",
+      "zh-Hans": "盖欧卡",
+      "zh-Hant": "蓋歐卡"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0382",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0383",
+    "no": "0383",
+    "form": null,
+    "names": {
+      "ja": "グラードン",
+      "en": "Groudon",
+      "ko": "그란돈",
+      "zh-Hans": "固拉多",
+      "zh-Hant": "固拉多"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0383",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0384",
+    "no": "0384",
+    "form": null,
+    "names": {
+      "ja": "レックウザ",
+      "en": "Rayquaza",
+      "ko": "레쿠쟈",
+      "zh-Hans": "烈空坐",
+      "zh-Hant": "烈空坐"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0384",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0385",
+    "no": "0385",
+    "form": null,
+    "names": {
+      "ja": "ジラーチ",
+      "en": "Jirachi",
+      "ko": "지라치",
+      "zh-Hans": "基拉祈",
+      "zh-Hant": "基拉祈"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0385",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0386",
+    "no": "0386",
+    "form": null,
+    "names": {
+      "ja": "デオキシス",
+      "en": "Deoxys",
+      "ko": "테오키스",
+      "zh-Hans": "代欧奇希斯",
+      "zh-Hant": "代歐奇希斯"
+    },
+    "types": [],
+    "generation": 3,
+    "evolution": {
+      "family_id": "0386",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0387",
+    "no": "0387",
+    "form": null,
+    "names": {
+      "ja": "ナエトル",
+      "en": "Turtwig",
+      "ko": "모부기",
+      "zh-Hans": "草苗龟",
+      "zh-Hant": "草苗龜"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0387",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0388",
+    "no": "0388",
+    "form": null,
+    "names": {
+      "ja": "ハヤシガメ",
+      "en": "Grotle",
+      "ko": "수풀부기",
+      "zh-Hans": "树林龟",
+      "zh-Hant": "樹林龜"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0388",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0389",
+    "no": "0389",
+    "form": null,
+    "names": {
+      "ja": "ドダイトス",
+      "en": "Torterra",
+      "ko": "토대부기",
+      "zh-Hans": "土台龟",
+      "zh-Hant": "土台龜"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0389",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0390",
+    "no": "0390",
+    "form": null,
+    "names": {
+      "ja": "ヒコザル",
+      "en": "Chimchar",
+      "ko": "불꽃숭이",
+      "zh-Hans": "小火焰猴",
+      "zh-Hant": "小火焰猴"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0390",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0391",
+    "no": "0391",
+    "form": null,
+    "names": {
+      "ja": "モウカザル",
+      "en": "Monferno",
+      "ko": "파이숭이",
+      "zh-Hans": "猛火猴",
+      "zh-Hant": "猛火猴"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0391",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0392",
+    "no": "0392",
+    "form": null,
+    "names": {
+      "ja": "ゴウカザル",
+      "en": "Infernape",
+      "ko": "초염몽",
+      "zh-Hans": "烈焰猴",
+      "zh-Hant": "烈焰猴"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0392",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0393",
+    "no": "0393",
+    "form": null,
+    "names": {
+      "ja": "ポッチャマ",
+      "en": "Piplup",
+      "ko": "팽도리",
+      "zh-Hans": "波加曼",
+      "zh-Hant": "波加曼"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0393",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0394",
+    "no": "0394",
+    "form": null,
+    "names": {
+      "ja": "ポッタイシ",
+      "en": "Prinplup",
+      "ko": "팽태자",
+      "zh-Hans": "波皇子",
+      "zh-Hant": "波皇子"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0394",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0395",
+    "no": "0395",
+    "form": null,
+    "names": {
+      "ja": "エンペルト",
+      "en": "Empoleon",
+      "ko": "엠페르트",
+      "zh-Hans": "帝王拿波",
+      "zh-Hant": "帝王拿波"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0395",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0396",
+    "no": "0396",
+    "form": null,
+    "names": {
+      "ja": "ムックル",
+      "en": "Starly",
+      "ko": "찌르꼬",
+      "zh-Hans": "姆克儿",
+      "zh-Hant": "姆克兒"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0396",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0397",
+    "no": "0397",
+    "form": null,
+    "names": {
+      "ja": "ムクバード",
+      "en": "Staravia",
+      "ko": "찌르버드",
+      "zh-Hans": "姆克鸟",
+      "zh-Hant": "姆克鳥"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0397",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0398",
+    "no": "0398",
+    "form": null,
+    "names": {
+      "ja": "ムクホーク",
+      "en": "Staraptor",
+      "ko": "찌르호크",
+      "zh-Hans": "姆克鹰",
+      "zh-Hant": "姆克鷹"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0398",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0399",
+    "no": "0399",
+    "form": null,
+    "names": {
+      "ja": "ビッパ",
+      "en": "Bidoof",
+      "ko": "비버니",
+      "zh-Hans": "大牙狸",
+      "zh-Hant": "大牙狸"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0399",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0400",
+    "no": "0400",
+    "form": null,
+    "names": {
+      "ja": "ビーダル",
+      "en": "Bibarel",
+      "ko": "비버통",
+      "zh-Hans": "大尾狸",
+      "zh-Hant": "大尾狸"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0400",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0401",
+    "no": "0401",
+    "form": null,
+    "names": {
+      "ja": "コロボーシ",
+      "en": "Kricketot",
+      "ko": "귀뚤뚜기",
+      "zh-Hans": "圆法师",
+      "zh-Hant": "圓法師"
+    },
+    "types": [
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0401",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0402",
+    "no": "0402",
+    "form": null,
+    "names": {
+      "ja": "コロトック",
+      "en": "Kricketune",
+      "ko": "귀뚤톡크",
+      "zh-Hans": "音箱蟀",
+      "zh-Hant": "音箱蟀"
+    },
+    "types": [
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0402",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0403",
+    "no": "0403",
+    "form": null,
+    "names": {
+      "ja": "コリンク",
+      "en": "Shinx",
+      "ko": "꼬링크",
+      "zh-Hans": "小猫怪",
+      "zh-Hant": "小貓怪"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0403",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0404",
+    "no": "0404",
+    "form": null,
+    "names": {
+      "ja": "ルクシオ",
+      "en": "Luxio",
+      "ko": "럭시오",
+      "zh-Hans": "勒克猫",
+      "zh-Hant": "勒克貓"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0404",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0405",
+    "no": "0405",
+    "form": null,
+    "names": {
+      "ja": "レントラー",
+      "en": "Luxray",
+      "ko": "렌트라",
+      "zh-Hans": "伦琴猫",
+      "zh-Hant": "倫琴貓"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0405",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0406",
+    "no": "0406",
+    "form": null,
+    "names": {
+      "ja": "スボミー",
+      "en": "Budew",
+      "ko": "꼬몽울",
+      "zh-Hans": "含羞苞",
+      "zh-Hant": "含羞苞"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0406",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0407",
+    "no": "0407",
+    "form": null,
+    "names": {
+      "ja": "ロズレイド",
+      "en": "Roserade",
+      "ko": "로즈레이드",
+      "zh-Hans": "罗丝雷朵",
+      "zh-Hant": "羅絲雷朵"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0407",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0408",
+    "no": "0408",
+    "form": null,
+    "names": {
+      "ja": "ズガイドス",
+      "en": "Cranidos",
+      "ko": "두개도스",
+      "zh-Hans": "头盖龙",
+      "zh-Hant": "頭蓋龍"
+    },
+    "types": [
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0408",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0409",
+    "no": "0409",
+    "form": null,
+    "names": {
+      "ja": "ラムパルド",
+      "en": "Rampardos",
+      "ko": "램펄드",
+      "zh-Hans": "战槌龙",
+      "zh-Hant": "戰槌龍"
+    },
+    "types": [
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0409",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0410",
+    "no": "0410",
+    "form": null,
+    "names": {
+      "ja": "タテトプス",
+      "en": "Shieldon",
+      "ko": "방패톱스",
+      "zh-Hans": "盾甲龙",
+      "zh-Hant": "盾甲龍"
+    },
+    "types": [
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0410",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0411",
+    "no": "0411",
+    "form": null,
+    "names": {
+      "ja": "トリデプス",
+      "en": "Bastiodon",
+      "ko": "바리톱스",
+      "zh-Hans": "护城龙",
+      "zh-Hant": "護城龍"
+    },
+    "types": [
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0411",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0412",
+    "no": "0412",
+    "form": null,
+    "names": {
+      "ja": "ミノムッチ",
+      "en": "Burmy",
+      "ko": "도롱충이",
+      "zh-Hans": "结草儿",
+      "zh-Hant": "結草兒"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0412",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0413",
+    "no": "0413",
+    "form": null,
+    "names": {
+      "ja": "ミノマダム",
+      "en": "Wormadam",
+      "ko": "도롱마담",
+      "zh-Hans": "结草贵妇",
+      "zh-Hant": "結草貴婦"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0413",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0414",
+    "no": "0414",
+    "form": null,
+    "names": {
+      "ja": "ガーメイル",
+      "en": "Mothim",
+      "ko": "나메일",
+      "zh-Hans": "绅士蛾",
+      "zh-Hant": "紳士蛾"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0414",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0415",
+    "no": "0415",
+    "form": null,
+    "names": {
+      "ja": "ミツハニー",
+      "en": "Combee",
+      "ko": "세꿀버리",
+      "zh-Hans": "三蜜蜂",
+      "zh-Hant": "三蜜蜂"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0415",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0416",
+    "no": "0416",
+    "form": null,
+    "names": {
+      "ja": "ビークイン",
+      "en": "Vespiquen",
+      "ko": "비퀸",
+      "zh-Hans": "蜂女王",
+      "zh-Hant": "蜂女王"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0416",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0417",
+    "no": "0417",
+    "form": null,
+    "names": {
+      "ja": "パチリス",
+      "en": "Pachirisu",
+      "ko": "파치리스",
+      "zh-Hans": "帕奇利兹",
+      "zh-Hant": "帕奇利茲"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0417",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0418",
+    "no": "0418",
+    "form": null,
+    "names": {
+      "ja": "ブイゼル",
+      "en": "Buizel",
+      "ko": "브이젤",
+      "zh-Hans": "泳圈鼬",
+      "zh-Hant": "泳圈鼬"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0418",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0419",
+    "no": "0419",
+    "form": null,
+    "names": {
+      "ja": "フローゼル",
+      "en": "Floatzel",
+      "ko": "플로젤",
+      "zh-Hans": "浮潜鼬",
+      "zh-Hant": "浮潛鼬"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0419",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0420",
+    "no": "0420",
+    "form": null,
+    "names": {
+      "ja": "チェリンボ",
+      "en": "Cherubi",
+      "ko": "체리버",
+      "zh-Hans": "樱花宝",
+      "zh-Hant": "櫻花寶"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0420",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0421",
+    "no": "0421",
+    "form": null,
+    "names": {
+      "ja": "チェリム",
+      "en": "Cherrim",
+      "ko": "체리꼬",
+      "zh-Hans": "樱花儿",
+      "zh-Hant": "櫻花兒"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0421",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0422",
+    "no": "0422",
+    "form": null,
+    "names": {
+      "ja": "カラナクシ",
+      "en": "Shellos",
+      "ko": "깝질무",
+      "zh-Hans": "无壳海兔",
+      "zh-Hant": "無殼海兔"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0422",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0423",
+    "no": "0423",
+    "form": null,
+    "names": {
+      "ja": "トリトドン",
+      "en": "Gastrodon",
+      "ko": "트리토돈",
+      "zh-Hans": "海兔兽",
+      "zh-Hant": "海兔獸"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0423",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0424",
+    "no": "0424",
+    "form": null,
+    "names": {
+      "ja": "エテボース",
+      "en": "Ambipom",
+      "ko": "겟핸보숭",
+      "zh-Hans": "双尾怪手",
+      "zh-Hant": "雙尾怪手"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0424",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0425",
+    "no": "0425",
+    "form": null,
+    "names": {
+      "ja": "フワンテ",
+      "en": "Drifloon",
+      "ko": "흔들풍손",
+      "zh-Hans": "飘飘球",
+      "zh-Hant": "飄飄球"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0425",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0426",
+    "no": "0426",
+    "form": null,
+    "names": {
+      "ja": "フワライド",
+      "en": "Drifblim",
+      "ko": "둥실라이드",
+      "zh-Hans": "随风球",
+      "zh-Hant": "隨風球"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0426",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0427",
+    "no": "0427",
+    "form": null,
+    "names": {
+      "ja": "ミミロル",
+      "en": "Buneary",
+      "ko": "이어롤",
+      "zh-Hans": "卷卷耳",
+      "zh-Hant": "捲捲耳"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0427",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0428",
+    "no": "0428",
+    "form": null,
+    "names": {
+      "ja": "ミミロップ",
+      "en": "Lopunny",
+      "ko": "이어롭",
+      "zh-Hans": "长耳兔",
+      "zh-Hant": "長耳兔"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0428",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0429",
+    "no": "0429",
+    "form": null,
+    "names": {
+      "ja": "ムウマージ",
+      "en": "Mismagius",
+      "ko": "무우마직",
+      "zh-Hans": "梦妖魔",
+      "zh-Hant": "夢妖魔"
+    },
+    "types": [
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0429",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0430",
+    "no": "0430",
+    "form": null,
+    "names": {
+      "ja": "ドンカラス",
+      "en": "Honchkrow",
+      "ko": "돈크로우",
+      "zh-Hans": "乌鸦头头",
+      "zh-Hant": "烏鴉頭頭"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0430",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0431",
+    "no": "0431",
+    "form": null,
+    "names": {
+      "ja": "ニャルマー",
+      "en": "Glameow",
+      "ko": "나옹마",
+      "zh-Hans": "魅力喵",
+      "zh-Hant": "魅力喵"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0431",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0432",
+    "no": "0432",
+    "form": null,
+    "names": {
+      "ja": "ブニャット",
+      "en": "Purugly",
+      "ko": "몬냥이",
+      "zh-Hans": "东施喵",
+      "zh-Hant": "東施喵"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0432",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0433",
+    "no": "0433",
+    "form": null,
+    "names": {
+      "ja": "リーシャン",
+      "en": "Chingling",
+      "ko": "랑딸랑",
+      "zh-Hans": "铃铛响",
+      "zh-Hant": "鈴鐺響"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0433",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0434",
+    "no": "0434",
+    "form": null,
+    "names": {
+      "ja": "スカンプー",
+      "en": "Stunky",
+      "ko": "스컹뿡",
+      "zh-Hans": "臭鼬噗",
+      "zh-Hant": "臭鼬噗"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0434",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0435",
+    "no": "0435",
+    "form": null,
+    "names": {
+      "ja": "スカタンク",
+      "en": "Skuntank",
+      "ko": "스컹탱크",
+      "zh-Hans": "坦克臭鼬",
+      "zh-Hant": "坦克臭鼬"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0435",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0436",
+    "no": "0436",
+    "form": null,
+    "names": {
+      "ja": "ドーミラー",
+      "en": "Bronzor",
+      "ko": "동미러",
+      "zh-Hans": "铜镜怪",
+      "zh-Hant": "銅鏡怪"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0436",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0437",
+    "no": "0437",
+    "form": null,
+    "names": {
+      "ja": "ドータクン",
+      "en": "Bronzong",
+      "ko": "동탁군",
+      "zh-Hans": "青铜钟",
+      "zh-Hant": "青銅鐘"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0437",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0438",
+    "no": "0438",
+    "form": null,
+    "names": {
+      "ja": "ウソハチ",
+      "en": "Bonsly",
+      "ko": "꼬지지",
+      "zh-Hans": "盆才怪",
+      "zh-Hant": "盆才怪"
+    },
+    "types": [
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0438",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0439",
+    "no": "0439",
+    "form": null,
+    "names": {
+      "ja": "マネネ",
+      "en": "Mime Jr.",
+      "ko": "흉내내",
+      "zh-Hans": "魔尼尼",
+      "zh-Hant": "魔尼尼"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0439",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0440",
+    "no": "0440",
+    "form": null,
+    "names": {
+      "ja": "ピンプク",
+      "en": "Happiny",
+      "ko": "핑복",
+      "zh-Hans": "小福蛋",
+      "zh-Hant": "小福蛋"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0440",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0441",
+    "no": "0441",
+    "form": null,
+    "names": {
+      "ja": "ペラップ",
+      "en": "Chatot",
+      "ko": "페라페",
+      "zh-Hans": "聒噪鸟",
+      "zh-Hant": "聒噪鳥"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0441",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0442",
+    "no": "0442",
+    "form": null,
+    "names": {
+      "ja": "ミカルゲ",
+      "en": "Spiritomb",
+      "ko": "화강돌",
+      "zh-Hans": "花岩怪",
+      "zh-Hant": "花岩怪"
+    },
+    "types": [
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0442",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0443",
+    "no": "0443",
+    "form": null,
+    "names": {
+      "ja": "フカマル",
+      "en": "Gible",
+      "ko": "딥상어동",
+      "zh-Hans": "圆陆鲨",
+      "zh-Hant": "圓陸鯊"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0443",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0444",
+    "no": "0444",
+    "form": null,
+    "names": {
+      "ja": "ガバイト",
+      "en": "Gabite",
+      "ko": "한바이트",
+      "zh-Hans": "尖牙陆鲨",
+      "zh-Hant": "尖牙陸鯊"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0444",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0445",
+    "no": "0445",
+    "form": null,
+    "names": {
+      "ja": "ガブリアス",
+      "en": "Garchomp",
+      "ko": "한카리아스",
+      "zh-Hans": "烈咬陆鲨",
+      "zh-Hant": "烈咬陸鯊"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0445",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0446",
+    "no": "0446",
+    "form": null,
+    "names": {
+      "ja": "ゴンベ",
+      "en": "Munchlax",
+      "ko": "먹고자",
+      "zh-Hans": "小卡比兽",
+      "zh-Hant": "小卡比獸"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0446",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0447",
+    "no": "0447",
+    "form": null,
+    "names": {
+      "ja": "リオル",
+      "en": "Riolu",
+      "ko": "리오르",
+      "zh-Hans": "利欧路",
+      "zh-Hant": "利歐路"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0447",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0448",
+    "no": "0448",
+    "form": null,
+    "names": {
+      "ja": "ルカリオ",
+      "en": "Lucario",
+      "ko": "루카리오",
+      "zh-Hans": "路卡利欧",
+      "zh-Hant": "路卡利歐"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0448",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0449",
+    "no": "0449",
+    "form": null,
+    "names": {
+      "ja": "ヒポポタス",
+      "en": "Hippopotas",
+      "ko": "히포포타스",
+      "zh-Hans": "沙河马",
+      "zh-Hant": "沙河馬"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0449",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0450",
+    "no": "0450",
+    "form": null,
+    "names": {
+      "ja": "カバルドン",
+      "en": "Hippowdon",
+      "ko": "하마돈",
+      "zh-Hans": "河马兽",
+      "zh-Hant": "河馬獸"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0450",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0451",
+    "no": "0451",
+    "form": null,
+    "names": {
+      "ja": "スコルピ",
+      "en": "Skorupi",
+      "ko": "스콜피",
+      "zh-Hans": "钳尾蝎",
+      "zh-Hant": "鉗尾蠍"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0451",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0452",
+    "no": "0452",
+    "form": null,
+    "names": {
+      "ja": "ドラピオン",
+      "en": "Drapion",
+      "ko": "드래피온",
+      "zh-Hans": "龙王蝎",
+      "zh-Hant": "龍王蠍"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0452",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0453",
+    "no": "0453",
+    "form": null,
+    "names": {
+      "ja": "グレッグル",
+      "en": "Croagunk",
+      "ko": "삐딱구리",
+      "zh-Hans": "不良蛙",
+      "zh-Hant": "不良蛙"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0453",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0454",
+    "no": "0454",
+    "form": null,
+    "names": {
+      "ja": "ドクロッグ",
+      "en": "Toxicroak",
+      "ko": "독개굴",
+      "zh-Hans": "毒骷蛙",
+      "zh-Hant": "毒骷蛙"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0454",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0455",
+    "no": "0455",
+    "form": null,
+    "names": {
+      "ja": "マスキッパ",
+      "en": "Carnivine",
+      "ko": "무스틈니",
+      "zh-Hans": "尖牙笼",
+      "zh-Hant": "尖牙籠"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0455",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0456",
+    "no": "0456",
+    "form": null,
+    "names": {
+      "ja": "ケイコウオ",
+      "en": "Finneon",
+      "ko": "형광어",
+      "zh-Hans": "荧光鱼",
+      "zh-Hant": "螢光魚"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0456",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0457",
+    "no": "0457",
+    "form": null,
+    "names": {
+      "ja": "ネオラント",
+      "en": "Lumineon",
+      "ko": "네오라이트",
+      "zh-Hans": "霓虹鱼",
+      "zh-Hant": "霓虹魚"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0457",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0458",
+    "no": "0458",
+    "form": null,
+    "names": {
+      "ja": "タマンタ",
+      "en": "Mantyke",
+      "ko": "타만타",
+      "zh-Hans": "小球飞鱼",
+      "zh-Hant": "小球飛魚"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0458",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0459",
+    "no": "0459",
+    "form": null,
+    "names": {
+      "ja": "ユキカブリ",
+      "en": "Snover",
+      "ko": "눈쓰개",
+      "zh-Hans": "雪笠怪",
+      "zh-Hant": "雪笠怪"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0459",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0460",
+    "no": "0460",
+    "form": null,
+    "names": {
+      "ja": "ユキノオー",
+      "en": "Abomasnow",
+      "ko": "눈설왕",
+      "zh-Hans": "暴雪王",
+      "zh-Hant": "暴雪王"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0460",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0461",
+    "no": "0461",
+    "form": null,
+    "names": {
+      "ja": "マニューラ",
+      "en": "Weavile",
+      "ko": "포푸니라",
+      "zh-Hans": "玛狃拉",
+      "zh-Hant": "瑪狃拉"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0461",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0462",
+    "no": "0462",
+    "form": null,
+    "names": {
+      "ja": "ジバコイル",
+      "en": "Magnezone",
+      "ko": "자포코일",
+      "zh-Hans": "自爆磁怪",
+      "zh-Hant": "自爆磁怪"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0462",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0463",
+    "no": "0463",
+    "form": null,
+    "names": {
+      "ja": "ベロベルト",
+      "en": "Lickilicky",
+      "ko": "내룸벨트",
+      "zh-Hans": "大舌舔",
+      "zh-Hant": "大舌舔"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0463",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0464",
+    "no": "0464",
+    "form": null,
+    "names": {
+      "ja": "ドサイドン",
+      "en": "Rhyperior",
+      "ko": "거대코뿌리",
+      "zh-Hans": "超甲狂犀",
+      "zh-Hant": "超甲狂犀"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0464",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0465",
+    "no": "0465",
+    "form": null,
+    "names": {
+      "ja": "モジャンボ",
+      "en": "Tangrowth",
+      "ko": "덩쿠림보",
+      "zh-Hans": "巨蔓藤",
+      "zh-Hant": "巨蔓藤"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0465",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0466",
+    "no": "0466",
+    "form": null,
+    "names": {
+      "ja": "エレキブル",
+      "en": "Electivire",
+      "ko": "에레키블",
+      "zh-Hans": "电击魔兽",
+      "zh-Hant": "電擊魔獸"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0466",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0467",
+    "no": "0467",
+    "form": null,
+    "names": {
+      "ja": "ブーバーン",
+      "en": "Magmortar",
+      "ko": "마그마번",
+      "zh-Hans": "鸭嘴炎兽",
+      "zh-Hant": "鴨嘴炎獸"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0467",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0468",
+    "no": "0468",
+    "form": null,
+    "names": {
+      "ja": "トゲキッス",
+      "en": "Togekiss",
+      "ko": "토게키스",
+      "zh-Hans": "波克基斯",
+      "zh-Hant": "波克基斯"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0468",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0469",
+    "no": "0469",
+    "form": null,
+    "names": {
+      "ja": "メガヤンマ",
+      "en": "Yanmega",
+      "ko": "메가자리",
+      "zh-Hans": "远古巨蜓",
+      "zh-Hant": "遠古巨蜓"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0469",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0470",
+    "no": "0470",
+    "form": null,
+    "names": {
+      "ja": "リーフィア",
+      "en": "Leafeon",
+      "ko": "리피아",
+      "zh-Hans": "叶伊布",
+      "zh-Hant": "葉伊布"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0470",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0471",
+    "no": "0471",
+    "form": null,
+    "names": {
+      "ja": "グレイシア",
+      "en": "Glaceon",
+      "ko": "글레이시아",
+      "zh-Hans": "冰伊布",
+      "zh-Hant": "冰伊布"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0471",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0472",
+    "no": "0472",
+    "form": null,
+    "names": {
+      "ja": "グライオン",
+      "en": "Gliscor",
+      "ko": "글라이온",
+      "zh-Hans": "天蝎王",
+      "zh-Hant": "天蠍王"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0472",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0473",
+    "no": "0473",
+    "form": null,
+    "names": {
+      "ja": "マンムー",
+      "en": "Mamoswine",
+      "ko": "맘모꾸리",
+      "zh-Hans": "象牙猪",
+      "zh-Hant": "象牙豬"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      },
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0473",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0474",
+    "no": "0474",
+    "form": null,
+    "names": {
+      "ja": "ポリゴンＺ",
+      "en": "Porygon-Z",
+      "ko": "폴리곤Z",
+      "zh-Hans": "多边兽乙型",
+      "zh-Hant": "多邊獸Ｚ"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0474",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0475",
+    "no": "0475",
+    "form": null,
+    "names": {
+      "ja": "エルレイド",
+      "en": "Gallade",
+      "ko": "엘레이드",
+      "zh-Hans": "艾路雷朵",
+      "zh-Hant": "艾路雷朵"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      },
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0475",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0476",
+    "no": "0476",
+    "form": null,
+    "names": {
+      "ja": "ダイノーズ",
+      "en": "Probopass",
+      "ko": "대코파스",
+      "zh-Hans": "大朝北鼻",
+      "zh-Hant": "大朝北鼻"
+    },
+    "types": [
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0476",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0477",
+    "no": "0477",
+    "form": null,
+    "names": {
+      "ja": "ヨノワール",
+      "en": "Dusknoir",
+      "ko": "야느와르몽",
+      "zh-Hans": "黑夜魔灵",
+      "zh-Hant": "黑夜魔靈"
+    },
+    "types": [
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0477",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0478",
+    "no": "0478",
+    "form": null,
+    "names": {
+      "ja": "ユキメノコ",
+      "en": "Froslass",
+      "ko": "눈여아",
+      "zh-Hans": "雪妖女",
+      "zh-Hant": "雪妖女"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0478",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0479",
+    "no": "0479",
+    "form": null,
+    "names": {
+      "ja": "ロトム",
+      "en": "Rotom",
+      "ko": "로토무",
+      "zh-Hans": "洛托姆",
+      "zh-Hant": "洛托姆"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0479",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0480",
+    "no": "0480",
+    "form": null,
+    "names": {
+      "ja": "ユクシー",
+      "en": "Uxie",
+      "ko": "유크시",
+      "zh-Hans": "由克希",
+      "zh-Hant": "由克希"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0480",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0481",
+    "no": "0481",
+    "form": null,
+    "names": {
+      "ja": "エムリット",
+      "en": "Mesprit",
+      "ko": "엠라이트",
+      "zh-Hans": "艾姆利多",
+      "zh-Hant": "艾姆利多"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0481",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0482",
+    "no": "0482",
+    "form": null,
+    "names": {
+      "ja": "アグノム",
+      "en": "Azelf",
+      "ko": "아그놈",
+      "zh-Hans": "亚克诺姆",
+      "zh-Hant": "亞克諾姆"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0482",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0483",
+    "no": "0483",
+    "form": null,
+    "names": {
+      "ja": "ディアルガ",
+      "en": "Dialga",
+      "ko": "디아루가",
+      "zh-Hans": "帝牙卢卡",
+      "zh-Hant": "帝牙盧卡"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0483",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0484",
+    "no": "0484",
+    "form": null,
+    "names": {
+      "ja": "パルキア",
+      "en": "Palkia",
+      "ko": "펄기아",
+      "zh-Hans": "帕路奇亚",
+      "zh-Hant": "帕路奇亞"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0484",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0485",
+    "no": "0485",
+    "form": null,
+    "names": {
+      "ja": "ヒードラン",
+      "en": "Heatran",
+      "ko": "히드런",
+      "zh-Hans": "席多蓝恩",
+      "zh-Hant": "席多藍恩"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0485",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0486",
+    "no": "0486",
+    "form": null,
+    "names": {
+      "ja": "レジギガス",
+      "en": "Regigigas",
+      "ko": "레지기가스",
+      "zh-Hans": "雷吉奇卡斯",
+      "zh-Hant": "雷吉奇卡斯"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0486",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0487",
+    "no": "0487",
+    "form": null,
+    "names": {
+      "ja": "ギラティナ",
+      "en": "Giratina",
+      "ko": "기라티나",
+      "zh-Hans": "骑拉帝纳",
+      "zh-Hant": "騎拉帝納"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0487",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0488",
+    "no": "0488",
+    "form": null,
+    "names": {
+      "ja": "クレセリア",
+      "en": "Cresselia",
+      "ko": "크레세리아",
+      "zh-Hans": "克雷色利亚",
+      "zh-Hant": "克雷色利亞"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0488",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0489",
+    "no": "0489",
+    "form": null,
+    "names": {
+      "ja": "フィオネ",
+      "en": "Phione",
+      "ko": "피오네",
+      "zh-Hans": "霏欧纳",
+      "zh-Hant": "霏歐納"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0489",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0490",
+    "no": "0490",
+    "form": null,
+    "names": {
+      "ja": "マナフィ",
+      "en": "Manaphy",
+      "ko": "마나피",
+      "zh-Hans": "玛纳霏",
+      "zh-Hant": "瑪納霏"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0490",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0491",
+    "no": "0491",
+    "form": null,
+    "names": {
+      "ja": "ダークライ",
+      "en": "Darkrai",
+      "ko": "다크라이",
+      "zh-Hans": "达克莱伊",
+      "zh-Hant": "達克萊伊"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0491",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0492",
+    "no": "0492",
+    "form": null,
+    "names": {
+      "ja": "シェイミ",
+      "en": "Shaymin",
+      "ko": "쉐이미",
+      "zh-Hans": "谢米",
+      "zh-Hant": "謝米"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0492",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0493",
+    "no": "0493",
+    "form": null,
+    "names": {
+      "ja": "アルセウス",
+      "en": "Arceus",
+      "ko": "아르세우스",
+      "zh-Hans": "阿尔宙斯",
+      "zh-Hant": "阿爾宙斯"
+    },
+    "types": [],
+    "generation": 4,
+    "evolution": {
+      "family_id": "0493",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0494",
+    "no": "0494",
+    "form": null,
+    "names": {
+      "ja": "ビクティニ",
+      "en": "Victini",
+      "ko": "비크티니",
+      "zh-Hans": "比克提尼",
+      "zh-Hant": "比克提尼"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0494",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0495",
+    "no": "0495",
+    "form": null,
+    "names": {
+      "ja": "ツタージャ",
+      "en": "Snivy",
+      "ko": "주리비얀",
+      "zh-Hans": "藤藤蛇",
+      "zh-Hant": "藤藤蛇"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0495",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0496",
+    "no": "0496",
+    "form": null,
+    "names": {
+      "ja": "ジャノビー",
+      "en": "Servine",
+      "ko": "샤비",
+      "zh-Hans": "青藤蛇",
+      "zh-Hant": "青藤蛇"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0496",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0497",
+    "no": "0497",
+    "form": null,
+    "names": {
+      "ja": "ジャローダ",
+      "en": "Serperior",
+      "ko": "샤로다",
+      "zh-Hans": "君主蛇",
+      "zh-Hant": "君主蛇"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0497",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0498",
+    "no": "0498",
+    "form": null,
+    "names": {
+      "ja": "ポカブ",
+      "en": "Tepig",
+      "ko": "뚜꾸리",
+      "zh-Hans": "暖暖猪",
+      "zh-Hant": "暖暖豬"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0498",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0499",
+    "no": "0499",
+    "form": null,
+    "names": {
+      "ja": "チャオブー",
+      "en": "Pignite",
+      "ko": "차오꿀",
+      "zh-Hans": "炒炒猪",
+      "zh-Hant": "炒炒豬"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0499",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0500",
+    "no": "0500",
+    "form": null,
+    "names": {
+      "ja": "エンブオー",
+      "en": "Emboar",
+      "ko": "염무왕",
+      "zh-Hans": "炎武王",
+      "zh-Hant": "炎武王"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0500",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0501",
+    "no": "0501",
+    "form": null,
+    "names": {
+      "ja": "ミジュマル",
+      "en": "Oshawott",
+      "ko": "수댕이",
+      "zh-Hans": "水水獭",
+      "zh-Hant": "水水獺"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0501",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0502",
+    "no": "0502",
+    "form": null,
+    "names": {
+      "ja": "フタチマル",
+      "en": "Dewott",
+      "ko": "쌍검자비",
+      "zh-Hans": "双刃丸",
+      "zh-Hant": "雙刃丸"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0502",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0503",
+    "no": "0503",
+    "form": null,
+    "names": {
+      "ja": "ダイケンキ",
+      "en": "Samurott",
+      "ko": "대검귀",
+      "zh-Hans": "大剑鬼",
+      "zh-Hant": "大劍鬼"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0503",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0503-hisui",
+    "no": "0503",
+    "form": "hisui",
+    "names": {
+      "ja": "ダイケンキ",
+      "en": "Samurott",
+      "ko": "대검귀",
+      "zh-Hans": "大剑鬼",
+      "zh-Hant": "大劍鬼"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0503-hisui",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0504",
+    "no": "0504",
+    "form": null,
+    "names": {
+      "ja": "ミネズミ",
+      "en": "Patrat",
+      "ko": "보르쥐",
+      "zh-Hans": "探探鼠",
+      "zh-Hant": "探探鼠"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0504",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0505",
+    "no": "0505",
+    "form": null,
+    "names": {
+      "ja": "ミルホッグ",
+      "en": "Watchog",
+      "ko": "보르그",
+      "zh-Hans": "步哨鼠",
+      "zh-Hant": "步哨鼠"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0505",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0506",
+    "no": "0506",
+    "form": null,
+    "names": {
+      "ja": "ヨーテリー",
+      "en": "Lillipup",
+      "ko": "요테리",
+      "zh-Hans": "小约克",
+      "zh-Hant": "小約克"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0506",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0507",
+    "no": "0507",
+    "form": null,
+    "names": {
+      "ja": "ハーデリア",
+      "en": "Herdier",
+      "ko": "하데리어",
+      "zh-Hans": "哈约克",
+      "zh-Hant": "哈約克"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0507",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0508",
+    "no": "0508",
+    "form": null,
+    "names": {
+      "ja": "ムーランド",
+      "en": "Stoutland",
+      "ko": "바랜드",
+      "zh-Hans": "长毛狗",
+      "zh-Hant": "長毛狗"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0508",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0509",
+    "no": "0509",
+    "form": null,
+    "names": {
+      "ja": "チョロネコ",
+      "en": "Purrloin",
+      "ko": "쌔비냥",
+      "zh-Hans": "扒手猫",
+      "zh-Hant": "扒手貓"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0509",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0510",
+    "no": "0510",
+    "form": null,
+    "names": {
+      "ja": "レパルダス",
+      "en": "Liepard",
+      "ko": "레파르다스",
+      "zh-Hans": "酷豹",
+      "zh-Hant": "酷豹"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0510",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0511",
+    "no": "0511",
+    "form": null,
+    "names": {
+      "ja": "ヤナップ",
+      "en": "Pansage",
+      "ko": "야나프",
+      "zh-Hans": "花椰猴",
+      "zh-Hant": "花椰猴"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0511",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0512",
+    "no": "0512",
+    "form": null,
+    "names": {
+      "ja": "ヤナッキー",
+      "en": "Simisage",
+      "ko": "야나키",
+      "zh-Hans": "花椰猿",
+      "zh-Hant": "花椰猿"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0512",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0513",
+    "no": "0513",
+    "form": null,
+    "names": {
+      "ja": "バオップ",
+      "en": "Pansear",
+      "ko": "바오프",
+      "zh-Hans": "爆香猴",
+      "zh-Hant": "爆香猴"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0513",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0514",
+    "no": "0514",
+    "form": null,
+    "names": {
+      "ja": "バオッキー",
+      "en": "Simisear",
+      "ko": "바오키",
+      "zh-Hans": "爆香猿",
+      "zh-Hant": "爆香猿"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0514",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0515",
+    "no": "0515",
+    "form": null,
+    "names": {
+      "ja": "ヒヤップ",
+      "en": "Panpour",
+      "ko": "앗차프",
+      "zh-Hans": "冷水猴",
+      "zh-Hant": "冷水猴"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0515",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0516",
+    "no": "0516",
+    "form": null,
+    "names": {
+      "ja": "ヒヤッキー",
+      "en": "Simipour",
+      "ko": "앗차키",
+      "zh-Hans": "冷水猿",
+      "zh-Hant": "冷水猿"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0516",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0517",
+    "no": "0517",
+    "form": null,
+    "names": {
+      "ja": "ムンナ",
+      "en": "Munna",
+      "ko": "몽나",
+      "zh-Hans": "食梦梦",
+      "zh-Hant": "食夢夢"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0517",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0518",
+    "no": "0518",
+    "form": null,
+    "names": {
+      "ja": "ムシャーナ",
+      "en": "Musharna",
+      "ko": "몽얌나",
+      "zh-Hans": "梦梦蚀",
+      "zh-Hant": "夢夢蝕"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0518",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0519",
+    "no": "0519",
+    "form": null,
+    "names": {
+      "ja": "マメパト",
+      "en": "Pidove",
+      "ko": "콩둘기",
+      "zh-Hans": "豆豆鸽",
+      "zh-Hant": "豆豆鴿"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0519",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0520",
+    "no": "0520",
+    "form": null,
+    "names": {
+      "ja": "ハトーボー",
+      "en": "Tranquill",
+      "ko": "유토브",
+      "zh-Hans": "咕咕鸽",
+      "zh-Hant": "咕咕鴿"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0520",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0521",
+    "no": "0521",
+    "form": null,
+    "names": {
+      "ja": "ケンホロウ",
+      "en": "Unfezant",
+      "ko": "켄호로우",
+      "zh-Hans": "高傲雉鸡",
+      "zh-Hant": "高傲雉雞"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0521",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0522",
+    "no": "0522",
+    "form": null,
+    "names": {
+      "ja": "シママ",
+      "en": "Blitzle",
+      "ko": "줄뮤마",
+      "zh-Hans": "斑斑马",
+      "zh-Hant": "斑斑馬"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0522",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0523",
+    "no": "0523",
+    "form": null,
+    "names": {
+      "ja": "ゼブライカ",
+      "en": "Zebstrika",
+      "ko": "제브라이카",
+      "zh-Hans": "雷电斑马",
+      "zh-Hant": "雷電斑馬"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0523",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0524",
+    "no": "0524",
+    "form": null,
+    "names": {
+      "ja": "ダンゴロ",
+      "en": "Roggenrola",
+      "ko": "단굴",
+      "zh-Hans": "石丸子",
+      "zh-Hant": "石丸子"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0524",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0525",
+    "no": "0525",
+    "form": null,
+    "names": {
+      "ja": "ガントル",
+      "en": "Boldore",
+      "ko": "암트르",
+      "zh-Hans": "地幔岩",
+      "zh-Hant": "地幔岩"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0525",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0526",
+    "no": "0526",
+    "form": null,
+    "names": {
+      "ja": "ギガイアス",
+      "en": "Gigalith",
+      "ko": "기가이어스",
+      "zh-Hans": "庞岩怪",
+      "zh-Hant": "龐岩怪"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0526",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0527",
+    "no": "0527",
+    "form": null,
+    "names": {
+      "ja": "コロモリ",
+      "en": "Woobat",
+      "ko": "또르박쥐",
+      "zh-Hans": "滚滚蝙蝠",
+      "zh-Hant": "滾滾蝙蝠"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0527",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0528",
+    "no": "0528",
+    "form": null,
+    "names": {
+      "ja": "ココロモリ",
+      "en": "Swoobat",
+      "ko": "맘박쥐",
+      "zh-Hans": "心蝙蝠",
+      "zh-Hant": "心蝙蝠"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0528",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0529",
+    "no": "0529",
+    "form": null,
+    "names": {
+      "ja": "モグリュー",
+      "en": "Drilbur",
+      "ko": "두더류",
+      "zh-Hans": "螺钉地鼠",
+      "zh-Hant": "螺釘地鼠"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0529",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0530",
+    "no": "0530",
+    "form": null,
+    "names": {
+      "ja": "ドリュウズ",
+      "en": "Excadrill",
+      "ko": "몰드류",
+      "zh-Hans": "龙头地鼠",
+      "zh-Hant": "龍頭地鼠"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0530",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0531",
+    "no": "0531",
+    "form": null,
+    "names": {
+      "ja": "タブンネ",
+      "en": "Audino",
+      "ko": "다부니",
+      "zh-Hans": "差不多娃娃",
+      "zh-Hant": "差不多娃娃"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0531",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0532",
+    "no": "0532",
+    "form": null,
+    "names": {
+      "ja": "ドッコラー",
+      "en": "Timburr",
+      "ko": "으랏차",
+      "zh-Hans": "搬运小匠",
+      "zh-Hant": "搬運小匠"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0532",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0533",
+    "no": "0533",
+    "form": null,
+    "names": {
+      "ja": "ドテッコツ",
+      "en": "Gurdurr",
+      "ko": "토쇠골",
+      "zh-Hans": "铁骨土人",
+      "zh-Hant": "鐵骨土人"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0533",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0534",
+    "no": "0534",
+    "form": null,
+    "names": {
+      "ja": "ローブシン",
+      "en": "Conkeldurr",
+      "ko": "노보청",
+      "zh-Hans": "修建老匠",
+      "zh-Hant": "修建老匠"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0534",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0535",
+    "no": "0535",
+    "form": null,
+    "names": {
+      "ja": "オタマロ",
+      "en": "Tympole",
+      "ko": "동챙이",
+      "zh-Hans": "圆蝌蚪",
+      "zh-Hant": "圓蝌蚪"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0535",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0536",
+    "no": "0536",
+    "form": null,
+    "names": {
+      "ja": "ガマガル",
+      "en": "Palpitoad",
+      "ko": "두까비",
+      "zh-Hans": "蓝蟾蜍",
+      "zh-Hant": "藍蟾蜍"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0536",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0537",
+    "no": "0537",
+    "form": null,
+    "names": {
+      "ja": "ガマゲロゲ",
+      "en": "Seismitoad",
+      "ko": "두빅굴",
+      "zh-Hans": "蟾蜍王",
+      "zh-Hant": "蟾蜍王"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0537",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0538",
+    "no": "0538",
+    "form": null,
+    "names": {
+      "ja": "ナゲキ",
+      "en": "Throh",
+      "ko": "던지미",
+      "zh-Hans": "投摔鬼",
+      "zh-Hant": "投摔鬼"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0538",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0539",
+    "no": "0539",
+    "form": null,
+    "names": {
+      "ja": "ダゲキ",
+      "en": "Sawk",
+      "ko": "타격귀",
+      "zh-Hans": "打击鬼",
+      "zh-Hant": "打擊鬼"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0539",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0540",
+    "no": "0540",
+    "form": null,
+    "names": {
+      "ja": "クルミル",
+      "en": "Sewaddle",
+      "ko": "두르보",
+      "zh-Hans": "虫宝包",
+      "zh-Hant": "蟲寶包"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0540",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0541",
+    "no": "0541",
+    "form": null,
+    "names": {
+      "ja": "クルマユ",
+      "en": "Swadloon",
+      "ko": "두르쿤",
+      "zh-Hans": "宝包茧",
+      "zh-Hant": "寶包繭"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0541",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0542",
+    "no": "0542",
+    "form": null,
+    "names": {
+      "ja": "ハハコモリ",
+      "en": "Leavanny",
+      "ko": "모아머",
+      "zh-Hans": "保姆虫",
+      "zh-Hant": "保母蟲"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0542",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0543",
+    "no": "0543",
+    "form": null,
+    "names": {
+      "ja": "フシデ",
+      "en": "Venipede",
+      "ko": "마디네",
+      "zh-Hans": "百足蜈蚣",
+      "zh-Hant": "百足蜈蚣"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0543",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0544",
+    "no": "0544",
+    "form": null,
+    "names": {
+      "ja": "ホイーガ",
+      "en": "Whirlipede",
+      "ko": "휠구",
+      "zh-Hans": "车轮球",
+      "zh-Hant": "車輪毬"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0544",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0545",
+    "no": "0545",
+    "form": null,
+    "names": {
+      "ja": "ペンドラー",
+      "en": "Scolipede",
+      "ko": "펜드라",
+      "zh-Hans": "蜈蚣王",
+      "zh-Hant": "蜈蚣王"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0545",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0546",
+    "no": "0546",
+    "form": null,
+    "names": {
+      "ja": "モンメン",
+      "en": "Cottonee",
+      "ko": "소미안",
+      "zh-Hans": "木棉球",
+      "zh-Hant": "木棉球"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0546",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0547",
+    "no": "0547",
+    "form": null,
+    "names": {
+      "ja": "エルフーン",
+      "en": "Whimsicott",
+      "ko": "엘풍",
+      "zh-Hans": "风妖精",
+      "zh-Hant": "風妖精"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0547",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0548",
+    "no": "0548",
+    "form": null,
+    "names": {
+      "ja": "チュリネ",
+      "en": "Petilil",
+      "ko": "치릴리",
+      "zh-Hans": "百合根娃娃",
+      "zh-Hant": "百合根娃娃"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0548",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0549",
+    "no": "0549",
+    "form": null,
+    "names": {
+      "ja": "ドレディア",
+      "en": "Lilligant",
+      "ko": "드레디어",
+      "zh-Hans": "裙儿小姐",
+      "zh-Hant": "裙兒小姐"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0549",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0549-hisui",
+    "no": "0549",
+    "form": "hisui",
+    "names": {
+      "ja": "ドレディア",
+      "en": "Lilligant",
+      "ko": "드레디어",
+      "zh-Hans": "裙儿小姐",
+      "zh-Hant": "裙兒小姐"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0549-hisui",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0550",
+    "no": "0550",
+    "form": null,
+    "names": {
+      "ja": "バスラオ",
+      "en": "Basculin",
+      "ko": "배쓰나이",
+      "zh-Hans": "野蛮鲈鱼",
+      "zh-Hant": "野蠻鱸魚"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0550",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0551",
+    "no": "0551",
+    "form": null,
+    "names": {
+      "ja": "メグロコ",
+      "en": "Sandile",
+      "ko": "깜눈크",
+      "zh-Hans": "黑眼鳄",
+      "zh-Hant": "黑眼鱷"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0551",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0552",
+    "no": "0552",
+    "form": null,
+    "names": {
+      "ja": "ワルビル",
+      "en": "Krokorok",
+      "ko": "악비르",
+      "zh-Hans": "混混鳄",
+      "zh-Hant": "混混鱷"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0552",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0553",
+    "no": "0553",
+    "form": null,
+    "names": {
+      "ja": "ワルビアル",
+      "en": "Krookodile",
+      "ko": "악비아르",
+      "zh-Hans": "流氓鳄",
+      "zh-Hant": "流氓鱷"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0553",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0554",
+    "no": "0554",
+    "form": null,
+    "names": {
+      "ja": "ダルマッカ",
+      "en": "Darumaka",
+      "ko": "달막화",
+      "zh-Hans": "火红不倒翁",
+      "zh-Hant": "火紅不倒翁"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0554",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0554-galar",
+    "no": "0554",
+    "form": "galar",
+    "names": {
+      "ja": "ダルマッカ",
+      "en": "Darumaka",
+      "ko": "달막화",
+      "zh-Hans": "火红不倒翁",
+      "zh-Hant": "火紅不倒翁"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0554-galar",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0555",
+    "no": "0555",
+    "form": null,
+    "names": {
+      "ja": "ヒヒダルマ",
+      "en": "Darmanitan",
+      "ko": "불비달마",
+      "zh-Hans": "达摩狒狒",
+      "zh-Hant": "達摩狒狒"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0555",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0555-galar",
+    "no": "0555",
+    "form": "galar",
+    "names": {
+      "ja": "ヒヒダルマ",
+      "en": "Darmanitan",
+      "ko": "불비달마",
+      "zh-Hans": "达摩狒狒",
+      "zh-Hant": "達摩狒狒"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0555-galar",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0556",
+    "no": "0556",
+    "form": null,
+    "names": {
+      "ja": "マラカッチ",
+      "en": "Maractus",
+      "ko": "마라카치",
+      "zh-Hans": "沙铃仙人掌",
+      "zh-Hant": "沙鈴仙人掌"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0556",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0557",
+    "no": "0557",
+    "form": null,
+    "names": {
+      "ja": "イシズマイ",
+      "en": "Dwebble",
+      "ko": "돌살이",
+      "zh-Hans": "石居蟹",
+      "zh-Hant": "石居蟹"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0557",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0558",
+    "no": "0558",
+    "form": null,
+    "names": {
+      "ja": "イワパレス",
+      "en": "Crustle",
+      "ko": "암팰리스",
+      "zh-Hans": "岩殿居蟹",
+      "zh-Hant": "岩殿居蟹"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0558",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0559",
+    "no": "0559",
+    "form": null,
+    "names": {
+      "ja": "ズルッグ",
+      "en": "Scraggy",
+      "ko": "곤율랭",
+      "zh-Hans": "滑滑小子",
+      "zh-Hant": "滑滑小子"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0559",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0560",
+    "no": "0560",
+    "form": null,
+    "names": {
+      "ja": "ズルズキン",
+      "en": "Scrafty",
+      "ko": "곤율거니",
+      "zh-Hans": "头巾混混",
+      "zh-Hant": "頭巾混混"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0560",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0561",
+    "no": "0561",
+    "form": null,
+    "names": {
+      "ja": "シンボラー",
+      "en": "Sigilyph",
+      "ko": "심보러",
+      "zh-Hans": "象征鸟",
+      "zh-Hant": "象徵鳥"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0561",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0562",
+    "no": "0562",
+    "form": null,
+    "names": {
+      "ja": "デスマス",
+      "en": "Yamask",
+      "ko": "데스마스",
+      "zh-Hans": "哭哭面具",
+      "zh-Hant": "哭哭面具"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0562",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0562-galar",
+    "no": "0562",
+    "form": "galar",
+    "names": {
+      "ja": "デスマス",
+      "en": "Yamask",
+      "ko": "데스마스",
+      "zh-Hans": "哭哭面具",
+      "zh-Hant": "哭哭面具"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0562-galar",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0563",
+    "no": "0563",
+    "form": null,
+    "names": {
+      "ja": "デスカーン",
+      "en": "Cofagrigus",
+      "ko": "데스니칸",
+      "zh-Hans": "迭失棺",
+      "zh-Hant": "死神棺"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0563",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0564",
+    "no": "0564",
+    "form": null,
+    "names": {
+      "ja": "プロトーガ",
+      "en": "Tirtouga",
+      "ko": "프로토가",
+      "zh-Hans": "原盖海龟",
+      "zh-Hant": "原蓋海龜"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0564",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0565",
+    "no": "0565",
+    "form": null,
+    "names": {
+      "ja": "アバゴーラ",
+      "en": "Carracosta",
+      "ko": "늑골라",
+      "zh-Hans": "肋骨海龟",
+      "zh-Hant": "肋骨海龜"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0565",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0566",
+    "no": "0566",
+    "form": null,
+    "names": {
+      "ja": "アーケン",
+      "en": "Archen",
+      "ko": "아켄",
+      "zh-Hans": "始祖小鸟",
+      "zh-Hant": "始祖小鳥"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0566",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0567",
+    "no": "0567",
+    "form": null,
+    "names": {
+      "ja": "アーケオス",
+      "en": "Archeops",
+      "ko": "아케오스",
+      "zh-Hans": "始祖大鸟",
+      "zh-Hant": "始祖大鳥"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0567",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0568",
+    "no": "0568",
+    "form": null,
+    "names": {
+      "ja": "ヤブクロン",
+      "en": "Trubbish",
+      "ko": "깨봉이",
+      "zh-Hans": "破破袋",
+      "zh-Hant": "破破袋"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0568",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0569",
+    "no": "0569",
+    "form": null,
+    "names": {
+      "ja": "ダストダス",
+      "en": "Garbodor",
+      "ko": "더스트나",
+      "zh-Hans": "灰尘山",
+      "zh-Hant": "灰塵山"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0569",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0570",
+    "no": "0570",
+    "form": null,
+    "names": {
+      "ja": "ゾロア",
+      "en": "Zorua",
+      "ko": "조로아",
+      "zh-Hans": "索罗亚",
+      "zh-Hant": "索羅亞"
+    },
+    "types": [
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0570",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0570-hisui",
+    "no": "0570",
+    "form": "hisui",
+    "names": {
+      "ja": "ゾロア",
+      "en": "Zorua",
+      "ko": "조로아",
+      "zh-Hans": "索罗亚",
+      "zh-Hant": "索羅亞"
+    },
+    "types": [
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0570-hisui",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0571",
+    "no": "0571",
+    "form": null,
+    "names": {
+      "ja": "ゾロアーク",
+      "en": "Zoroark",
+      "ko": "조로아크",
+      "zh-Hans": "索罗亚克",
+      "zh-Hant": "索羅亞克"
+    },
+    "types": [
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0571",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0571-hisui",
+    "no": "0571",
+    "form": "hisui",
+    "names": {
+      "ja": "ゾロアーク",
+      "en": "Zoroark",
+      "ko": "조로아크",
+      "zh-Hans": "索罗亚克",
+      "zh-Hant": "索羅亞克"
+    },
+    "types": [
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0571-hisui",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0572",
+    "no": "0572",
+    "form": null,
+    "names": {
+      "ja": "チラーミィ",
+      "en": "Minccino",
+      "ko": "치라미",
+      "zh-Hans": "泡沫栗鼠",
+      "zh-Hant": "泡沫栗鼠"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0572",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0573",
+    "no": "0573",
+    "form": null,
+    "names": {
+      "ja": "チラチーノ",
+      "en": "Cinccino",
+      "ko": "치라치노",
+      "zh-Hans": "奇诺栗鼠",
+      "zh-Hant": "奇諾栗鼠"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0573",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0574",
+    "no": "0574",
+    "form": null,
+    "names": {
+      "ja": "ゴチム",
+      "en": "Gothita",
+      "ko": "고디탱",
+      "zh-Hans": "哥德宝宝",
+      "zh-Hant": "哥德寶寶"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0574",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0575",
+    "no": "0575",
+    "form": null,
+    "names": {
+      "ja": "ゴチミル",
+      "en": "Gothorita",
+      "ko": "고디보미",
+      "zh-Hans": "哥德小童",
+      "zh-Hant": "哥德小童"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0575",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0576",
+    "no": "0576",
+    "form": null,
+    "names": {
+      "ja": "ゴチルゼル",
+      "en": "Gothitelle",
+      "ko": "고디모아젤",
+      "zh-Hans": "哥德小姐",
+      "zh-Hant": "哥德小姐"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0576",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0577",
+    "no": "0577",
+    "form": null,
+    "names": {
+      "ja": "ユニラン",
+      "en": "Solosis",
+      "ko": "유니란",
+      "zh-Hans": "单卵细胞球",
+      "zh-Hant": "單卵細胞球"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0577",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0578",
+    "no": "0578",
+    "form": null,
+    "names": {
+      "ja": "ダブラン",
+      "en": "Duosion",
+      "ko": "듀란",
+      "zh-Hans": "双卵细胞球",
+      "zh-Hant": "雙卵細胞球"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0578",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0579",
+    "no": "0579",
+    "form": null,
+    "names": {
+      "ja": "ランクルス",
+      "en": "Reuniclus",
+      "ko": "란쿨루스",
+      "zh-Hans": "人造细胞卵",
+      "zh-Hant": "人造細胞卵"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0579",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0580",
+    "no": "0580",
+    "form": null,
+    "names": {
+      "ja": "コアルヒー",
+      "en": "Ducklett",
+      "ko": "꼬지보리",
+      "zh-Hans": "鸭宝宝",
+      "zh-Hant": "鴨寶寶"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0580",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0581",
+    "no": "0581",
+    "form": null,
+    "names": {
+      "ja": "スワンナ",
+      "en": "Swanna",
+      "ko": "스완나",
+      "zh-Hans": "舞天鹅",
+      "zh-Hant": "舞天鵝"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0581",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0582",
+    "no": "0582",
+    "form": null,
+    "names": {
+      "ja": "バニプッチ",
+      "en": "Vanillite",
+      "ko": "바닐프티",
+      "zh-Hans": "迷你冰",
+      "zh-Hant": "迷你冰"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0582",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0583",
+    "no": "0583",
+    "form": null,
+    "names": {
+      "ja": "バニリッチ",
+      "en": "Vanillish",
+      "ko": "바닐리치",
+      "zh-Hans": "多多冰",
+      "zh-Hant": "多多冰"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0583",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0584",
+    "no": "0584",
+    "form": null,
+    "names": {
+      "ja": "バイバニラ",
+      "en": "Vanilluxe",
+      "ko": "배바닐라",
+      "zh-Hans": "双倍多多冰",
+      "zh-Hant": "雙倍多多冰"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0584",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0585",
+    "no": "0585",
+    "form": null,
+    "names": {
+      "ja": "シキジカ",
+      "en": "Deerling",
+      "ko": "사철록",
+      "zh-Hans": "四季鹿",
+      "zh-Hant": "四季鹿"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0585",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0586",
+    "no": "0586",
+    "form": null,
+    "names": {
+      "ja": "メブキジカ",
+      "en": "Sawsbuck",
+      "ko": "바라철록",
+      "zh-Hans": "萌芽鹿",
+      "zh-Hant": "萌芽鹿"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0586",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0587",
+    "no": "0587",
+    "form": null,
+    "names": {
+      "ja": "エモンガ",
+      "en": "Emolga",
+      "ko": "에몽가",
+      "zh-Hans": "电飞鼠",
+      "zh-Hant": "電飛鼠"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0587",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0588",
+    "no": "0588",
+    "form": null,
+    "names": {
+      "ja": "カブルモ",
+      "en": "Karrablast",
+      "ko": "딱정곤",
+      "zh-Hans": "盖盖虫",
+      "zh-Hant": "蓋蓋蟲"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0588",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0589",
+    "no": "0589",
+    "form": null,
+    "names": {
+      "ja": "シュバルゴ",
+      "en": "Escavalier",
+      "ko": "슈바르고",
+      "zh-Hans": "骑士蜗牛",
+      "zh-Hant": "騎士蝸牛"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0589",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0590",
+    "no": "0590",
+    "form": null,
+    "names": {
+      "ja": "タマゲタケ",
+      "en": "Foongus",
+      "ko": "깜놀버슬",
+      "zh-Hans": "哎呀球菇",
+      "zh-Hant": "哎呀球菇"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0590",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0591",
+    "no": "0591",
+    "form": null,
+    "names": {
+      "ja": "モロバレル",
+      "en": "Amoonguss",
+      "ko": "뽀록나",
+      "zh-Hans": "败露球菇",
+      "zh-Hant": "敗露球菇"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0591",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0592",
+    "no": "0592",
+    "form": null,
+    "names": {
+      "ja": "プルリル",
+      "en": "Frillish",
+      "ko": "탱그릴",
+      "zh-Hans": "轻飘飘",
+      "zh-Hant": "輕飄飄"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0592",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0593",
+    "no": "0593",
+    "form": null,
+    "names": {
+      "ja": "ブルンゲル",
+      "en": "Jellicent",
+      "ko": "탱탱겔",
+      "zh-Hans": "胖嘟嘟",
+      "zh-Hant": "胖嘟嘟"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0593",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0594",
+    "no": "0594",
+    "form": null,
+    "names": {
+      "ja": "ママンボウ",
+      "en": "Alomomola",
+      "ko": "맘복치",
+      "zh-Hans": "保姆曼波",
+      "zh-Hant": "保母曼波"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0594",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0595",
+    "no": "0595",
+    "form": null,
+    "names": {
+      "ja": "バチュル",
+      "en": "Joltik",
+      "ko": "파쪼옥",
+      "zh-Hans": "电电虫",
+      "zh-Hant": "電電蟲"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0595",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0596",
+    "no": "0596",
+    "form": null,
+    "names": {
+      "ja": "デンチュラ",
+      "en": "Galvantula",
+      "ko": "전툴라",
+      "zh-Hans": "电蜘蛛",
+      "zh-Hant": "電蜘蛛"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0596",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0597",
+    "no": "0597",
+    "form": null,
+    "names": {
+      "ja": "テッシード",
+      "en": "Ferroseed",
+      "ko": "철시드",
+      "zh-Hans": "种子铁球",
+      "zh-Hant": "種子鐵球"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0597",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0598",
+    "no": "0598",
+    "form": null,
+    "names": {
+      "ja": "ナットレイ",
+      "en": "Ferrothorn",
+      "ko": "너트령",
+      "zh-Hans": "坚果哑铃",
+      "zh-Hant": "堅果啞鈴"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0598",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0599",
+    "no": "0599",
+    "form": null,
+    "names": {
+      "ja": "ギアル",
+      "en": "Klink",
+      "ko": "기어르",
+      "zh-Hans": "齿轮儿",
+      "zh-Hant": "齒輪兒"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0599",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0600",
+    "no": "0600",
+    "form": null,
+    "names": {
+      "ja": "ギギアル",
+      "en": "Klang",
+      "ko": "기기어르",
+      "zh-Hans": "齿轮组",
+      "zh-Hant": "齒輪組"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0600",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0601",
+    "no": "0601",
+    "form": null,
+    "names": {
+      "ja": "ギギギアル",
+      "en": "Klinklang",
+      "ko": "기기기어르",
+      "zh-Hans": "齿轮怪",
+      "zh-Hant": "齒輪怪"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0601",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0602",
+    "no": "0602",
+    "form": null,
+    "names": {
+      "ja": "シビシラス",
+      "en": "Tynamo",
+      "ko": "저리어",
+      "zh-Hans": "麻麻小鱼",
+      "zh-Hant": "麻麻小魚"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0602",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0603",
+    "no": "0603",
+    "form": null,
+    "names": {
+      "ja": "シビビール",
+      "en": "Eelektrik",
+      "ko": "저리릴",
+      "zh-Hans": "麻麻鳗",
+      "zh-Hant": "麻麻鰻"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0603",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0604",
+    "no": "0604",
+    "form": null,
+    "names": {
+      "ja": "シビルドン",
+      "en": "Eelektross",
+      "ko": "저리더프",
+      "zh-Hans": "麻麻鳗鱼王",
+      "zh-Hant": "麻麻鰻魚王"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0604",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0605",
+    "no": "0605",
+    "form": null,
+    "names": {
+      "ja": "リグレー",
+      "en": "Elgyem",
+      "ko": "리그레",
+      "zh-Hans": "小灰怪",
+      "zh-Hant": "小灰怪"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0605",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0606",
+    "no": "0606",
+    "form": null,
+    "names": {
+      "ja": "オーベム",
+      "en": "Beheeyem",
+      "ko": "벰크",
+      "zh-Hans": "大宇怪",
+      "zh-Hant": "大宇怪"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0606",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0607",
+    "no": "0607",
+    "form": null,
+    "names": {
+      "ja": "ヒトモシ",
+      "en": "Litwick",
+      "ko": "불켜미",
+      "zh-Hans": "烛光灵",
+      "zh-Hant": "燭光靈"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0607",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0608",
+    "no": "0608",
+    "form": null,
+    "names": {
+      "ja": "ランプラー",
+      "en": "Lampent",
+      "ko": "램프라",
+      "zh-Hans": "灯火幽灵",
+      "zh-Hant": "燈火幽靈"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0608",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0609",
+    "no": "0609",
+    "form": null,
+    "names": {
+      "ja": "シャンデラ",
+      "en": "Chandelure",
+      "ko": "샹델라",
+      "zh-Hans": "水晶灯火灵",
+      "zh-Hant": "水晶燈火靈"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0609",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0610",
+    "no": "0610",
+    "form": null,
+    "names": {
+      "ja": "キバゴ",
+      "en": "Axew",
+      "ko": "터검니",
+      "zh-Hans": "牙牙",
+      "zh-Hant": "牙牙"
+    },
+    "types": [
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0610",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0611",
+    "no": "0611",
+    "form": null,
+    "names": {
+      "ja": "オノンド",
+      "en": "Fraxure",
+      "ko": "액슨도",
+      "zh-Hans": "斧牙龙",
+      "zh-Hant": "斧牙龍"
+    },
+    "types": [
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0611",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0612",
+    "no": "0612",
+    "form": null,
+    "names": {
+      "ja": "オノノクス",
+      "en": "Haxorus",
+      "ko": "액스라이즈",
+      "zh-Hans": "双斧战龙",
+      "zh-Hant": "雙斧戰龍"
+    },
+    "types": [
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0612",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0613",
+    "no": "0613",
+    "form": null,
+    "names": {
+      "ja": "クマシュン",
+      "en": "Cubchoo",
+      "ko": "코고미",
+      "zh-Hans": "喷嚏熊",
+      "zh-Hant": "噴嚏熊"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0613",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0614",
+    "no": "0614",
+    "form": null,
+    "names": {
+      "ja": "ツンベアー",
+      "en": "Beartic",
+      "ko": "툰베어",
+      "zh-Hans": "冻原熊",
+      "zh-Hant": "凍原熊"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0614",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0615",
+    "no": "0615",
+    "form": null,
+    "names": {
+      "ja": "フリージオ",
+      "en": "Cryogonal",
+      "ko": "프리지오",
+      "zh-Hans": "几何雪花",
+      "zh-Hant": "幾何雪花"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0615",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0616",
+    "no": "0616",
+    "form": null,
+    "names": {
+      "ja": "チョボマキ",
+      "en": "Shelmet",
+      "ko": "쪼마리",
+      "zh-Hans": "小嘴蜗",
+      "zh-Hant": "小嘴蝸"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0616",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0617",
+    "no": "0617",
+    "form": null,
+    "names": {
+      "ja": "アギルダー",
+      "en": "Accelgor",
+      "ko": "어지리더",
+      "zh-Hans": "敏捷虫",
+      "zh-Hant": "敏捷蟲"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0617",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0618",
+    "no": "0618",
+    "form": null,
+    "names": {
+      "ja": "マッギョ",
+      "en": "Stunfisk",
+      "ko": "메더",
+      "zh-Hans": "泥巴鱼",
+      "zh-Hant": "泥巴魚"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0618",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0618-galar",
+    "no": "0618",
+    "form": "galar",
+    "names": {
+      "ja": "マッギョ",
+      "en": "Stunfisk",
+      "ko": "메더",
+      "zh-Hans": "泥巴鱼",
+      "zh-Hant": "泥巴魚"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0618-galar",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0619",
+    "no": "0619",
+    "form": null,
+    "names": {
+      "ja": "コジョフー",
+      "en": "Mienfoo",
+      "ko": "비조푸",
+      "zh-Hans": "功夫鼬",
+      "zh-Hant": "功夫鼬"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0619",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0620",
+    "no": "0620",
+    "form": null,
+    "names": {
+      "ja": "コジョンド",
+      "en": "Mienshao",
+      "ko": "비조도",
+      "zh-Hans": "师父鼬",
+      "zh-Hant": "師父鼬"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0620",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0621",
+    "no": "0621",
+    "form": null,
+    "names": {
+      "ja": "クリムガン",
+      "en": "Druddigon",
+      "ko": "크리만",
+      "zh-Hans": "赤面龙",
+      "zh-Hant": "赤面龍"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0621",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0622",
+    "no": "0622",
+    "form": null,
+    "names": {
+      "ja": "ゴビット",
+      "en": "Golett",
+      "ko": "골비람",
+      "zh-Hans": "泥偶小人",
+      "zh-Hant": "泥偶小人"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0622",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0623",
+    "no": "0623",
+    "form": null,
+    "names": {
+      "ja": "ゴルーグ",
+      "en": "Golurk",
+      "ko": "골루그",
+      "zh-Hans": "泥偶巨人",
+      "zh-Hant": "泥偶巨人"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0623",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0624",
+    "no": "0624",
+    "form": null,
+    "names": {
+      "ja": "コマタナ",
+      "en": "Pawniard",
+      "ko": "자망칼",
+      "zh-Hans": "驹刀小兵",
+      "zh-Hant": "駒刀小兵"
+    },
+    "types": [
+      {
+        "ja": "あく",
+        "en": "Dark"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0624",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0625",
+    "no": "0625",
+    "form": null,
+    "names": {
+      "ja": "キリキザン",
+      "en": "Bisharp",
+      "ko": "절각참",
+      "zh-Hans": "劈斩司令",
+      "zh-Hant": "劈斬司令"
+    },
+    "types": [
+      {
+        "ja": "あく",
+        "en": "Dark"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0625",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0626",
+    "no": "0626",
+    "form": null,
+    "names": {
+      "ja": "バッフロン",
+      "en": "Bouffalant",
+      "ko": "버프론",
+      "zh-Hans": "爆炸头水牛",
+      "zh-Hant": "爆炸頭水牛"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0626",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0627",
+    "no": "0627",
+    "form": null,
+    "names": {
+      "ja": "ワシボン",
+      "en": "Rufflet",
+      "ko": "수리둥보",
+      "zh-Hans": "毛头小鹰",
+      "zh-Hant": "毛頭小鷹"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0627",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0628",
+    "no": "0628",
+    "form": null,
+    "names": {
+      "ja": "ウォーグル",
+      "en": "Braviary",
+      "ko": "워글",
+      "zh-Hans": "勇士雄鹰",
+      "zh-Hant": "勇士雄鷹"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0628",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0628-hisui",
+    "no": "0628",
+    "form": "hisui",
+    "names": {
+      "ja": "ウォーグル",
+      "en": "Braviary",
+      "ko": "워글",
+      "zh-Hans": "勇士雄鹰",
+      "zh-Hant": "勇士雄鷹"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0628-hisui",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0629",
+    "no": "0629",
+    "form": null,
+    "names": {
+      "ja": "バルチャイ",
+      "en": "Vullaby",
+      "ko": "벌차이",
+      "zh-Hans": "秃鹰丫头",
+      "zh-Hant": "禿鷹丫頭"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0629",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0630",
+    "no": "0630",
+    "form": null,
+    "names": {
+      "ja": "バルジーナ",
+      "en": "Mandibuzz",
+      "ko": "버랜지나",
+      "zh-Hans": "秃鹰娜",
+      "zh-Hant": "禿鷹娜"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0630",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0631",
+    "no": "0631",
+    "form": null,
+    "names": {
+      "ja": "クイタラン",
+      "en": "Heatmor",
+      "ko": "앤티골",
+      "zh-Hans": "熔蚁兽",
+      "zh-Hant": "熔蟻獸"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0631",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0632",
+    "no": "0632",
+    "form": null,
+    "names": {
+      "ja": "アイアント",
+      "en": "Durant",
+      "ko": "아이앤트",
+      "zh-Hans": "铁蚁",
+      "zh-Hant": "鐵蟻"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0632",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0633",
+    "no": "0633",
+    "form": null,
+    "names": {
+      "ja": "モノズ",
+      "en": "Deino",
+      "ko": "모노두",
+      "zh-Hans": "单首龙",
+      "zh-Hant": "單首龍"
+    },
+    "types": [
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0633",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0634",
+    "no": "0634",
+    "form": null,
+    "names": {
+      "ja": "ジヘッド",
+      "en": "Zweilous",
+      "ko": "디헤드",
+      "zh-Hans": "双首暴龙",
+      "zh-Hant": "雙首暴龍"
+    },
+    "types": [
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0634",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0635",
+    "no": "0635",
+    "form": null,
+    "names": {
+      "ja": "サザンドラ",
+      "en": "Hydreigon",
+      "ko": "삼삼드래",
+      "zh-Hans": "三首恶龙",
+      "zh-Hant": "三首惡龍"
+    },
+    "types": [
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0635",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0636",
+    "no": "0636",
+    "form": null,
+    "names": {
+      "ja": "メラルバ",
+      "en": "Larvesta",
+      "ko": "활화르바",
+      "zh-Hans": "燃烧虫",
+      "zh-Hant": "燃燒蟲"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0636",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0637",
+    "no": "0637",
+    "form": null,
+    "names": {
+      "ja": "ウルガモス",
+      "en": "Volcarona",
+      "ko": "불카모스",
+      "zh-Hans": "火神蛾",
+      "zh-Hant": "火神蛾"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0637",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0638",
+    "no": "0638",
+    "form": null,
+    "names": {
+      "ja": "コバルオン",
+      "en": "Cobalion",
+      "ko": "코바르온",
+      "zh-Hans": "勾帕路翁",
+      "zh-Hant": "勾帕路翁"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0638",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0639",
+    "no": "0639",
+    "form": null,
+    "names": {
+      "ja": "テラキオン",
+      "en": "Terrakion",
+      "ko": "테라키온",
+      "zh-Hans": "代拉基翁",
+      "zh-Hant": "代拉基翁"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0639",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0640",
+    "no": "0640",
+    "form": null,
+    "names": {
+      "ja": "ビリジオン",
+      "en": "Virizion",
+      "ko": "비리디온",
+      "zh-Hans": "毕力吉翁",
+      "zh-Hant": "畢力吉翁"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0640",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0641",
+    "no": "0641",
+    "form": null,
+    "names": {
+      "ja": "トルネロス",
+      "en": "Tornadus",
+      "ko": "토네로스",
+      "zh-Hans": "龙卷云",
+      "zh-Hant": "龍捲雲"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0641",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0642",
+    "no": "0642",
+    "form": null,
+    "names": {
+      "ja": "ボルトロス",
+      "en": "Thundurus",
+      "ko": "볼트로스",
+      "zh-Hans": "雷电云",
+      "zh-Hant": "雷電雲"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0642",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0643",
+    "no": "0643",
+    "form": null,
+    "names": {
+      "ja": "レシラム",
+      "en": "Reshiram",
+      "ko": "레시라무",
+      "zh-Hans": "莱希拉姆",
+      "zh-Hant": "萊希拉姆"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0643",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0644",
+    "no": "0644",
+    "form": null,
+    "names": {
+      "ja": "ゼクロム",
+      "en": "Zekrom",
+      "ko": "제크로무",
+      "zh-Hans": "捷克罗姆",
+      "zh-Hant": "捷克羅姆"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0644",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0645",
+    "no": "0645",
+    "form": null,
+    "names": {
+      "ja": "ランドロス",
+      "en": "Landorus",
+      "ko": "랜드로스",
+      "zh-Hans": "土地云",
+      "zh-Hant": "土地雲"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0645",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0646",
+    "no": "0646",
+    "form": null,
+    "names": {
+      "ja": "キュレム",
+      "en": "Kyurem",
+      "ko": "큐레무",
+      "zh-Hans": "酋雷姆",
+      "zh-Hant": "酋雷姆"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0646",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0647",
+    "no": "0647",
+    "form": null,
+    "names": {
+      "ja": "ケルディオ",
+      "en": "Keldeo",
+      "ko": "케르디오",
+      "zh-Hans": "凯路迪欧",
+      "zh-Hant": "凱路迪歐"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0647",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0648",
+    "no": "0648",
+    "form": null,
+    "names": {
+      "ja": "メロエッタ",
+      "en": "Meloetta",
+      "ko": "메로엣타",
+      "zh-Hans": "美洛耶塔",
+      "zh-Hant": "美洛耶塔"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0648",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0649",
+    "no": "0649",
+    "form": null,
+    "names": {
+      "ja": "ゲノセクト",
+      "en": "Genesect",
+      "ko": "게노세크트",
+      "zh-Hans": "盖诺赛克特",
+      "zh-Hant": "蓋諾賽克特"
+    },
+    "types": [],
+    "generation": 5,
+    "evolution": {
+      "family_id": "0649",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0650",
+    "no": "0650",
+    "form": null,
+    "names": {
+      "ja": "ハリマロン",
+      "en": "Chespin",
+      "ko": "도치마론",
+      "zh-Hans": "哈力栗",
+      "zh-Hant": "哈力栗"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0650",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0651",
+    "no": "0651",
+    "form": null,
+    "names": {
+      "ja": "ハリボーグ",
+      "en": "Quilladin",
+      "ko": "도치보구",
+      "zh-Hans": "胖胖哈力",
+      "zh-Hant": "胖胖哈力"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0651",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0652",
+    "no": "0652",
+    "form": null,
+    "names": {
+      "ja": "ブリガロン",
+      "en": "Chesnaught",
+      "ko": "브리가론",
+      "zh-Hans": "布里卡隆",
+      "zh-Hant": "布里卡隆"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0652",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0653",
+    "no": "0653",
+    "form": null,
+    "names": {
+      "ja": "フォッコ",
+      "en": "Fennekin",
+      "ko": "푸호꼬",
+      "zh-Hans": "火狐狸",
+      "zh-Hant": "火狐狸"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0653",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0654",
+    "no": "0654",
+    "form": null,
+    "names": {
+      "ja": "テールナー",
+      "en": "Braixen",
+      "ko": "테르나",
+      "zh-Hans": "长尾火狐",
+      "zh-Hant": "長尾火狐"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0654",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0655",
+    "no": "0655",
+    "form": null,
+    "names": {
+      "ja": "マフォクシー",
+      "en": "Delphox",
+      "ko": "마폭시",
+      "zh-Hans": "妖火红狐",
+      "zh-Hant": "妖火紅狐"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0655",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0656",
+    "no": "0656",
+    "form": null,
+    "names": {
+      "ja": "ケロマツ",
+      "en": "Froakie",
+      "ko": "개구마르",
+      "zh-Hans": "呱呱泡蛙",
+      "zh-Hant": "呱呱泡蛙"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0656",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0657",
+    "no": "0657",
+    "form": null,
+    "names": {
+      "ja": "ゲコガシラ",
+      "en": "Frogadier",
+      "ko": "개굴반장",
+      "zh-Hans": "呱头蛙",
+      "zh-Hant": "呱頭蛙"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0657",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0658",
+    "no": "0658",
+    "form": null,
+    "names": {
+      "ja": "ゲッコウガ",
+      "en": "Greninja",
+      "ko": "개굴닌자",
+      "zh-Hans": "甲贺忍蛙",
+      "zh-Hant": "甲賀忍蛙"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0658",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0659",
+    "no": "0659",
+    "form": null,
+    "names": {
+      "ja": "ホルビー",
+      "en": "Bunnelby",
+      "ko": "파르빗",
+      "zh-Hans": "掘掘兔",
+      "zh-Hant": "掘掘兔"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0659",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0660",
+    "no": "0660",
+    "form": null,
+    "names": {
+      "ja": "ホルード",
+      "en": "Diggersby",
+      "ko": "파르토",
+      "zh-Hans": "掘地兔",
+      "zh-Hant": "掘地兔"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0660",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0661",
+    "no": "0661",
+    "form": null,
+    "names": {
+      "ja": "ヤヤコマ",
+      "en": "Fletchling",
+      "ko": "화살꼬빈",
+      "zh-Hans": "小箭雀",
+      "zh-Hant": "小箭雀"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0661",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0662",
+    "no": "0662",
+    "form": null,
+    "names": {
+      "ja": "ヒノヤコマ",
+      "en": "Fletchinder",
+      "ko": "불화살빈",
+      "zh-Hans": "火箭雀",
+      "zh-Hant": "火箭雀"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0662",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0663",
+    "no": "0663",
+    "form": null,
+    "names": {
+      "ja": "ファイアロー",
+      "en": "Talonflame",
+      "ko": "파이어로",
+      "zh-Hans": "烈箭鹰",
+      "zh-Hant": "烈箭鷹"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0663",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0664",
+    "no": "0664",
+    "form": null,
+    "names": {
+      "ja": "コフキムシ",
+      "en": "Scatterbug",
+      "ko": "분이벌레",
+      "zh-Hans": "粉蝶虫",
+      "zh-Hant": "粉蝶蟲"
+    },
+    "types": [
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0664",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0665",
+    "no": "0665",
+    "form": null,
+    "names": {
+      "ja": "コフーライ",
+      "en": "Spewpa",
+      "ko": "분떠도리",
+      "zh-Hans": "粉蝶蛹",
+      "zh-Hant": "粉蝶蛹"
+    },
+    "types": [
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0665",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0666",
+    "no": "0666",
+    "form": null,
+    "names": {
+      "ja": "ビビヨン",
+      "en": "Vivillon",
+      "ko": "비비용",
+      "zh-Hans": "彩粉蝶",
+      "zh-Hant": "彩粉蝶"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0666",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0667",
+    "no": "0667",
+    "form": null,
+    "names": {
+      "ja": "シシコ",
+      "en": "Litleo",
+      "ko": "레오꼬",
+      "zh-Hans": "小狮狮",
+      "zh-Hant": "小獅獅"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0667",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0668",
+    "no": "0668",
+    "form": null,
+    "names": {
+      "ja": "カエンジシ",
+      "en": "Pyroar",
+      "ko": "화염레오",
+      "zh-Hans": "火炎狮",
+      "zh-Hant": "火炎獅"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0668",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0669",
+    "no": "0669",
+    "form": null,
+    "names": {
+      "ja": "フラベベ",
+      "en": "Flabébé",
+      "ko": "플라베베",
+      "zh-Hans": "花蓓蓓",
+      "zh-Hant": "花蓓蓓"
+    },
+    "types": [
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0669",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0670",
+    "no": "0670",
+    "form": null,
+    "names": {
+      "ja": "フラエッテ",
+      "en": "Floette",
+      "ko": "플라엣테",
+      "zh-Hans": "花叶蒂",
+      "zh-Hant": "花葉蒂"
+    },
+    "types": [
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0670",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0671",
+    "no": "0671",
+    "form": null,
+    "names": {
+      "ja": "フラージェス",
+      "en": "Florges",
+      "ko": "플라제스",
+      "zh-Hans": "花洁夫人",
+      "zh-Hant": "花潔夫人"
+    },
+    "types": [
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0671",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0672",
+    "no": "0672",
+    "form": null,
+    "names": {
+      "ja": "メェークル",
+      "en": "Skiddo",
+      "ko": "메이클",
+      "zh-Hans": "坐骑小羊",
+      "zh-Hant": "坐騎小羊"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0672",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0673",
+    "no": "0673",
+    "form": null,
+    "names": {
+      "ja": "ゴーゴート",
+      "en": "Gogoat",
+      "ko": "고고트",
+      "zh-Hans": "坐骑山羊",
+      "zh-Hant": "坐騎山羊"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0673",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0674",
+    "no": "0674",
+    "form": null,
+    "names": {
+      "ja": "ヤンチャム",
+      "en": "Pancham",
+      "ko": "판짱",
+      "zh-Hans": "顽皮熊猫",
+      "zh-Hant": "頑皮熊貓"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0674",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0675",
+    "no": "0675",
+    "form": null,
+    "names": {
+      "ja": "ゴロンダ",
+      "en": "Pangoro",
+      "ko": "부란다",
+      "zh-Hans": "霸道熊猫",
+      "zh-Hant": "流氓熊貓"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0675",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0676",
+    "no": "0676",
+    "form": null,
+    "names": {
+      "ja": "トリミアン",
+      "en": "Furfrou",
+      "ko": "트리미앙",
+      "zh-Hans": "多丽米亚",
+      "zh-Hant": "多麗米亞"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0676",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0677",
+    "no": "0677",
+    "form": null,
+    "names": {
+      "ja": "ニャスパー",
+      "en": "Espurr",
+      "ko": "냐스퍼",
+      "zh-Hans": "妙喵",
+      "zh-Hant": "妙喵"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0677",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0678",
+    "no": "0678",
+    "form": null,
+    "names": {
+      "ja": "ニャオニクス",
+      "en": "Meowstic",
+      "ko": "냐오닉스",
+      "zh-Hans": "超能妙喵",
+      "zh-Hant": "超能妙喵"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0678",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0679",
+    "no": "0679",
+    "form": null,
+    "names": {
+      "ja": "ヒトツキ",
+      "en": "Honedge",
+      "ko": "단칼빙",
+      "zh-Hans": "独剑鞘",
+      "zh-Hant": "獨劍鞘"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0679",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0680",
+    "no": "0680",
+    "form": null,
+    "names": {
+      "ja": "ニダンギル",
+      "en": "Doublade",
+      "ko": "쌍검킬",
+      "zh-Hans": "双剑鞘",
+      "zh-Hant": "雙劍鞘"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0680",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0681",
+    "no": "0681",
+    "form": null,
+    "names": {
+      "ja": "ギルガルド",
+      "en": "Aegislash",
+      "ko": "킬가르도",
+      "zh-Hans": "坚盾剑怪",
+      "zh-Hant": "堅盾劍怪"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0681",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0682",
+    "no": "0682",
+    "form": null,
+    "names": {
+      "ja": "シュシュプ",
+      "en": "Spritzee",
+      "ko": "슈쁘",
+      "zh-Hans": "粉香香",
+      "zh-Hant": "粉香香"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0682",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0683",
+    "no": "0683",
+    "form": null,
+    "names": {
+      "ja": "フレフワン",
+      "en": "Aromatisse",
+      "ko": "프레프티르",
+      "zh-Hans": "芳香精",
+      "zh-Hant": "芳香精"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0683",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0684",
+    "no": "0684",
+    "form": null,
+    "names": {
+      "ja": "ペロッパフ",
+      "en": "Swirlix",
+      "ko": "나룸퍼프",
+      "zh-Hans": "绵绵泡芙",
+      "zh-Hant": "綿綿泡芙"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0684",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0685",
+    "no": "0685",
+    "form": null,
+    "names": {
+      "ja": "ペロリーム",
+      "en": "Slurpuff",
+      "ko": "나루림",
+      "zh-Hans": "胖甜妮",
+      "zh-Hant": "胖甜妮"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0685",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0686",
+    "no": "0686",
+    "form": null,
+    "names": {
+      "ja": "マーイーカ",
+      "en": "Inkay",
+      "ko": "오케이징",
+      "zh-Hans": "好啦鱿",
+      "zh-Hant": "好啦魷"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0686",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0687",
+    "no": "0687",
+    "form": null,
+    "names": {
+      "ja": "カラマネロ",
+      "en": "Malamar",
+      "ko": "칼라마네로",
+      "zh-Hans": "乌贼王",
+      "zh-Hant": "烏賊王"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0687",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0688",
+    "no": "0688",
+    "form": null,
+    "names": {
+      "ja": "カメテテ",
+      "en": "Binacle",
+      "ko": "거북손손",
+      "zh-Hans": "龟脚脚",
+      "zh-Hant": "龜腳腳"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0688",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0689",
+    "no": "0689",
+    "form": null,
+    "names": {
+      "ja": "ガメノデス",
+      "en": "Barbaracle",
+      "ko": "거북손데스",
+      "zh-Hans": "龟足巨铠",
+      "zh-Hant": "龜足巨鎧"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0689",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0690",
+    "no": "0690",
+    "form": null,
+    "names": {
+      "ja": "クズモー",
+      "en": "Skrelp",
+      "ko": "수레기",
+      "zh-Hans": "垃垃藻",
+      "zh-Hant": "垃垃藻"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0690",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0691",
+    "no": "0691",
+    "form": null,
+    "names": {
+      "ja": "ドラミドロ",
+      "en": "Dragalge",
+      "ko": "드래캄",
+      "zh-Hans": "毒藻龙",
+      "zh-Hant": "毒藻龍"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0691",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0692",
+    "no": "0692",
+    "form": null,
+    "names": {
+      "ja": "ウデッポウ",
+      "en": "Clauncher",
+      "ko": "완철포",
+      "zh-Hans": "铁臂枪虾",
+      "zh-Hant": "鐵臂槍蝦"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0692",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0693",
+    "no": "0693",
+    "form": null,
+    "names": {
+      "ja": "ブロスター",
+      "en": "Clawitzer",
+      "ko": "블로스터",
+      "zh-Hans": "钢炮臂虾",
+      "zh-Hant": "鋼炮臂蝦"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0693",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0694",
+    "no": "0694",
+    "form": null,
+    "names": {
+      "ja": "エリキテル",
+      "en": "Helioptile",
+      "ko": "목도리키텔",
+      "zh-Hans": "伞电蜥",
+      "zh-Hant": "傘電蜥"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0694",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0695",
+    "no": "0695",
+    "form": null,
+    "names": {
+      "ja": "エレザード",
+      "en": "Heliolisk",
+      "ko": "일레도리자드",
+      "zh-Hans": "光电伞蜥",
+      "zh-Hant": "光電傘蜥"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0695",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0696",
+    "no": "0696",
+    "form": null,
+    "names": {
+      "ja": "チゴラス",
+      "en": "Tyrunt",
+      "ko": "티고라스",
+      "zh-Hans": "宝宝暴龙",
+      "zh-Hant": "寶寶暴龍"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0696",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0697",
+    "no": "0697",
+    "form": null,
+    "names": {
+      "ja": "ガチゴラス",
+      "en": "Tyrantrum",
+      "ko": "견고라스",
+      "zh-Hans": "怪颚龙",
+      "zh-Hant": "怪顎龍"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0697",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0698",
+    "no": "0698",
+    "form": null,
+    "names": {
+      "ja": "アマルス",
+      "en": "Amaura",
+      "ko": "아마루스",
+      "zh-Hans": "冰雪龙",
+      "zh-Hant": "冰雪龍"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0698",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0699",
+    "no": "0699",
+    "form": null,
+    "names": {
+      "ja": "アマルルガ",
+      "en": "Aurorus",
+      "ko": "아마루르가",
+      "zh-Hans": "冰雪巨龙",
+      "zh-Hant": "冰雪巨龍"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0699",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0700",
+    "no": "0700",
+    "form": null,
+    "names": {
+      "ja": "ニンフィア",
+      "en": "Sylveon",
+      "ko": "님피아",
+      "zh-Hans": "仙子伊布",
+      "zh-Hant": "仙子伊布"
+    },
+    "types": [
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0700",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0701",
+    "no": "0701",
+    "form": null,
+    "names": {
+      "ja": "ルチャブル",
+      "en": "Hawlucha",
+      "ko": "루차불",
+      "zh-Hans": "摔角鹰人",
+      "zh-Hant": "摔角鷹人"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0701",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0702",
+    "no": "0702",
+    "form": null,
+    "names": {
+      "ja": "デデンネ",
+      "en": "Dedenne",
+      "ko": "데덴네",
+      "zh-Hans": "咚咚鼠",
+      "zh-Hant": "咚咚鼠"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0702",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0703",
+    "no": "0703",
+    "form": null,
+    "names": {
+      "ja": "メレシー",
+      "en": "Carbink",
+      "ko": "멜리시",
+      "zh-Hans": "小碎钻",
+      "zh-Hant": "小碎鑽"
+    },
+    "types": [
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0703",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0704",
+    "no": "0704",
+    "form": null,
+    "names": {
+      "ja": "ヌメラ",
+      "en": "Goomy",
+      "ko": "미끄메라",
+      "zh-Hans": "黏黏宝",
+      "zh-Hant": "黏黏寶"
+    },
+    "types": [
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0704",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0705",
+    "no": "0705",
+    "form": null,
+    "names": {
+      "ja": "ヌメイル",
+      "en": "Sliggoo",
+      "ko": "미끄네일",
+      "zh-Hans": "黏美儿",
+      "zh-Hant": "黏美兒"
+    },
+    "types": [
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0705",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0705-hisui",
+    "no": "0705",
+    "form": "hisui",
+    "names": {
+      "ja": "ヌメイル",
+      "en": "Sliggoo",
+      "ko": "미끄네일",
+      "zh-Hans": "黏美儿",
+      "zh-Hant": "黏美兒"
+    },
+    "types": [
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0705-hisui",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0706",
+    "no": "0706",
+    "form": null,
+    "names": {
+      "ja": "ヌメルゴン",
+      "en": "Goodra",
+      "ko": "미끄래곤",
+      "zh-Hans": "黏美龙",
+      "zh-Hant": "黏美龍"
+    },
+    "types": [
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0706",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0706-hisui",
+    "no": "0706",
+    "form": "hisui",
+    "names": {
+      "ja": "ヌメルゴン",
+      "en": "Goodra",
+      "ko": "미끄래곤",
+      "zh-Hans": "黏美龙",
+      "zh-Hant": "黏美龍"
+    },
+    "types": [
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0706-hisui",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0707",
+    "no": "0707",
+    "form": null,
+    "names": {
+      "ja": "クレッフィ",
+      "en": "Klefki",
+      "ko": "클레피",
+      "zh-Hans": "钥圈儿",
+      "zh-Hant": "鑰圈兒"
+    },
+    "types": [
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0707",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0708",
+    "no": "0708",
+    "form": null,
+    "names": {
+      "ja": "ボクレー",
+      "en": "Phantump",
+      "ko": "나목령",
+      "zh-Hans": "小木灵",
+      "zh-Hant": "小木靈"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0708",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0709",
+    "no": "0709",
+    "form": null,
+    "names": {
+      "ja": "オーロット",
+      "en": "Trevenant",
+      "ko": "대로트",
+      "zh-Hans": "朽木妖",
+      "zh-Hant": "朽木妖"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0709",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0710",
+    "no": "0710",
+    "form": null,
+    "names": {
+      "ja": "バケッチャ",
+      "en": "Pumpkaboo",
+      "ko": "호바귀",
+      "zh-Hans": "南瓜精",
+      "zh-Hant": "南瓜精"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0710",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0711",
+    "no": "0711",
+    "form": null,
+    "names": {
+      "ja": "パンプジン",
+      "en": "Gourgeist",
+      "ko": "펌킨인",
+      "zh-Hans": "南瓜怪人",
+      "zh-Hant": "南瓜怪人"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0711",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0712",
+    "no": "0712",
+    "form": null,
+    "names": {
+      "ja": "カチコール",
+      "en": "Bergmite",
+      "ko": "꽁어름",
+      "zh-Hans": "冰宝",
+      "zh-Hant": "冰寶"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0712",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0713",
+    "no": "0713",
+    "form": null,
+    "names": {
+      "ja": "クレベース",
+      "en": "Avalugg",
+      "ko": "크레베이스",
+      "zh-Hans": "冰岩怪",
+      "zh-Hant": "冰岩怪"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0713",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0713-hisui",
+    "no": "0713",
+    "form": "hisui",
+    "names": {
+      "ja": "クレベース",
+      "en": "Avalugg",
+      "ko": "크레베이스",
+      "zh-Hans": "冰岩怪",
+      "zh-Hant": "冰岩怪"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0713-hisui",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0714",
+    "no": "0714",
+    "form": null,
+    "names": {
+      "ja": "オンバット",
+      "en": "Noibat",
+      "ko": "음뱃",
+      "zh-Hans": "嗡蝠",
+      "zh-Hant": "嗡蝠"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0714",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0715",
+    "no": "0715",
+    "form": null,
+    "names": {
+      "ja": "オンバーン",
+      "en": "Noivern",
+      "ko": "음번",
+      "zh-Hans": "音波龙",
+      "zh-Hant": "音波龍"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0715",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0716",
+    "no": "0716",
+    "form": null,
+    "names": {
+      "ja": "ゼルネアス",
+      "en": "Xerneas",
+      "ko": "제르네아스",
+      "zh-Hans": "哲尔尼亚斯",
+      "zh-Hant": "哲爾尼亞斯"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0716",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0717",
+    "no": "0717",
+    "form": null,
+    "names": {
+      "ja": "イベルタル",
+      "en": "Yveltal",
+      "ko": "이벨타르",
+      "zh-Hans": "伊裴尔塔尔",
+      "zh-Hant": "伊裴爾塔爾"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0717",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0718",
+    "no": "0718",
+    "form": null,
+    "names": {
+      "ja": "ジガルデ",
+      "en": "Zygarde",
+      "ko": "지가르데",
+      "zh-Hans": "基格尔德",
+      "zh-Hant": "基格爾德"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0718",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0719",
+    "no": "0719",
+    "form": null,
+    "names": {
+      "ja": "ディアンシー",
+      "en": "Diancie",
+      "ko": "디안시",
+      "zh-Hans": "蒂安希",
+      "zh-Hant": "蒂安希"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0719",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0720",
+    "no": "0720",
+    "form": null,
+    "names": {
+      "ja": "フーパ",
+      "en": "Hoopa",
+      "ko": "후파",
+      "zh-Hans": "胡帕",
+      "zh-Hant": "胡帕"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0720",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0721",
+    "no": "0721",
+    "form": null,
+    "names": {
+      "ja": "ボルケニオン",
+      "en": "Volcanion",
+      "ko": "볼케니온",
+      "zh-Hans": "波尔凯尼恩",
+      "zh-Hant": "波爾凱尼恩"
+    },
+    "types": [],
+    "generation": 6,
+    "evolution": {
+      "family_id": "0721",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0722",
+    "no": "0722",
+    "form": null,
+    "names": {
+      "ja": "モクロー",
+      "en": "Rowlet",
+      "ko": "나몰빼미",
+      "zh-Hans": "木木枭",
+      "zh-Hant": "木木梟"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0722",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0723",
+    "no": "0723",
+    "form": null,
+    "names": {
+      "ja": "フクスロー",
+      "en": "Dartrix",
+      "ko": "빼미스로우",
+      "zh-Hans": "投羽枭",
+      "zh-Hant": "投羽梟"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0723",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0724",
+    "no": "0724",
+    "form": null,
+    "names": {
+      "ja": "ジュナイパー",
+      "en": "Decidueye",
+      "ko": "모크나이퍼",
+      "zh-Hans": "狙射树枭",
+      "zh-Hant": "狙射樹梟"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0724",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0724-hisui",
+    "no": "0724",
+    "form": "hisui",
+    "names": {
+      "ja": "ジュナイパー",
+      "en": "Decidueye",
+      "ko": "모크나이퍼",
+      "zh-Hans": "狙射树枭",
+      "zh-Hant": "狙射樹梟"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0724-hisui",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0725",
+    "no": "0725",
+    "form": null,
+    "names": {
+      "ja": "ニャビー",
+      "en": "Litten",
+      "ko": "냐오불",
+      "zh-Hans": "火斑喵",
+      "zh-Hant": "火斑喵"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0725",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0726",
+    "no": "0726",
+    "form": null,
+    "names": {
+      "ja": "ニャヒート",
+      "en": "Torracat",
+      "ko": "냐오히트",
+      "zh-Hans": "炎热喵",
+      "zh-Hant": "炎熱喵"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0726",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0727",
+    "no": "0727",
+    "form": null,
+    "names": {
+      "ja": "ガオガエン",
+      "en": "Incineroar",
+      "ko": "어흥염",
+      "zh-Hans": "炽焰咆哮虎",
+      "zh-Hant": "熾焰咆哮虎"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0727",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0728",
+    "no": "0728",
+    "form": null,
+    "names": {
+      "ja": "アシマリ",
+      "en": "Popplio",
+      "ko": "누리공",
+      "zh-Hans": "球球海狮",
+      "zh-Hant": "球球海獅"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0728",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0729",
+    "no": "0729",
+    "form": null,
+    "names": {
+      "ja": "オシャマリ",
+      "en": "Brionne",
+      "ko": "키요공",
+      "zh-Hans": "花漾海狮",
+      "zh-Hant": "花漾海獅"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0729",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0730",
+    "no": "0730",
+    "form": null,
+    "names": {
+      "ja": "アシレーヌ",
+      "en": "Primarina",
+      "ko": "누리레느",
+      "zh-Hans": "西狮海壬",
+      "zh-Hant": "西獅海壬"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0730",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0731",
+    "no": "0731",
+    "form": null,
+    "names": {
+      "ja": "ツツケラ",
+      "en": "Pikipek",
+      "ko": "콕코구리",
+      "zh-Hans": "小笃儿",
+      "zh-Hant": "小篤兒"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0731",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0732",
+    "no": "0732",
+    "form": null,
+    "names": {
+      "ja": "ケララッパ",
+      "en": "Trumbeak",
+      "ko": "크라파",
+      "zh-Hans": "喇叭啄鸟",
+      "zh-Hant": "喇叭啄鳥"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0732",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0733",
+    "no": "0733",
+    "form": null,
+    "names": {
+      "ja": "ドデカバシ",
+      "en": "Toucannon",
+      "ko": "왕큰부리",
+      "zh-Hans": "铳嘴大鸟",
+      "zh-Hant": "銃嘴大鳥"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0733",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0734",
+    "no": "0734",
+    "form": null,
+    "names": {
+      "ja": "ヤングース",
+      "en": "Yungoos",
+      "ko": "영구스",
+      "zh-Hans": "猫鼬少",
+      "zh-Hant": "貓鼬少"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0734",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0735",
+    "no": "0735",
+    "form": null,
+    "names": {
+      "ja": "デカグース",
+      "en": "Gumshoos",
+      "ko": "형사구스",
+      "zh-Hans": "猫鼬探长",
+      "zh-Hant": "貓鼬探長"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0735",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0736",
+    "no": "0736",
+    "form": null,
+    "names": {
+      "ja": "アゴジムシ",
+      "en": "Grubbin",
+      "ko": "턱지충이",
+      "zh-Hans": "强颚鸡母虫",
+      "zh-Hant": "強顎雞母蟲"
+    },
+    "types": [
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0736",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0737",
+    "no": "0737",
+    "form": null,
+    "names": {
+      "ja": "デンヂムシ",
+      "en": "Charjabug",
+      "ko": "전지충이",
+      "zh-Hans": "虫电宝",
+      "zh-Hant": "蟲電寶"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0737",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0738",
+    "no": "0738",
+    "form": null,
+    "names": {
+      "ja": "クワガノン",
+      "en": "Vikavolt",
+      "ko": "투구뿌논",
+      "zh-Hans": "锹农炮虫",
+      "zh-Hant": "鍬農炮蟲"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0738",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0739",
+    "no": "0739",
+    "form": null,
+    "names": {
+      "ja": "マケンカニ",
+      "en": "Crabrawler",
+      "ko": "오기지게",
+      "zh-Hans": "好胜蟹",
+      "zh-Hant": "好勝蟹"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0739",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0740",
+    "no": "0740",
+    "form": null,
+    "names": {
+      "ja": "ケケンカニ",
+      "en": "Crabominable",
+      "ko": "모단단게",
+      "zh-Hans": "好胜毛蟹",
+      "zh-Hant": "好勝毛蟹"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      },
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0740",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0741",
+    "no": "0741",
+    "form": null,
+    "names": {
+      "ja": "オドリドリ",
+      "en": "Oricorio",
+      "ko": "춤추새",
+      "zh-Hans": "花舞鸟",
+      "zh-Hant": "花舞鳥"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0741",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0742",
+    "no": "0742",
+    "form": null,
+    "names": {
+      "ja": "アブリー",
+      "en": "Cutiefly",
+      "ko": "에블리",
+      "zh-Hans": "萌虻",
+      "zh-Hant": "萌虻"
+    },
+    "types": [
+      {
+        "ja": "むし",
+        "en": "Bug"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0742",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0743",
+    "no": "0743",
+    "form": null,
+    "names": {
+      "ja": "アブリボン",
+      "en": "Ribombee",
+      "ko": "에리본",
+      "zh-Hans": "蝶结萌虻",
+      "zh-Hant": "蝶結萌虻"
+    },
+    "types": [
+      {
+        "ja": "むし",
+        "en": "Bug"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0743",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0744",
+    "no": "0744",
+    "form": null,
+    "names": {
+      "ja": "イワンコ",
+      "en": "Rockruff",
+      "ko": "암멍이",
+      "zh-Hans": "岩狗狗",
+      "zh-Hant": "岩狗狗"
+    },
+    "types": [
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0744",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0745",
+    "no": "0745",
+    "form": null,
+    "names": {
+      "ja": "ルガルガン",
+      "en": "Lycanroc",
+      "ko": "루가루암",
+      "zh-Hans": "鬃岩狼人",
+      "zh-Hant": "鬃岩狼人"
+    },
+    "types": [
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0745",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0746",
+    "no": "0746",
+    "form": null,
+    "names": {
+      "ja": "ヨワシ",
+      "en": "Wishiwashi",
+      "ko": "약어리",
+      "zh-Hans": "弱丁鱼",
+      "zh-Hant": "弱丁魚"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0746",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0747",
+    "no": "0747",
+    "form": null,
+    "names": {
+      "ja": "ヒドイデ",
+      "en": "Mareanie",
+      "ko": "시마사리",
+      "zh-Hans": "好坏星",
+      "zh-Hant": "好壞星"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0747",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0748",
+    "no": "0748",
+    "form": null,
+    "names": {
+      "ja": "ドヒドイデ",
+      "en": "Toxapex",
+      "ko": "더시마사리",
+      "zh-Hans": "超坏星",
+      "zh-Hant": "超壞星"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0748",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0749",
+    "no": "0749",
+    "form": null,
+    "names": {
+      "ja": "ドロバンコ",
+      "en": "Mudbray",
+      "ko": "머드나기",
+      "zh-Hans": "泥驴仔",
+      "zh-Hant": "泥驢仔"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0749",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0750",
+    "no": "0750",
+    "form": null,
+    "names": {
+      "ja": "バンバドロ",
+      "en": "Mudsdale",
+      "ko": "만마드",
+      "zh-Hans": "重泥挽马",
+      "zh-Hant": "重泥挽馬"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0750",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0751",
+    "no": "0751",
+    "form": null,
+    "names": {
+      "ja": "シズクモ",
+      "en": "Dewpider",
+      "ko": "물거미",
+      "zh-Hans": "滴蛛",
+      "zh-Hant": "滴蛛"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0751",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0752",
+    "no": "0752",
+    "form": null,
+    "names": {
+      "ja": "オニシズクモ",
+      "en": "Araquanid",
+      "ko": "깨비물거미",
+      "zh-Hans": "滴蛛霸",
+      "zh-Hant": "滴蛛霸"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0752",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0753",
+    "no": "0753",
+    "form": null,
+    "names": {
+      "ja": "カリキリ",
+      "en": "Fomantis",
+      "ko": "짜랑랑",
+      "zh-Hans": "伪螳草",
+      "zh-Hant": "偽螳草"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0753",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0754",
+    "no": "0754",
+    "form": null,
+    "names": {
+      "ja": "ラランテス",
+      "en": "Lurantis",
+      "ko": "라란티스",
+      "zh-Hans": "兰螳花",
+      "zh-Hant": "蘭螳花"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0754",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0755",
+    "no": "0755",
+    "form": null,
+    "names": {
+      "ja": "ネマシュ",
+      "en": "Morelull",
+      "ko": "자마슈",
+      "zh-Hans": "睡睡菇",
+      "zh-Hant": "睡睡菇"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0755",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0756",
+    "no": "0756",
+    "form": null,
+    "names": {
+      "ja": "マシェード",
+      "en": "Shiinotic",
+      "ko": "마셰이드",
+      "zh-Hans": "灯罩夜菇",
+      "zh-Hant": "燈罩夜菇"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0756",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0757",
+    "no": "0757",
+    "form": null,
+    "names": {
+      "ja": "ヤトウモリ",
+      "en": "Salandit",
+      "ko": "야도뇽",
+      "zh-Hans": "夜盗火蜥",
+      "zh-Hant": "夜盜火蜥"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0757",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0758",
+    "no": "0758",
+    "form": null,
+    "names": {
+      "ja": "エンニュート",
+      "en": "Salazzle",
+      "ko": "염뉴트",
+      "zh-Hans": "焰后蜥",
+      "zh-Hant": "焰后蜥"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0758",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0759",
+    "no": "0759",
+    "form": null,
+    "names": {
+      "ja": "ヌイコグマ",
+      "en": "Stufful",
+      "ko": "포곰곰",
+      "zh-Hans": "童偶熊",
+      "zh-Hant": "童偶熊"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0759",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0760",
+    "no": "0760",
+    "form": null,
+    "names": {
+      "ja": "キテルグマ",
+      "en": "Bewear",
+      "ko": "이븐곰",
+      "zh-Hans": "穿着熊",
+      "zh-Hant": "穿著熊"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0760",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0761",
+    "no": "0761",
+    "form": null,
+    "names": {
+      "ja": "アマカジ",
+      "en": "Bounsweet",
+      "ko": "달콤아",
+      "zh-Hans": "甜竹竹",
+      "zh-Hant": "甜竹竹"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0761",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0762",
+    "no": "0762",
+    "form": null,
+    "names": {
+      "ja": "アママイコ",
+      "en": "Steenee",
+      "ko": "달무리나",
+      "zh-Hans": "甜舞妮",
+      "zh-Hant": "甜舞妮"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0762",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0763",
+    "no": "0763",
+    "form": null,
+    "names": {
+      "ja": "アマージョ",
+      "en": "Tsareena",
+      "ko": "달코퀸",
+      "zh-Hans": "甜冷美后",
+      "zh-Hant": "甜冷美后"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0763",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0764",
+    "no": "0764",
+    "form": null,
+    "names": {
+      "ja": "キュワワー",
+      "en": "Comfey",
+      "ko": "큐아링",
+      "zh-Hans": "花疗环环",
+      "zh-Hant": "花療環環"
+    },
+    "types": [
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0764",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0765",
+    "no": "0765",
+    "form": null,
+    "names": {
+      "ja": "ヤレユータン",
+      "en": "Oranguru",
+      "ko": "하랑우탄",
+      "zh-Hans": "智挥猩",
+      "zh-Hant": "智揮猩"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0765",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0766",
+    "no": "0766",
+    "form": null,
+    "names": {
+      "ja": "ナゲツケサル",
+      "en": "Passimian",
+      "ko": "내던숭이",
+      "zh-Hans": "投掷猴",
+      "zh-Hant": "投擲猴"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0766",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0767",
+    "no": "0767",
+    "form": null,
+    "names": {
+      "ja": "コソクムシ",
+      "en": "Wimpod",
+      "ko": "꼬시레",
+      "zh-Hans": "胆小虫",
+      "zh-Hant": "膽小蟲"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0767",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0768",
+    "no": "0768",
+    "form": null,
+    "names": {
+      "ja": "グソクムシャ",
+      "en": "Golisopod",
+      "ko": "갑주무사",
+      "zh-Hans": "具甲武者",
+      "zh-Hant": "具甲武者"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0768",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0769",
+    "no": "0769",
+    "form": null,
+    "names": {
+      "ja": "スナバァ",
+      "en": "Sandygast",
+      "ko": "모래꿍",
+      "zh-Hans": "沙丘娃",
+      "zh-Hant": "沙丘娃"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0769",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0770",
+    "no": "0770",
+    "form": null,
+    "names": {
+      "ja": "シロデスナ",
+      "en": "Palossand",
+      "ko": "모래성이당",
+      "zh-Hans": "噬沙堡爷",
+      "zh-Hant": "噬沙堡爺"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0770",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0771",
+    "no": "0771",
+    "form": null,
+    "names": {
+      "ja": "ナマコブシ",
+      "en": "Pyukumuku",
+      "ko": "해무기",
+      "zh-Hans": "拳海参",
+      "zh-Hant": "拳海參"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0771",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0772",
+    "no": "0772",
+    "form": null,
+    "names": {
+      "ja": "タイプ：ヌル",
+      "en": "Type: Null",
+      "ko": "타입:널",
+      "zh-Hans": "属性：空",
+      "zh-Hant": "屬性：空"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0772",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0773",
+    "no": "0773",
+    "form": null,
+    "names": {
+      "ja": "シルヴァディ",
+      "en": "Silvally",
+      "ko": "실버디",
+      "zh-Hans": "银伴战兽",
+      "zh-Hant": "銀伴戰獸"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0773",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0774",
+    "no": "0774",
+    "form": null,
+    "names": {
+      "ja": "メテノ",
+      "en": "Minior",
+      "ko": "메테노",
+      "zh-Hans": "小陨星",
+      "zh-Hant": "小隕星"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0774",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0775",
+    "no": "0775",
+    "form": null,
+    "names": {
+      "ja": "ネッコアラ",
+      "en": "Komala",
+      "ko": "자말라",
+      "zh-Hans": "树枕尾熊",
+      "zh-Hant": "樹枕尾熊"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0775",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0776",
+    "no": "0776",
+    "form": null,
+    "names": {
+      "ja": "バクガメス",
+      "en": "Turtonator",
+      "ko": "폭거북스",
+      "zh-Hans": "爆焰龟兽",
+      "zh-Hant": "爆焰龜獸"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0776",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0777",
+    "no": "0777",
+    "form": null,
+    "names": {
+      "ja": "トゲデマル",
+      "en": "Togedemaru",
+      "ko": "토게데마루",
+      "zh-Hans": "托戈德玛尔",
+      "zh-Hant": "托戈德瑪爾"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0777",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0778",
+    "no": "0778",
+    "form": null,
+    "names": {
+      "ja": "ミミッキュ",
+      "en": "Mimikyu",
+      "ko": "따라큐",
+      "zh-Hans": "谜拟丘",
+      "zh-Hant": "謎擬Ｑ"
+    },
+    "types": [
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0778",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0779",
+    "no": "0779",
+    "form": null,
+    "names": {
+      "ja": "ハギギシリ",
+      "en": "Bruxish",
+      "ko": "치갈기",
+      "zh-Hans": "磨牙彩皮鱼",
+      "zh-Hant": "磨牙彩皮魚"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0779",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0780",
+    "no": "0780",
+    "form": null,
+    "names": {
+      "ja": "ジジーロン",
+      "en": "Drampa",
+      "ko": "할비롱",
+      "zh-Hans": "老翁龙",
+      "zh-Hant": "老翁龍"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0780",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0781",
+    "no": "0781",
+    "form": null,
+    "names": {
+      "ja": "ダダリン",
+      "en": "Dhelmise",
+      "ko": "타타륜",
+      "zh-Hans": "破破舵轮",
+      "zh-Hant": "破破舵輪"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0781",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0782",
+    "no": "0782",
+    "form": null,
+    "names": {
+      "ja": "ジャラコ",
+      "en": "Jangmo-o",
+      "ko": "짜랑꼬",
+      "zh-Hans": "心鳞宝",
+      "zh-Hant": "心鱗寶"
+    },
+    "types": [
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0782",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0783",
+    "no": "0783",
+    "form": null,
+    "names": {
+      "ja": "ジャランゴ",
+      "en": "Hakamo-o",
+      "ko": "짜랑고우",
+      "zh-Hans": "鳞甲龙",
+      "zh-Hant": "鱗甲龍"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0783",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0784",
+    "no": "0784",
+    "form": null,
+    "names": {
+      "ja": "ジャラランガ",
+      "en": "Kommo-o",
+      "ko": "짜랑고우거",
+      "zh-Hans": "杖尾鳞甲龙",
+      "zh-Hant": "杖尾鱗甲龍"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0784",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0785",
+    "no": "0785",
+    "form": null,
+    "names": {
+      "ja": "カプ・コケコ",
+      "en": "Tapu Koko",
+      "ko": "카푸꼬꼬꼭",
+      "zh-Hans": "卡璞・鸣鸣",
+      "zh-Hant": "卡璞・鳴鳴"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0785",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0786",
+    "no": "0786",
+    "form": null,
+    "names": {
+      "ja": "カプ・テテフ",
+      "en": "Tapu Lele",
+      "ko": "카푸나비나",
+      "zh-Hans": "卡璞・蝶蝶",
+      "zh-Hant": "卡璞・蝶蝶"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0786",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0787",
+    "no": "0787",
+    "form": null,
+    "names": {
+      "ja": "カプ・ブルル",
+      "en": "Tapu Bulu",
+      "ko": "카푸브루루",
+      "zh-Hans": "卡璞・哞哞",
+      "zh-Hant": "卡璞・哞哞"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0787",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0788",
+    "no": "0788",
+    "form": null,
+    "names": {
+      "ja": "カプ・レヒレ",
+      "en": "Tapu Fini",
+      "ko": "카푸느지느",
+      "zh-Hans": "卡璞・鳍鳍",
+      "zh-Hant": "卡璞・鰭鰭"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0788",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0789",
+    "no": "0789",
+    "form": null,
+    "names": {
+      "ja": "コスモッグ",
+      "en": "Cosmog",
+      "ko": "코스모그",
+      "zh-Hans": "科斯莫古",
+      "zh-Hant": "科斯莫古"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0789",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0790",
+    "no": "0790",
+    "form": null,
+    "names": {
+      "ja": "コスモウム",
+      "en": "Cosmoem",
+      "ko": "코스모움",
+      "zh-Hans": "科斯莫姆",
+      "zh-Hant": "科斯莫姆"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0790",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0791",
+    "no": "0791",
+    "form": null,
+    "names": {
+      "ja": "ソルガレオ",
+      "en": "Solgaleo",
+      "ko": "솔가레오",
+      "zh-Hans": "索尔迦雷欧",
+      "zh-Hant": "索爾迦雷歐"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0791",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0792",
+    "no": "0792",
+    "form": null,
+    "names": {
+      "ja": "ルナアーラ",
+      "en": "Lunala",
+      "ko": "루나아라",
+      "zh-Hans": "露奈雅拉",
+      "zh-Hant": "露奈雅拉"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0792",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0793",
+    "no": "0793",
+    "form": null,
+    "names": {
+      "ja": "ウツロイド",
+      "en": "Nihilego",
+      "ko": "텅비드",
+      "zh-Hans": "虚吾伊德",
+      "zh-Hant": "虛吾伊德"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0793",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0794",
+    "no": "0794",
+    "form": null,
+    "names": {
+      "ja": "マッシブーン",
+      "en": "Buzzwole",
+      "ko": "매시붕",
+      "zh-Hans": "爆肌蚊",
+      "zh-Hant": "爆肌蚊"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0794",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0795",
+    "no": "0795",
+    "form": null,
+    "names": {
+      "ja": "フェローチェ",
+      "en": "Pheromosa",
+      "ko": "페로코체",
+      "zh-Hans": "费洛美螂",
+      "zh-Hant": "費洛美螂"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0795",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0796",
+    "no": "0796",
+    "form": null,
+    "names": {
+      "ja": "デンジュモク",
+      "en": "Xurkitree",
+      "ko": "전수목",
+      "zh-Hans": "电束木",
+      "zh-Hant": "電束木"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0796",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0797",
+    "no": "0797",
+    "form": null,
+    "names": {
+      "ja": "テッカグヤ",
+      "en": "Celesteela",
+      "ko": "철화구야",
+      "zh-Hans": "铁火辉夜",
+      "zh-Hant": "鐵火輝夜"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0797",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0798",
+    "no": "0798",
+    "form": null,
+    "names": {
+      "ja": "カミツルギ",
+      "en": "Kartana",
+      "ko": "종이신도",
+      "zh-Hans": "纸御剑",
+      "zh-Hant": "紙御劍"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0798",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0799",
+    "no": "0799",
+    "form": null,
+    "names": {
+      "ja": "アクジキング",
+      "en": "Guzzlord",
+      "ko": "악식킹",
+      "zh-Hans": "恶食大王",
+      "zh-Hant": "惡食大王"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0799",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0800",
+    "no": "0800",
+    "form": null,
+    "names": {
+      "ja": "ネクロズマ",
+      "en": "Necrozma",
+      "ko": "네크로즈마",
+      "zh-Hans": "奈克洛兹玛",
+      "zh-Hant": "奈克洛茲瑪"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0800",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0801",
+    "no": "0801",
+    "form": null,
+    "names": {
+      "ja": "マギアナ",
+      "en": "Magearna",
+      "ko": "마기아나",
+      "zh-Hans": "玛机雅娜",
+      "zh-Hant": "瑪機雅娜"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0801",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0802",
+    "no": "0802",
+    "form": null,
+    "names": {
+      "ja": "マーシャドー",
+      "en": "Marshadow",
+      "ko": "마샤도",
+      "zh-Hans": "玛夏多",
+      "zh-Hant": "瑪夏多"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0802",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0803",
+    "no": "0803",
+    "form": null,
+    "names": {
+      "ja": "ベベノム",
+      "en": "Poipole",
+      "ko": "베베놈",
+      "zh-Hans": "毒贝比",
+      "zh-Hant": "毒貝比"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0803",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0804",
+    "no": "0804",
+    "form": null,
+    "names": {
+      "ja": "アーゴヨン",
+      "en": "Naganadel",
+      "ko": "아고용",
+      "zh-Hans": "四颚针龙",
+      "zh-Hant": "四顎針龍"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0804",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0805",
+    "no": "0805",
+    "form": null,
+    "names": {
+      "ja": "ツンデツンデ",
+      "en": "Stakataka",
+      "ko": "차곡차곡",
+      "zh-Hans": "垒磊石",
+      "zh-Hant": "壘磊石"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0805",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0806",
+    "no": "0806",
+    "form": null,
+    "names": {
+      "ja": "ズガドーン",
+      "en": "Blacephalon",
+      "ko": "두파팡",
+      "zh-Hans": "砰头小丑",
+      "zh-Hant": "砰頭小丑"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0806",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0807",
+    "no": "0807",
+    "form": null,
+    "names": {
+      "ja": "ゼラオラ",
+      "en": "Zeraora",
+      "ko": "제라오라",
+      "zh-Hans": "捷拉奥拉",
+      "zh-Hant": "捷拉奧拉"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0807",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0808",
+    "no": "0808",
+    "form": null,
+    "names": {
+      "ja": "メルタン",
+      "en": "Meltan",
+      "ko": "멜탄",
+      "zh-Hans": "美录坦",
+      "zh-Hant": "美錄坦"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0808",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0809",
+    "no": "0809",
+    "form": null,
+    "names": {
+      "ja": "メルメタル",
+      "en": "Melmetal",
+      "ko": "멜메탈",
+      "zh-Hans": "美录梅塔",
+      "zh-Hant": "美錄梅塔"
+    },
+    "types": [],
+    "generation": 7,
+    "evolution": {
+      "family_id": "0809",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0810",
+    "no": "0810",
+    "form": null,
+    "names": {
+      "ja": "サルノリ",
+      "en": "Grookey",
+      "ko": "흥나숭",
+      "zh-Hans": "敲音猴",
+      "zh-Hant": "敲音猴"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0810",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0811",
+    "no": "0811",
+    "form": null,
+    "names": {
+      "ja": "バチンキー",
+      "en": "Thwackey",
+      "ko": "채키몽",
+      "zh-Hans": "啪咚猴",
+      "zh-Hant": "啪咚猴"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0811",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0812",
+    "no": "0812",
+    "form": null,
+    "names": {
+      "ja": "ゴリランダー",
+      "en": "Rillaboom",
+      "ko": "고릴타",
+      "zh-Hans": "轰擂金刚猩",
+      "zh-Hant": "轟擂金剛猩"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0812",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0813",
+    "no": "0813",
+    "form": null,
+    "names": {
+      "ja": "ヒバニー",
+      "en": "Scorbunny",
+      "ko": "염버니",
+      "zh-Hans": "炎兔儿",
+      "zh-Hant": "炎兔兒"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0813",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0814",
+    "no": "0814",
+    "form": null,
+    "names": {
+      "ja": "ラビフット",
+      "en": "Raboot",
+      "ko": "래비풋",
+      "zh-Hans": "腾蹴小将",
+      "zh-Hant": "騰蹴小將"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0814",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0815",
+    "no": "0815",
+    "form": null,
+    "names": {
+      "ja": "エースバーン",
+      "en": "Cinderace",
+      "ko": "에이스번",
+      "zh-Hans": "闪焰王牌",
+      "zh-Hant": "閃焰王牌"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0815",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0816",
+    "no": "0816",
+    "form": null,
+    "names": {
+      "ja": "メッソン",
+      "en": "Sobble",
+      "ko": "울머기",
+      "zh-Hans": "泪眼蜥",
+      "zh-Hant": "淚眼蜥"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0816",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0817",
+    "no": "0817",
+    "form": null,
+    "names": {
+      "ja": "ジメレオン",
+      "en": "Drizzile",
+      "ko": "누겔레온",
+      "zh-Hans": "变涩蜥",
+      "zh-Hant": "變澀蜥"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0817",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0818",
+    "no": "0818",
+    "form": null,
+    "names": {
+      "ja": "インテレオン",
+      "en": "Inteleon",
+      "ko": "인텔리레온",
+      "zh-Hans": "千面避役",
+      "zh-Hant": "千面避役"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0818",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0819",
+    "no": "0819",
+    "form": null,
+    "names": {
+      "ja": "ホシガリス",
+      "en": "Skwovet",
+      "ko": "탐리스",
+      "zh-Hans": "贪心栗鼠",
+      "zh-Hant": "貪心栗鼠"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0819",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0820",
+    "no": "0820",
+    "form": null,
+    "names": {
+      "ja": "ヨクバリス",
+      "en": "Greedent",
+      "ko": "요씽리스",
+      "zh-Hans": "藏饱栗鼠",
+      "zh-Hant": "藏飽栗鼠"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0820",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0821",
+    "no": "0821",
+    "form": null,
+    "names": {
+      "ja": "ココガラ",
+      "en": "Rookidee",
+      "ko": "파라꼬",
+      "zh-Hans": "稚山雀",
+      "zh-Hant": "稚山雀"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0821",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0822",
+    "no": "0822",
+    "form": null,
+    "names": {
+      "ja": "アオガラス",
+      "en": "Corvisquire",
+      "ko": "파크로우",
+      "zh-Hans": "蓝鸦",
+      "zh-Hant": "藍鴉"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0822",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0823",
+    "no": "0823",
+    "form": null,
+    "names": {
+      "ja": "アーマーガア",
+      "en": "Corviknight",
+      "ko": "아머까오",
+      "zh-Hans": "钢铠鸦",
+      "zh-Hant": "鋼鎧鴉"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0823",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0824",
+    "no": "0824",
+    "form": null,
+    "names": {
+      "ja": "サッチムシ",
+      "en": "Blipbug",
+      "ko": "두루지벌레",
+      "zh-Hans": "索侦虫",
+      "zh-Hant": "索偵蟲"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0824",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0825",
+    "no": "0825",
+    "form": null,
+    "names": {
+      "ja": "レドームシ",
+      "en": "Dottler",
+      "ko": "레돔벌레",
+      "zh-Hans": "天罩虫",
+      "zh-Hant": "天罩蟲"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0825",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0826",
+    "no": "0826",
+    "form": null,
+    "names": {
+      "ja": "イオルブ",
+      "en": "Orbeetle",
+      "ko": "이올브",
+      "zh-Hans": "以欧路普",
+      "zh-Hant": "以歐路普"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0826",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0827",
+    "no": "0827",
+    "form": null,
+    "names": {
+      "ja": "クスネ",
+      "en": "Nickit",
+      "ko": "훔처우",
+      "zh-Hans": "狡小狐",
+      "zh-Hant": "偷兒狐"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0827",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0828",
+    "no": "0828",
+    "form": null,
+    "names": {
+      "ja": "フォクスライ",
+      "en": "Thievul",
+      "ko": "폭슬라이",
+      "zh-Hans": "猾大狐",
+      "zh-Hant": "狐大盜"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0828",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0829",
+    "no": "0829",
+    "form": null,
+    "names": {
+      "ja": "ヒメンカ",
+      "en": "Gossifleur",
+      "ko": "꼬모카",
+      "zh-Hans": "幼棉棉",
+      "zh-Hant": "幼棉棉"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0829",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0830",
+    "no": "0830",
+    "form": null,
+    "names": {
+      "ja": "ワタシラガ",
+      "en": "Eldegoss",
+      "ko": "백솜모카",
+      "zh-Hans": "白蓬蓬",
+      "zh-Hant": "白蓬蓬"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0830",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0831",
+    "no": "0831",
+    "form": null,
+    "names": {
+      "ja": "ウールー",
+      "en": "Wooloo",
+      "ko": "우르",
+      "zh-Hans": "毛辫羊",
+      "zh-Hant": "毛辮羊"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0831",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0832",
+    "no": "0832",
+    "form": null,
+    "names": {
+      "ja": "バイウールー",
+      "en": "Dubwool",
+      "ko": "배우르",
+      "zh-Hans": "毛毛角羊",
+      "zh-Hant": "毛毛角羊"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0832",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0833",
+    "no": "0833",
+    "form": null,
+    "names": {
+      "ja": "カムカメ",
+      "en": "Chewtle",
+      "ko": "깨물부기",
+      "zh-Hans": "咬咬龟",
+      "zh-Hant": "咬咬龜"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0833",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0834",
+    "no": "0834",
+    "form": null,
+    "names": {
+      "ja": "カジリガメ",
+      "en": "Drednaw",
+      "ko": "갈가부기",
+      "zh-Hans": "暴噬龟",
+      "zh-Hant": "暴噬龜"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0834",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0835",
+    "no": "0835",
+    "form": null,
+    "names": {
+      "ja": "ワンパチ",
+      "en": "Yamper",
+      "ko": "멍파치",
+      "zh-Hans": "来电汪",
+      "zh-Hant": "來電汪"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0835",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0836",
+    "no": "0836",
+    "form": null,
+    "names": {
+      "ja": "パルスワン",
+      "en": "Boltund",
+      "ko": "펄스멍",
+      "zh-Hans": "逐电犬",
+      "zh-Hant": "逐電犬"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0836",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0837",
+    "no": "0837",
+    "form": null,
+    "names": {
+      "ja": "タンドン",
+      "en": "Rolycoly",
+      "ko": "탄동",
+      "zh-Hans": "小炭仔",
+      "zh-Hant": "小炭仔"
+    },
+    "types": [
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0837",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0838",
+    "no": "0838",
+    "form": null,
+    "names": {
+      "ja": "トロッゴン",
+      "en": "Carkol",
+      "ko": "탄차곤",
+      "zh-Hans": "大炭车",
+      "zh-Hant": "大炭車"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0838",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0839",
+    "no": "0839",
+    "form": null,
+    "names": {
+      "ja": "セキタンザン",
+      "en": "Coalossal",
+      "ko": "석탄산",
+      "zh-Hans": "巨炭山",
+      "zh-Hant": "巨炭山"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0839",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0840",
+    "no": "0840",
+    "form": null,
+    "names": {
+      "ja": "カジッチュ",
+      "en": "Applin",
+      "ko": "과사삭벌레",
+      "zh-Hans": "啃果虫",
+      "zh-Hant": "啃果蟲"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0840",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0841",
+    "no": "0841",
+    "form": null,
+    "names": {
+      "ja": "アップリュー",
+      "en": "Flapple",
+      "ko": "애프룡",
+      "zh-Hans": "苹裹龙",
+      "zh-Hant": "蘋裹龍"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0841",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0842",
+    "no": "0842",
+    "form": null,
+    "names": {
+      "ja": "タルップル",
+      "en": "Appletun",
+      "ko": "단지래플",
+      "zh-Hans": "丰蜜龙",
+      "zh-Hant": "豐蜜龍"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0842",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0843",
+    "no": "0843",
+    "form": null,
+    "names": {
+      "ja": "スナヘビ",
+      "en": "Silicobra",
+      "ko": "모래뱀",
+      "zh-Hans": "沙包蛇",
+      "zh-Hant": "沙包蛇"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0843",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0844",
+    "no": "0844",
+    "form": null,
+    "names": {
+      "ja": "サダイジャ",
+      "en": "Sandaconda",
+      "ko": "사다이사",
+      "zh-Hans": "沙螺蟒",
+      "zh-Hant": "沙螺蟒"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0844",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0845",
+    "no": "0845",
+    "form": null,
+    "names": {
+      "ja": "ウッウ",
+      "en": "Cramorant",
+      "ko": "윽우지",
+      "zh-Hans": "古月鸟",
+      "zh-Hant": "古月鳥"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0845",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0846",
+    "no": "0846",
+    "form": null,
+    "names": {
+      "ja": "サシカマス",
+      "en": "Arrokuda",
+      "ko": "찌로꼬치",
+      "zh-Hans": "刺梭鱼",
+      "zh-Hant": "刺梭魚"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0846",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0847",
+    "no": "0847",
+    "form": null,
+    "names": {
+      "ja": "カマスジョー",
+      "en": "Barraskewda",
+      "ko": "꼬치조",
+      "zh-Hans": "戽斗尖梭",
+      "zh-Hant": "戽斗尖梭"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0847",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0848",
+    "no": "0848",
+    "form": null,
+    "names": {
+      "ja": "エレズン",
+      "en": "Toxel",
+      "ko": "일레즌",
+      "zh-Hans": "电音婴",
+      "zh-Hant": "毒電嬰"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0848",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0849",
+    "no": "0849",
+    "form": null,
+    "names": {
+      "ja": "ストリンダー",
+      "en": "Toxtricity",
+      "ko": "스트린더",
+      "zh-Hans": "颤弦蝾螈",
+      "zh-Hant": "顫弦蠑螈"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0849",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0850",
+    "no": "0850",
+    "form": null,
+    "names": {
+      "ja": "ヤクデ",
+      "en": "Sizzlipede",
+      "ko": "태우지네",
+      "zh-Hans": "烧火蚣",
+      "zh-Hant": "燒火蚣"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0850",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0851",
+    "no": "0851",
+    "form": null,
+    "names": {
+      "ja": "マルヤクデ",
+      "en": "Centiskorch",
+      "ko": "다태우지네",
+      "zh-Hans": "焚焰蚣",
+      "zh-Hant": "焚焰蚣"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0851",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0852",
+    "no": "0852",
+    "form": null,
+    "names": {
+      "ja": "タタッコ",
+      "en": "Clobbopus",
+      "ko": "때때무노",
+      "zh-Hans": "拳拳蛸",
+      "zh-Hant": "拳拳蛸"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0852",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0853",
+    "no": "0853",
+    "form": null,
+    "names": {
+      "ja": "オトスパス",
+      "en": "Grapploct",
+      "ko": "케오퍼스",
+      "zh-Hans": "八爪武师",
+      "zh-Hant": "八爪武師"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0853",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0854",
+    "no": "0854",
+    "form": null,
+    "names": {
+      "ja": "ヤバチャ",
+      "en": "Sinistea",
+      "ko": "데인차",
+      "zh-Hans": "来悲茶",
+      "zh-Hant": "來悲茶"
+    },
+    "types": [
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0854",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0855",
+    "no": "0855",
+    "form": null,
+    "names": {
+      "ja": "ポットデス",
+      "en": "Polteageist",
+      "ko": "포트데스",
+      "zh-Hans": "怖思壶",
+      "zh-Hant": "怖思壺"
+    },
+    "types": [
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0855",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0856",
+    "no": "0856",
+    "form": null,
+    "names": {
+      "ja": "ミブリム",
+      "en": "Hatenna",
+      "ko": "몸지브림",
+      "zh-Hans": "迷布莉姆",
+      "zh-Hant": "迷布莉姆"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0856",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0857",
+    "no": "0857",
+    "form": null,
+    "names": {
+      "ja": "テブリム",
+      "en": "Hattrem",
+      "ko": "손지브림",
+      "zh-Hans": "提布莉姆",
+      "zh-Hant": "提布莉姆"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0857",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0858",
+    "no": "0858",
+    "form": null,
+    "names": {
+      "ja": "ブリムオン",
+      "en": "Hatterene",
+      "ko": "브리무음",
+      "zh-Hans": "布莉姆温",
+      "zh-Hant": "布莉姆溫"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0858",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0859",
+    "no": "0859",
+    "form": null,
+    "names": {
+      "ja": "ベロバー",
+      "en": "Impidimp",
+      "ko": "메롱꿍",
+      "zh-Hans": "捣蛋小妖",
+      "zh-Hant": "搗蛋小妖"
+    },
+    "types": [
+      {
+        "ja": "あく",
+        "en": "Dark"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0859",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0860",
+    "no": "0860",
+    "form": null,
+    "names": {
+      "ja": "ギモー",
+      "en": "Morgrem",
+      "ko": "쏘겨모",
+      "zh-Hans": "诈唬魔",
+      "zh-Hant": "詐唬魔"
+    },
+    "types": [
+      {
+        "ja": "あく",
+        "en": "Dark"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0860",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0861",
+    "no": "0861",
+    "form": null,
+    "names": {
+      "ja": "オーロンゲ",
+      "en": "Grimmsnarl",
+      "ko": "오롱털",
+      "zh-Hans": "长毛巨魔",
+      "zh-Hant": "長毛巨魔"
+    },
+    "types": [
+      {
+        "ja": "あく",
+        "en": "Dark"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0861",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0862",
+    "no": "0862",
+    "form": null,
+    "names": {
+      "ja": "タチフサグマ",
+      "en": "Obstagoon",
+      "ko": "가로막구리",
+      "zh-Hans": "堵拦熊",
+      "zh-Hant": "堵攔熊"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0862",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0863",
+    "no": "0863",
+    "form": null,
+    "names": {
+      "ja": "ニャイキング",
+      "en": "Perrserker",
+      "ko": "나이킹",
+      "zh-Hans": "喵头目",
+      "zh-Hant": "喵頭目"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0863",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0864",
+    "no": "0864",
+    "form": null,
+    "names": {
+      "ja": "サニゴーン",
+      "en": "Cursola",
+      "ko": "산호르곤",
+      "zh-Hans": "魔灵珊瑚",
+      "zh-Hant": "魔靈珊瑚"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0864",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0865",
+    "no": "0865",
+    "form": null,
+    "names": {
+      "ja": "ネギガナイト",
+      "en": "Sirfetch’d",
+      "ko": "창파나이트",
+      "zh-Hans": "葱游兵",
+      "zh-Hant": "蔥遊兵"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0865",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0866",
+    "no": "0866",
+    "form": null,
+    "names": {
+      "ja": "バリコオル",
+      "en": "Mr. Rime",
+      "ko": "마임꽁꽁",
+      "zh-Hans": "踏冰人偶",
+      "zh-Hant": "踏冰人偶"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0866",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0867",
+    "no": "0867",
+    "form": null,
+    "names": {
+      "ja": "デスバーン",
+      "en": "Runerigus",
+      "ko": "데스판",
+      "zh-Hans": "迭失板",
+      "zh-Hant": "死神板"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0867",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0868",
+    "no": "0868",
+    "form": null,
+    "names": {
+      "ja": "マホミル",
+      "en": "Milcery",
+      "ko": "마빌크",
+      "zh-Hans": "小仙奶",
+      "zh-Hant": "小仙奶"
+    },
+    "types": [
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0868",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0869",
+    "no": "0869",
+    "form": null,
+    "names": {
+      "ja": "マホイップ",
+      "en": "Alcremie",
+      "ko": "마휘핑",
+      "zh-Hans": "霜奶仙",
+      "zh-Hant": "霜奶仙"
+    },
+    "types": [
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0869",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0870",
+    "no": "0870",
+    "form": null,
+    "names": {
+      "ja": "タイレーツ",
+      "en": "Falinks",
+      "ko": "대여르",
+      "zh-Hans": "列阵兵",
+      "zh-Hant": "列陣兵"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0870",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0871",
+    "no": "0871",
+    "form": null,
+    "names": {
+      "ja": "バチンウニ",
+      "en": "Pincurchin",
+      "ko": "찌르성게",
+      "zh-Hans": "啪嚓海胆",
+      "zh-Hant": "啪嚓海膽"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0871",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0872",
+    "no": "0872",
+    "form": null,
+    "names": {
+      "ja": "ユキハミ",
+      "en": "Snom",
+      "ko": "누니머기",
+      "zh-Hans": "雪吞虫",
+      "zh-Hant": "雪吞蟲"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0872",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0873",
+    "no": "0873",
+    "form": null,
+    "names": {
+      "ja": "モスノウ",
+      "en": "Frosmoth",
+      "ko": "모스노우",
+      "zh-Hans": "雪绒蛾",
+      "zh-Hant": "雪絨蛾"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0873",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0874",
+    "no": "0874",
+    "form": null,
+    "names": {
+      "ja": "イシヘンジン",
+      "en": "Stonjourner",
+      "ko": "돌헨진",
+      "zh-Hans": "巨石丁",
+      "zh-Hant": "巨石丁"
+    },
+    "types": [
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0874",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0875",
+    "no": "0875",
+    "form": null,
+    "names": {
+      "ja": "コオリッポ",
+      "en": "Eiscue",
+      "ko": "빙큐보",
+      "zh-Hans": "冰砌鹅",
+      "zh-Hant": "冰砌鵝"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0875",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0876",
+    "no": "0876",
+    "form": null,
+    "names": {
+      "ja": "イエッサン",
+      "en": "Indeedee",
+      "ko": "에써르",
+      "zh-Hans": "爱管侍",
+      "zh-Hant": "愛管侍"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0876",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0877",
+    "no": "0877",
+    "form": null,
+    "names": {
+      "ja": "モルペコ",
+      "en": "Morpeko",
+      "ko": "모르페코",
+      "zh-Hans": "莫鲁贝可",
+      "zh-Hant": "莫魯貝可"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0877",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0878",
+    "no": "0878",
+    "form": null,
+    "names": {
+      "ja": "ゾウドウ",
+      "en": "Cufant",
+      "ko": "끼리동",
+      "zh-Hans": "铜象",
+      "zh-Hant": "銅象"
+    },
+    "types": [
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0878",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0879",
+    "no": "0879",
+    "form": null,
+    "names": {
+      "ja": "ダイオウドウ",
+      "en": "Copperajah",
+      "ko": "대왕끼리동",
+      "zh-Hans": "大王铜象",
+      "zh-Hant": "大王銅象"
+    },
+    "types": [
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0879",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0880",
+    "no": "0880",
+    "form": null,
+    "names": {
+      "ja": "パッチラゴン",
+      "en": "Dracozolt",
+      "ko": "파치래곤",
+      "zh-Hans": "雷鸟龙",
+      "zh-Hant": "雷鳥龍"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0880",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0881",
+    "no": "0881",
+    "form": null,
+    "names": {
+      "ja": "パッチルドン",
+      "en": "Arctozolt",
+      "ko": "파치르돈",
+      "zh-Hans": "雷鸟海兽",
+      "zh-Hant": "雷鳥海獸"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0881",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0882",
+    "no": "0882",
+    "form": null,
+    "names": {
+      "ja": "ウオノラゴン",
+      "en": "Dracovish",
+      "ko": "어래곤",
+      "zh-Hans": "鳃鱼龙",
+      "zh-Hant": "鰓魚龍"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0882",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0883",
+    "no": "0883",
+    "form": null,
+    "names": {
+      "ja": "ウオチルドン",
+      "en": "Arctovish",
+      "ko": "어치르돈",
+      "zh-Hans": "鳃鱼海兽",
+      "zh-Hant": "鰓魚海獸"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0883",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0884",
+    "no": "0884",
+    "form": null,
+    "names": {
+      "ja": "ジュラルドン",
+      "en": "Duraludon",
+      "ko": "두랄루돈",
+      "zh-Hans": "铝钢龙",
+      "zh-Hant": "鋁鋼龍"
+    },
+    "types": [
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0884",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0885",
+    "no": "0885",
+    "form": null,
+    "names": {
+      "ja": "ドラメシヤ",
+      "en": "Dreepy",
+      "ko": "드라꼰",
+      "zh-Hans": "多龙梅西亚",
+      "zh-Hant": "多龍梅西亞"
+    },
+    "types": [
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0885",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0886",
+    "no": "0886",
+    "form": null,
+    "names": {
+      "ja": "ドロンチ",
+      "en": "Drakloak",
+      "ko": "드래런치",
+      "zh-Hans": "多龙奇",
+      "zh-Hant": "多龍奇"
+    },
+    "types": [
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0886",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0887",
+    "no": "0887",
+    "form": null,
+    "names": {
+      "ja": "ドラパルト",
+      "en": "Dragapult",
+      "ko": "드래펄트",
+      "zh-Hans": "多龙巴鲁托",
+      "zh-Hant": "多龍巴魯托"
+    },
+    "types": [
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0887",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0888",
+    "no": "0888",
+    "form": null,
+    "names": {
+      "ja": "ザシアン",
+      "en": "Zacian",
+      "ko": "자시안",
+      "zh-Hans": "苍响",
+      "zh-Hant": "蒼響"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0888",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0889",
+    "no": "0889",
+    "form": null,
+    "names": {
+      "ja": "ザマゼンタ",
+      "en": "Zamazenta",
+      "ko": "자마젠타",
+      "zh-Hans": "藏玛然特",
+      "zh-Hant": "藏瑪然特"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0889",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0890",
+    "no": "0890",
+    "form": null,
+    "names": {
+      "ja": "ムゲンダイナ",
+      "en": "Eternatus",
+      "ko": "무한다이노",
+      "zh-Hans": "无极汰那",
+      "zh-Hant": "無極汰那"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0890",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0891",
+    "no": "0891",
+    "form": null,
+    "names": {
+      "ja": "ダクマ",
+      "en": "Kubfu",
+      "ko": "치고마",
+      "zh-Hans": "熊徒弟",
+      "zh-Hant": "熊徒弟"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0891",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0892",
+    "no": "0892",
+    "form": null,
+    "names": {
+      "ja": "ウーラオス",
+      "en": "Urshifu",
+      "ko": "우라오스",
+      "zh-Hans": "武道熊师",
+      "zh-Hant": "武道熊師"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0892",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0893",
+    "no": "0893",
+    "form": null,
+    "names": {
+      "ja": "ザルード",
+      "en": "Zarude",
+      "ko": "자루도",
+      "zh-Hans": "萨戮德",
+      "zh-Hant": "薩戮德"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0893",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0894",
+    "no": "0894",
+    "form": null,
+    "names": {
+      "ja": "レジエレキ",
+      "en": "Regieleki",
+      "ko": "레지에레키",
+      "zh-Hans": "雷吉艾勒奇",
+      "zh-Hant": "雷吉艾勒奇"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0894",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0895",
+    "no": "0895",
+    "form": null,
+    "names": {
+      "ja": "レジドラゴ",
+      "en": "Regidrago",
+      "ko": "레지드래고",
+      "zh-Hans": "雷吉铎拉戈",
+      "zh-Hant": "雷吉鐸拉戈"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0895",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0896",
+    "no": "0896",
+    "form": null,
+    "names": {
+      "ja": "ブリザポス",
+      "en": "Glastrier",
+      "ko": "블리자포스",
+      "zh-Hans": "雪暴马",
+      "zh-Hant": "雪暴馬"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0896",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0897",
+    "no": "0897",
+    "form": null,
+    "names": {
+      "ja": "レイスポス",
+      "en": "Spectrier",
+      "ko": "레이스포스",
+      "zh-Hans": "灵幽马",
+      "zh-Hant": "靈幽馬"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0897",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0898",
+    "no": "0898",
+    "form": null,
+    "names": {
+      "ja": "バドレックス",
+      "en": "Calyrex",
+      "ko": "버드렉스",
+      "zh-Hans": "蕾冠王",
+      "zh-Hant": "蕾冠王"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0898",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0899",
+    "no": "0899",
+    "form": null,
+    "names": {
+      "ja": "アヤシシ",
+      "en": "Wyrdeer",
+      "ko": "신비록",
+      "zh-Hans": "诡角鹿",
+      "zh-Hant": "詭角鹿"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0899",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0900",
+    "no": "0900",
+    "form": null,
+    "names": {
+      "ja": "バサギリ",
+      "en": "Kleavor",
+      "ko": "사마자르",
+      "zh-Hans": "劈斧螳螂",
+      "zh-Hant": "劈斧螳螂"
+    },
+    "types": [
+      {
+        "ja": "むし",
+        "en": "Bug"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0900",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0901",
+    "no": "0901",
+    "form": null,
+    "names": {
+      "ja": "ガチグマ",
+      "en": "Ursaluna",
+      "ko": "다투곰",
+      "zh-Hans": "月月熊",
+      "zh-Hant": "月月熊"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0901",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0902",
+    "no": "0902",
+    "form": null,
+    "names": {
+      "ja": "イダイトウ",
+      "en": "Basculegion",
+      "ko": "대쓰여너",
+      "zh-Hans": "幽尾玄鱼",
+      "zh-Hant": "幽尾玄魚"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0902",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0903",
+    "no": "0903",
+    "form": null,
+    "names": {
+      "ja": "オオニューラ",
+      "en": "Sneasler",
+      "ko": "포푸니크",
+      "zh-Hans": "大狃拉",
+      "zh-Hant": "大狃拉"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0903",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0904",
+    "no": "0904",
+    "form": null,
+    "names": {
+      "ja": "ハリーマン",
+      "en": "Overqwil",
+      "ko": "장침바루",
+      "zh-Hans": "万针鱼",
+      "zh-Hant": "萬針魚"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0904",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0905",
+    "no": "0905",
+    "form": null,
+    "names": {
+      "ja": "ラブトロス",
+      "en": "Enamorus",
+      "ko": "러브로스",
+      "zh-Hans": "眷恋云",
+      "zh-Hant": "眷戀雲"
+    },
+    "types": [],
+    "generation": 8,
+    "evolution": {
+      "family_id": "0905",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0906",
+    "no": "0906",
+    "form": null,
+    "names": {
+      "ja": "ニャオハ",
+      "en": "Sprigatito",
+      "ko": "나오하",
+      "zh-Hans": "新叶喵",
+      "zh-Hant": "新葉喵"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0906",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0907",
+    "no": "0907",
+    "form": null,
+    "names": {
+      "ja": "ニャローテ",
+      "en": "Floragato",
+      "ko": "나로테",
+      "zh-Hans": "蒂蕾喵",
+      "zh-Hant": "蒂蕾喵"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0907",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0908",
+    "no": "0908",
+    "form": null,
+    "names": {
+      "ja": "マスカーニャ",
+      "en": "Meowscarada",
+      "ko": "마스카나",
+      "zh-Hans": "魔幻假面喵",
+      "zh-Hant": "魔幻假面喵"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0908",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0909",
+    "no": "0909",
+    "form": null,
+    "names": {
+      "ja": "ホゲータ",
+      "en": "Fuecoco",
+      "ko": "뜨아거",
+      "zh-Hans": "呆火鳄",
+      "zh-Hant": "呆火鱷"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0909",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0910",
+    "no": "0910",
+    "form": null,
+    "names": {
+      "ja": "アチゲータ",
+      "en": "Crocalor",
+      "ko": "악뜨거",
+      "zh-Hans": "炙烫鳄",
+      "zh-Hant": "炙燙鱷"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0910",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0911",
+    "no": "0911",
+    "form": null,
+    "names": {
+      "ja": "ラウドボーン",
+      "en": "Skeledirge",
+      "ko": "라우드본",
+      "zh-Hans": "骨纹巨声鳄",
+      "zh-Hant": "骨紋巨聲鱷"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0911",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0912",
+    "no": "0912",
+    "form": null,
+    "names": {
+      "ja": "クワッス",
+      "en": "Quaxly",
+      "ko": "꾸왁스",
+      "zh-Hans": "润水鸭",
+      "zh-Hant": "潤水鴨"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0912",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0913",
+    "no": "0913",
+    "form": null,
+    "names": {
+      "ja": "ウェルカモ",
+      "en": "Quaxwell",
+      "ko": "아꾸왁",
+      "zh-Hans": "涌跃鸭",
+      "zh-Hant": "湧躍鴨"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0913",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0914",
+    "no": "0914",
+    "form": null,
+    "names": {
+      "ja": "ウェーニバル",
+      "en": "Quaquaval",
+      "ko": "웨이니발",
+      "zh-Hans": "狂欢浪舞鸭",
+      "zh-Hant": "狂歡浪舞鴨"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0914",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0915",
+    "no": "0915",
+    "form": null,
+    "names": {
+      "ja": "グルトン",
+      "en": "Lechonk",
+      "ko": "맛보돈",
+      "zh-Hans": "爱吃豚",
+      "zh-Hant": "愛吃豚"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0915",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0916",
+    "no": "0916",
+    "form": null,
+    "names": {
+      "ja": "パフュートン",
+      "en": "Oinkologne",
+      "ko": "퍼퓨돈",
+      "zh-Hans": "飘香豚",
+      "zh-Hant": "飄香豚"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0916",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0917",
+    "no": "0917",
+    "form": null,
+    "names": {
+      "ja": "タマンチュラ",
+      "en": "Tarountula",
+      "ko": "타랜툴라",
+      "zh-Hans": "团珠蛛",
+      "zh-Hant": "團珠蛛"
+    },
+    "types": [
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0917",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0918",
+    "no": "0918",
+    "form": null,
+    "names": {
+      "ja": "ワナイダー",
+      "en": "Spidops",
+      "ko": "트래피더",
+      "zh-Hans": "操陷蛛",
+      "zh-Hant": "操陷蛛"
+    },
+    "types": [
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0918",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0919",
+    "no": "0919",
+    "form": null,
+    "names": {
+      "ja": "マメバッタ",
+      "en": "Nymble",
+      "ko": "콩알뚜기",
+      "zh-Hans": "豆蟋蟀",
+      "zh-Hant": "豆蟋蟀"
+    },
+    "types": [
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0919",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0920",
+    "no": "0920",
+    "form": null,
+    "names": {
+      "ja": "エクスレッグ",
+      "en": "Lokix",
+      "ko": "엑스레그",
+      "zh-Hans": "烈腿蝗",
+      "zh-Hant": "烈腿蝗"
+    },
+    "types": [
+      {
+        "ja": "むし",
+        "en": "Bug"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0920",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0921",
+    "no": "0921",
+    "form": null,
+    "names": {
+      "ja": "パモ",
+      "en": "Pawmi",
+      "ko": "빠모",
+      "zh-Hans": "布拨",
+      "zh-Hant": "布撥"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0921",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0922",
+    "no": "0922",
+    "form": null,
+    "names": {
+      "ja": "パモット",
+      "en": "Pawmo",
+      "ko": "빠모트",
+      "zh-Hans": "布土拨",
+      "zh-Hant": "布土撥"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0922",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0923",
+    "no": "0923",
+    "form": null,
+    "names": {
+      "ja": "パーモット",
+      "en": "Pawmot",
+      "ko": "빠르모트",
+      "zh-Hans": "巴布土拨",
+      "zh-Hant": "巴布土撥"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0923",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0924",
+    "no": "0924",
+    "form": null,
+    "names": {
+      "ja": "ワッカネズミ",
+      "en": "Tandemaus",
+      "ko": "두리쥐",
+      "zh-Hans": "一对鼠",
+      "zh-Hant": "一對鼠"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0924",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0925",
+    "no": "0925",
+    "form": null,
+    "names": {
+      "ja": "イッカネズミ",
+      "en": "Maushold",
+      "ko": "파밀리쥐",
+      "zh-Hans": "一家鼠",
+      "zh-Hant": "一家鼠"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0925",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0926",
+    "no": "0926",
+    "form": null,
+    "names": {
+      "ja": "パピモッチ",
+      "en": "Fidough",
+      "ko": "쫀도기",
+      "zh-Hans": "狗仔包",
+      "zh-Hant": "狗仔包"
+    },
+    "types": [
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0926",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0927",
+    "no": "0927",
+    "form": null,
+    "names": {
+      "ja": "バウッツェル",
+      "en": "Dachsbun",
+      "ko": "바우첼",
+      "zh-Hans": "麻花犬",
+      "zh-Hant": "麻花犬"
+    },
+    "types": [
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0927",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0928",
+    "no": "0928",
+    "form": null,
+    "names": {
+      "ja": "ミニーブ",
+      "en": "Smoliv",
+      "ko": "미니브",
+      "zh-Hans": "迷你芙",
+      "zh-Hant": "迷你芙"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0928",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0929",
+    "no": "0929",
+    "form": null,
+    "names": {
+      "ja": "オリーニョ",
+      "en": "Dolliv",
+      "ko": "올리뇨",
+      "zh-Hans": "奥利纽",
+      "zh-Hant": "奧利紐"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0929",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0930",
+    "no": "0930",
+    "form": null,
+    "names": {
+      "ja": "オリーヴァ",
+      "en": "Arboliva",
+      "ko": "올리르바",
+      "zh-Hans": "奥利瓦",
+      "zh-Hant": "奧利瓦"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0930",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0931",
+    "no": "0931",
+    "form": null,
+    "names": {
+      "ja": "イキリンコ",
+      "en": "Squawkabilly",
+      "ko": "시비꼬",
+      "zh-Hans": "怒鹦哥",
+      "zh-Hant": "怒鸚哥"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0931",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0932",
+    "no": "0932",
+    "form": null,
+    "names": {
+      "ja": "コジオ",
+      "en": "Nacli",
+      "ko": "베베솔트",
+      "zh-Hans": "盐石宝",
+      "zh-Hant": "鹽石寶"
+    },
+    "types": [
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0932",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0933",
+    "no": "0933",
+    "form": null,
+    "names": {
+      "ja": "ジオヅム",
+      "en": "Naclstack",
+      "ko": "스태솔트",
+      "zh-Hans": "盐石垒",
+      "zh-Hant": "鹽石壘"
+    },
+    "types": [
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0933",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0934",
+    "no": "0934",
+    "form": null,
+    "names": {
+      "ja": "キョジオーン",
+      "en": "Garganacl",
+      "ko": "콜로솔트",
+      "zh-Hans": "盐石巨灵",
+      "zh-Hant": "鹽石巨靈"
+    },
+    "types": [
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0934",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0935",
+    "no": "0935",
+    "form": null,
+    "names": {
+      "ja": "カルボウ",
+      "en": "Charcadet",
+      "ko": "카르본",
+      "zh-Hans": "炭小侍",
+      "zh-Hant": "炭小侍"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0935",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0936",
+    "no": "0936",
+    "form": null,
+    "names": {
+      "ja": "グレンアルマ",
+      "en": "Armarouge",
+      "ko": "카디나르마",
+      "zh-Hans": "红莲铠骑",
+      "zh-Hant": "紅蓮鎧騎"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0936",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0937",
+    "no": "0937",
+    "form": null,
+    "names": {
+      "ja": "ソウブレイズ",
+      "en": "Ceruledge",
+      "ko": "파라블레이즈",
+      "zh-Hans": "苍炎刃鬼",
+      "zh-Hant": "蒼炎刃鬼"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0937",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0938",
+    "no": "0938",
+    "form": null,
+    "names": {
+      "ja": "ズピカ",
+      "en": "Tadbulb",
+      "ko": "빈나두",
+      "zh-Hans": "光蚪仔",
+      "zh-Hant": "光蚪仔"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0938",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0939",
+    "no": "0939",
+    "form": null,
+    "names": {
+      "ja": "ハラバリー",
+      "en": "Bellibolt",
+      "ko": "찌리배리",
+      "zh-Hans": "电肚蛙",
+      "zh-Hant": "電肚蛙"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0939",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0940",
+    "no": "0940",
+    "form": null,
+    "names": {
+      "ja": "カイデン",
+      "en": "Wattrel",
+      "ko": "찌리비",
+      "zh-Hans": "电海燕",
+      "zh-Hant": "電海燕"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0940",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0941",
+    "no": "0941",
+    "form": null,
+    "names": {
+      "ja": "タイカイデン",
+      "en": "Kilowattrel",
+      "ko": "찌리비크",
+      "zh-Hans": "大电海燕",
+      "zh-Hant": "大電海燕"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0941",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0942",
+    "no": "0942",
+    "form": null,
+    "names": {
+      "ja": "オラチフ",
+      "en": "Maschiff",
+      "ko": "오라티프",
+      "zh-Hans": "偶叫獒",
+      "zh-Hant": "偶叫獒"
+    },
+    "types": [
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0942",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0943",
+    "no": "0943",
+    "form": null,
+    "names": {
+      "ja": "マフィティフ",
+      "en": "Mabosstiff",
+      "ko": "마피티프",
+      "zh-Hans": "獒教父",
+      "zh-Hant": "獒教父"
+    },
+    "types": [
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0943",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0944",
+    "no": "0944",
+    "form": null,
+    "names": {
+      "ja": "シルシュルー",
+      "en": "Shroodle",
+      "ko": "땃쭈르",
+      "zh-Hans": "滋汁鼹",
+      "zh-Hant": "滋汁鼴"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0944",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0945",
+    "no": "0945",
+    "form": null,
+    "names": {
+      "ja": "タギングル",
+      "en": "Grafaiai",
+      "ko": "태깅구르",
+      "zh-Hans": "涂标客",
+      "zh-Hant": "塗標客"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0945",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0946",
+    "no": "0946",
+    "form": null,
+    "names": {
+      "ja": "アノクサ",
+      "en": "Bramblin",
+      "ko": "그푸리",
+      "zh-Hans": "纳噬草",
+      "zh-Hant": "納噬草"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0946",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0947",
+    "no": "0947",
+    "form": null,
+    "names": {
+      "ja": "アノホラグサ",
+      "en": "Brambleghast",
+      "ko": "공푸리",
+      "zh-Hans": "怖纳噬草",
+      "zh-Hant": "怖納噬草"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0947",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0948",
+    "no": "0948",
+    "form": null,
+    "names": {
+      "ja": "ノノクラゲ",
+      "en": "Toedscool",
+      "ko": "들눈해",
+      "zh-Hans": "原野水母",
+      "zh-Hant": "原野水母"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0948",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0949",
+    "no": "0949",
+    "form": null,
+    "names": {
+      "ja": "リククラゲ",
+      "en": "Toedscruel",
+      "ko": "육파리",
+      "zh-Hans": "陆地水母",
+      "zh-Hant": "陸地水母"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0949",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0950",
+    "no": "0950",
+    "form": null,
+    "names": {
+      "ja": "ガケガニ",
+      "en": "Klawf",
+      "ko": "절벼게",
+      "zh-Hans": "毛崖蟹",
+      "zh-Hant": "毛崖蟹"
+    },
+    "types": [
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0950",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0951",
+    "no": "0951",
+    "form": null,
+    "names": {
+      "ja": "カプサイジ",
+      "en": "Capsakid",
+      "ko": "캡싸이",
+      "zh-Hans": "热辣娃",
+      "zh-Hant": "熱辣娃"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0951",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0952",
+    "no": "0952",
+    "form": null,
+    "names": {
+      "ja": "スコヴィラン",
+      "en": "Scovillain",
+      "ko": "스코빌런",
+      "zh-Hans": "狠辣椒",
+      "zh-Hant": "狠辣椒"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0952",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0953",
+    "no": "0953",
+    "form": null,
+    "names": {
+      "ja": "シガロコ",
+      "en": "Rellor",
+      "ko": "구르데",
+      "zh-Hans": "虫滚泥",
+      "zh-Hant": "蟲滾泥"
+    },
+    "types": [
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0953",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0954",
+    "no": "0954",
+    "form": null,
+    "names": {
+      "ja": "ベラカス",
+      "en": "Rabsca",
+      "ko": "베라카스",
+      "zh-Hans": "虫甲圣",
+      "zh-Hant": "蟲甲聖"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0954",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0955",
+    "no": "0955",
+    "form": null,
+    "names": {
+      "ja": "ヒラヒナ",
+      "en": "Flittle",
+      "ko": "하느라기",
+      "zh-Hans": "飘飘雏",
+      "zh-Hant": "飄飄雛"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0955",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0956",
+    "no": "0956",
+    "form": null,
+    "names": {
+      "ja": "クエスパトラ",
+      "en": "Espathra",
+      "ko": "클레스퍼트라",
+      "zh-Hans": "超能艳鸵",
+      "zh-Hant": "超能豔鴕"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0956",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0957",
+    "no": "0957",
+    "form": null,
+    "names": {
+      "ja": "カヌチャン",
+      "en": "Tinkatink",
+      "ko": "어리짱",
+      "zh-Hans": "小锻匠",
+      "zh-Hant": "小鍛匠"
+    },
+    "types": [
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0957",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0958",
+    "no": "0958",
+    "form": null,
+    "names": {
+      "ja": "ナカヌチャン",
+      "en": "Tinkatuff",
+      "ko": "벼리짱",
+      "zh-Hans": "巧锻匠",
+      "zh-Hant": "巧鍛匠"
+    },
+    "types": [
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0958",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0959",
+    "no": "0959",
+    "form": null,
+    "names": {
+      "ja": "デカヌチャン",
+      "en": "Tinkaton",
+      "ko": "두드리짱",
+      "zh-Hans": "巨锻匠",
+      "zh-Hant": "巨鍛匠"
+    },
+    "types": [
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0959",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0960",
+    "no": "0960",
+    "form": null,
+    "names": {
+      "ja": "ウミディグダ",
+      "en": "Wiglett",
+      "ko": "바다그다",
+      "zh-Hans": "海地鼠",
+      "zh-Hant": "海地鼠"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0960",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0961",
+    "no": "0961",
+    "form": null,
+    "names": {
+      "ja": "ウミトリオ",
+      "en": "Wugtrio",
+      "ko": "바닥트리오",
+      "zh-Hans": "三海地鼠",
+      "zh-Hant": "三海地鼠"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0961",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0962",
+    "no": "0962",
+    "form": null,
+    "names": {
+      "ja": "オトシドリ",
+      "en": "Bombirdier",
+      "ko": "떨구새",
+      "zh-Hans": "下石鸟",
+      "zh-Hant": "下石鳥"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0962",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0963",
+    "no": "0963",
+    "form": null,
+    "names": {
+      "ja": "ナミイルカ",
+      "en": "Finizen",
+      "ko": "맨돌핀",
+      "zh-Hans": "波普海豚",
+      "zh-Hant": "波普海豚"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0963",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0964",
+    "no": "0964",
+    "form": null,
+    "names": {
+      "ja": "イルカマン",
+      "en": "Palafin",
+      "ko": "돌핀맨",
+      "zh-Hans": "海豚侠",
+      "zh-Hant": "海豚俠"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0964",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0965",
+    "no": "0965",
+    "form": null,
+    "names": {
+      "ja": "ブロロン",
+      "en": "Varoom",
+      "ko": "부르롱",
+      "zh-Hans": "噗隆隆",
+      "zh-Hant": "噗隆隆"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0965",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0966",
+    "no": "0966",
+    "form": null,
+    "names": {
+      "ja": "ブロロローム",
+      "en": "Revavroom",
+      "ko": "부르르룸",
+      "zh-Hans": "普隆隆姆",
+      "zh-Hant": "普隆隆姆"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0966",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0967",
+    "no": "0967",
+    "form": null,
+    "names": {
+      "ja": "モトトカゲ",
+      "en": "Cyclizar",
+      "ko": "모토마",
+      "zh-Hans": "摩托蜥",
+      "zh-Hant": "摩托蜥"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0967",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0968",
+    "no": "0968",
+    "form": null,
+    "names": {
+      "ja": "ミミズズ",
+      "en": "Orthworm",
+      "ko": "꿈트렁",
+      "zh-Hans": "拖拖蚓",
+      "zh-Hant": "拖拖蚓"
+    },
+    "types": [
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0968",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0969",
+    "no": "0969",
+    "form": null,
+    "names": {
+      "ja": "キラーメ",
+      "en": "Glimmet",
+      "ko": "초롱순",
+      "zh-Hans": "晶光芽",
+      "zh-Hant": "晶光芽"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0969",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0970",
+    "no": "0970",
+    "form": null,
+    "names": {
+      "ja": "キラフロル",
+      "en": "Glimmora",
+      "ko": "킬라플로르",
+      "zh-Hans": "晶光花",
+      "zh-Hant": "晶光花"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0970",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0971",
+    "no": "0971",
+    "form": null,
+    "names": {
+      "ja": "ボチ",
+      "en": "Greavard",
+      "ko": "망망이",
+      "zh-Hans": "墓仔狗",
+      "zh-Hant": "墓仔狗"
+    },
+    "types": [
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0971",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0972",
+    "no": "0972",
+    "form": null,
+    "names": {
+      "ja": "ハカドッグ",
+      "en": "Houndstone",
+      "ko": "묘두기",
+      "zh-Hans": "墓扬犬",
+      "zh-Hant": "墓揚犬"
+    },
+    "types": [
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0972",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0973",
+    "no": "0973",
+    "form": null,
+    "names": {
+      "ja": "カラミンゴ",
+      "en": "Flamigo",
+      "ko": "꼬이밍고",
+      "zh-Hans": "缠红鹤",
+      "zh-Hant": "纏紅鶴"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      },
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0973",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0974",
+    "no": "0974",
+    "form": null,
+    "names": {
+      "ja": "アルクジラ",
+      "en": "Cetoddle",
+      "ko": "터벅고래",
+      "zh-Hans": "走鲸",
+      "zh-Hant": "走鯨"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0974",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0975",
+    "no": "0975",
+    "form": null,
+    "names": {
+      "ja": "ハルクジラ",
+      "en": "Cetitan",
+      "ko": "우락고래",
+      "zh-Hans": "浩大鲸",
+      "zh-Hant": "浩大鯨"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0975",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0976",
+    "no": "0976",
+    "form": null,
+    "names": {
+      "ja": "ミガルーサ",
+      "en": "Veluza",
+      "ko": "가비루사",
+      "zh-Hans": "轻身鳕",
+      "zh-Hant": "輕身鱈"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0976",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0977",
+    "no": "0977",
+    "form": null,
+    "names": {
+      "ja": "ヘイラッシャ",
+      "en": "Dondozo",
+      "ko": "어써러셔",
+      "zh-Hans": "吃吼霸",
+      "zh-Hant": "吃吼霸"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0977",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0978",
+    "no": "0978",
+    "form": null,
+    "names": {
+      "ja": "シャリタツ",
+      "en": "Tatsugiri",
+      "ko": "싸리용",
+      "zh-Hans": "米立龙",
+      "zh-Hant": "米立龍"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0978",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0979",
+    "no": "0979",
+    "form": null,
+    "names": {
+      "ja": "コノヨザル",
+      "en": "Annihilape",
+      "ko": "저승갓숭",
+      "zh-Hans": "弃世猴",
+      "zh-Hant": "棄世猴"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0979",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0980",
+    "no": "0980",
+    "form": null,
+    "names": {
+      "ja": "ドオー",
+      "en": "Clodsire",
+      "ko": "토오",
+      "zh-Hans": "土王",
+      "zh-Hant": "土王"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0980",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0981",
+    "no": "0981",
+    "form": null,
+    "names": {
+      "ja": "リキキリン",
+      "en": "Farigiraf",
+      "ko": "키키링",
+      "zh-Hans": "奇麒麟",
+      "zh-Hant": "奇麒麟"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      },
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0981",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0982",
+    "no": "0982",
+    "form": null,
+    "names": {
+      "ja": "ノココッチ",
+      "en": "Dudunsparce",
+      "ko": "노고고치",
+      "zh-Hans": "土龙节节",
+      "zh-Hant": "土龍節節"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0982",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0983",
+    "no": "0983",
+    "form": null,
+    "names": {
+      "ja": "ドドゲザン",
+      "en": "Kingambit",
+      "ko": "대도각참",
+      "zh-Hans": "仆刀将军",
+      "zh-Hant": "仆斬將軍"
+    },
+    "types": [
+      {
+        "ja": "あく",
+        "en": "Dark"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0983",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0984",
+    "no": "0984",
+    "form": null,
+    "names": {
+      "ja": "イダイナキバ",
+      "en": "Great Tusk",
+      "ko": "위대한엄니",
+      "zh-Hans": "雄伟牙",
+      "zh-Hant": "雄偉牙"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      },
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0984",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0985",
+    "no": "0985",
+    "form": null,
+    "names": {
+      "ja": "サケブシッポ",
+      "en": "Scream Tail",
+      "ko": "우렁찬꼬리",
+      "zh-Hans": "吼叫尾",
+      "zh-Hant": "吼叫尾"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0985",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0986",
+    "no": "0986",
+    "form": null,
+    "names": {
+      "ja": "アラブルタケ",
+      "en": "Brute Bonnet",
+      "ko": "사나운버섯",
+      "zh-Hans": "猛恶菇",
+      "zh-Hant": "猛惡菇"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0986",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0987",
+    "no": "0987",
+    "form": null,
+    "names": {
+      "ja": "ハバタクカミ",
+      "en": "Flutter Mane",
+      "ko": "날개치는머리",
+      "zh-Hans": "振翼发",
+      "zh-Hant": "振翼髮"
+    },
+    "types": [
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0987",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0988",
+    "no": "0988",
+    "form": null,
+    "names": {
+      "ja": "チヲハウハネ",
+      "en": "Slither Wing",
+      "ko": "땅을기는날개",
+      "zh-Hans": "爬地翅",
+      "zh-Hant": "爬地翅"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      },
+      {
+        "ja": "むし",
+        "en": "Bug"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0988",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0989",
+    "no": "0989",
+    "form": null,
+    "names": {
+      "ja": "スナノケガワ",
+      "en": "Sandy Shocks",
+      "ko": "모래털가죽",
+      "zh-Hans": "沙铁皮",
+      "zh-Hant": "沙鐵皮"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0989",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0990",
+    "no": "0990",
+    "form": null,
+    "names": {
+      "ja": "テツノワダチ",
+      "en": "Iron Treads",
+      "ko": "무쇠바퀴",
+      "zh-Hans": "铁辙迹",
+      "zh-Hant": "鐵轍跡"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0990",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0991",
+    "no": "0991",
+    "form": null,
+    "names": {
+      "ja": "テツノツツミ",
+      "en": "Iron Bundle",
+      "ko": "무쇠보따리",
+      "zh-Hans": "铁包袱",
+      "zh-Hant": "鐵包袱"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0991",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0992",
+    "no": "0992",
+    "form": null,
+    "names": {
+      "ja": "テツノカイナ",
+      "en": "Iron Hands",
+      "ko": "무쇠손",
+      "zh-Hans": "铁臂膀",
+      "zh-Hant": "鐵臂膀"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0992",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0993",
+    "no": "0993",
+    "form": null,
+    "names": {
+      "ja": "テツノコウベ",
+      "en": "Iron Jugulis",
+      "ko": "무쇠머리",
+      "zh-Hans": "铁脖颈",
+      "zh-Hant": "鐵脖頸"
+    },
+    "types": [
+      {
+        "ja": "ひこう",
+        "en": "Flying"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0993",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0994",
+    "no": "0994",
+    "form": null,
+    "names": {
+      "ja": "テツノドクガ",
+      "en": "Iron Moth",
+      "ko": "무쇠독나방",
+      "zh-Hans": "铁毒蛾",
+      "zh-Hant": "鐵毒蛾"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0994",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0995",
+    "no": "0995",
+    "form": null,
+    "names": {
+      "ja": "テツノイバラ",
+      "en": "Iron Thorns",
+      "ko": "무쇠가시",
+      "zh-Hans": "铁荆棘",
+      "zh-Hant": "鐵荊棘"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0995",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0996",
+    "no": "0996",
+    "form": null,
+    "names": {
+      "ja": "セビエ",
+      "en": "Frigibax",
+      "ko": "드니차",
+      "zh-Hans": "凉脊龙",
+      "zh-Hant": "涼脊龍"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0996",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0997",
+    "no": "0997",
+    "form": null,
+    "names": {
+      "ja": "セゴール",
+      "en": "Arctibax",
+      "ko": "드니꽁",
+      "zh-Hans": "冻脊龙",
+      "zh-Hant": "凍脊龍"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0997",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0998",
+    "no": "0998",
+    "form": null,
+    "names": {
+      "ja": "セグレイブ",
+      "en": "Baxcalibur",
+      "ko": "드닐레이브",
+      "zh-Hans": "戟脊龙",
+      "zh-Hant": "戟脊龍"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0998",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "0999",
+    "no": "0999",
+    "form": null,
+    "names": {
+      "ja": "コレクレー",
+      "en": "Gimmighoul",
+      "ko": "모으령",
+      "zh-Hans": "索财灵",
+      "zh-Hant": "索財靈"
+    },
+    "types": [
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "0999",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1000",
+    "no": "1000",
+    "form": null,
+    "names": {
+      "ja": "サーフゴー",
+      "en": "Gholdengo",
+      "ko": "타부자고",
+      "zh-Hans": "赛富豪",
+      "zh-Hant": "賽富豪"
+    },
+    "types": [
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1000",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1001",
+    "no": "1001",
+    "form": null,
+    "names": {
+      "ja": "チオンジェン",
+      "en": "Wo-Chien",
+      "ko": "총지엔",
+      "zh-Hans": "古简蜗",
+      "zh-Hant": "古簡蝸"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1001",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1002",
+    "no": "1002",
+    "form": null,
+    "names": {
+      "ja": "パオジアン",
+      "en": "Chien-Pao",
+      "ko": "파오젠",
+      "zh-Hans": "古剑豹",
+      "zh-Hant": "古劍豹"
+    },
+    "types": [
+      {
+        "ja": "こおり",
+        "en": "Ice"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1002",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1003",
+    "no": "1003",
+    "form": null,
+    "names": {
+      "ja": "ディンルー",
+      "en": "Ting-Lu",
+      "ko": "딩루",
+      "zh-Hans": "古鼎鹿",
+      "zh-Hant": "古鼎鹿"
+    },
+    "types": [
+      {
+        "ja": "じめん",
+        "en": "Ground"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1003",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1004",
+    "no": "1004",
+    "form": null,
+    "names": {
+      "ja": "イーユイ",
+      "en": "Chi-Yu",
+      "ko": "위유이",
+      "zh-Hans": "古玉鱼",
+      "zh-Hant": "古玉魚"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1004",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1005",
+    "no": "1005",
+    "form": null,
+    "names": {
+      "ja": "トドロクツキ",
+      "en": "Roaring Moon",
+      "ko": "고동치는달",
+      "zh-Hans": "轰鸣月",
+      "zh-Hant": "轟鳴月"
+    },
+    "types": [
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      },
+      {
+        "ja": "あく",
+        "en": "Dark"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1005",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1006",
+    "no": "1006",
+    "form": null,
+    "names": {
+      "ja": "テツノブジン",
+      "en": "Iron Valiant",
+      "ko": "무쇠무인",
+      "zh-Hans": "铁武者",
+      "zh-Hant": "鐵武者"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1006",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1007",
+    "no": "1007",
+    "form": null,
+    "names": {
+      "ja": "コライドン",
+      "en": "Koraidon",
+      "ko": "코라이돈",
+      "zh-Hans": "故勒顿",
+      "zh-Hant": "故勒頓"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1007",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1008",
+    "no": "1008",
+    "form": null,
+    "names": {
+      "ja": "ミライドン",
+      "en": "Miraidon",
+      "ko": "미라이돈",
+      "zh-Hans": "密勒顿",
+      "zh-Hant": "密勒頓"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1008",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1009",
+    "no": "1009",
+    "form": null,
+    "names": {
+      "ja": "ウネルミナモ",
+      "en": "Walking Wake",
+      "ko": "굽이치는물결",
+      "zh-Hans": "波荡水",
+      "zh-Hant": "波盪水"
+    },
+    "types": [
+      {
+        "ja": "みず",
+        "en": "Water"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1009",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1010",
+    "no": "1010",
+    "form": null,
+    "names": {
+      "ja": "テツノイサハ",
+      "en": "Iron Leaves",
+      "ko": "무쇠잎새",
+      "zh-Hans": "铁斑叶",
+      "zh-Hant": "鐵斑葉"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1010",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1011",
+    "no": "1011",
+    "form": null,
+    "names": {
+      "ja": "カミッチュ",
+      "en": "Dipplin",
+      "ko": "과미르",
+      "zh-Hans": "裹蜜虫",
+      "zh-Hant": "裹蜜蟲"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1011",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1012",
+    "no": "1012",
+    "form": null,
+    "names": {
+      "ja": "チャデス",
+      "en": "Poltchageist",
+      "ko": "차데스",
+      "zh-Hans": "斯魔茶",
+      "zh-Hant": "斯魔茶"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1012",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1013",
+    "no": "1013",
+    "form": null,
+    "names": {
+      "ja": "ヤバソチャ",
+      "en": "Sinistcha",
+      "ko": "그우린차",
+      "zh-Hans": "来悲粗茶",
+      "zh-Hant": "來悲粗茶"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1013",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1014",
+    "no": "1014",
+    "form": null,
+    "names": {
+      "ja": "イイネイヌ",
+      "en": "Okidogi",
+      "ko": "조타구",
+      "zh-Hans": "够赞狗",
+      "zh-Hant": "夠讚狗"
+    },
+    "types": [
+      {
+        "ja": "かくとう",
+        "en": "Fighting"
+      },
+      {
+        "ja": "どく",
+        "en": "Poison"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1014",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1015",
+    "no": "1015",
+    "form": null,
+    "names": {
+      "ja": "マシマシラ",
+      "en": "Munkidori",
+      "ko": "이야후",
+      "zh-Hans": "愿增猿",
+      "zh-Hant": "願增猿"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1015",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1016",
+    "no": "1016",
+    "form": null,
+    "names": {
+      "ja": "キチキギス",
+      "en": "Fezandipiti",
+      "ko": "기로치",
+      "zh-Hans": "吉雉鸡",
+      "zh-Hant": "吉雉雞"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "フェアリー",
+        "en": "Fairy"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1016",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1017",
+    "no": "1017",
+    "form": null,
+    "names": {
+      "ja": "オーガポン",
+      "en": "Ogerpon",
+      "ko": "오거폰",
+      "zh-Hans": "厄诡椪",
+      "zh-Hant": "厄鬼椪"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1017",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1018",
+    "no": "1018",
+    "form": null,
+    "names": {
+      "ja": "ブリジュラス",
+      "en": "Archaludon",
+      "ko": "브리두라스",
+      "zh-Hans": "铝钢桥龙",
+      "zh-Hant": "鋁鋼橋龍"
+    },
+    "types": [
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1018",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1019",
+    "no": "1019",
+    "form": null,
+    "names": {
+      "ja": "カミツオロチ",
+      "en": "Hydrapple",
+      "ko": "과미드라",
+      "zh-Hans": "蜜集大蛇",
+      "zh-Hant": "蜜集大蛇"
+    },
+    "types": [
+      {
+        "ja": "くさ",
+        "en": "Grass"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1019",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1020",
+    "no": "1020",
+    "form": null,
+    "names": {
+      "ja": "ウガツホムラ",
+      "en": "Gouging Fire",
+      "ko": "꿰뚫는화염",
+      "zh-Hans": "破空焰",
+      "zh-Hant": "破空焰"
+    },
+    "types": [
+      {
+        "ja": "ほのお",
+        "en": "Fire"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1020",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1021",
+    "no": "1021",
+    "form": null,
+    "names": {
+      "ja": "タケルライコ",
+      "en": "Raging Bolt",
+      "ko": "날뛰는우레",
+      "zh-Hans": "猛雷鼓",
+      "zh-Hant": "猛雷鼓"
+    },
+    "types": [
+      {
+        "ja": "でんき",
+        "en": "Electric"
+      },
+      {
+        "ja": "ドラゴン",
+        "en": "Dragon"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1021",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1022",
+    "no": "1022",
+    "form": null,
+    "names": {
+      "ja": "テツノイワオ",
+      "en": "Iron Boulder",
+      "ko": "무쇠암석",
+      "zh-Hans": "铁磐岩",
+      "zh-Hant": "鐵磐岩"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      },
+      {
+        "ja": "いわ",
+        "en": "Rock"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1022",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1023",
+    "no": "1023",
+    "form": null,
+    "names": {
+      "ja": "テツノカシラ",
+      "en": "Iron Crown",
+      "ko": "무쇠감투",
+      "zh-Hans": "铁头壳",
+      "zh-Hant": "鐵頭殼"
+    },
+    "types": [
+      {
+        "ja": "エスパー",
+        "en": "Psychic"
+      },
+      {
+        "ja": "はがね",
+        "en": "Steel"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1023",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1024",
+    "no": "1024",
+    "form": null,
+    "names": {
+      "ja": "テラパゴス",
+      "en": "Terapagos",
+      "ko": "테라파고스",
+      "zh-Hans": "太乐巴戈斯",
+      "zh-Hant": "太樂巴戈斯"
+    },
+    "types": [
+      {
+        "ja": "ノーマル",
+        "en": "Normal"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1024",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  },
+  {
+    "id": "1025",
+    "no": "1025",
+    "form": null,
+    "names": {
+      "ja": "モモワロウ",
+      "en": "Pecharunt",
+      "ko": "복숭악동",
+      "zh-Hans": "桃歹郎",
+      "zh-Hant": "桃歹郎"
+    },
+    "types": [
+      {
+        "ja": "どく",
+        "en": "Poison"
+      },
+      {
+        "ja": "ゴースト",
+        "en": "Ghost"
+      }
+    ],
+    "generation": 9,
+    "evolution": {
+      "family_id": "1025",
+      "evolves_from": null,
+      "evolves_to": []
+    },
+    "color": null
+  }
+]

--- a/docs/pokemon_types_bilingual.json
+++ b/docs/pokemon_types_bilingual.json
@@ -1,0 +1,10234 @@
+[
+  {
+    "no": "0906",
+    "name_jpn": "ニャオハ",
+    "name_eng": "Sprigatito",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0907",
+    "name_jpn": "ニャローテ",
+    "name_eng": "Floragato",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0908",
+    "name_jpn": "マスカーニャ",
+    "name_eng": "Meowscarada",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0909",
+    "name_jpn": "ホゲータ",
+    "name_eng": "Fuecoco",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      }
+    ]
+  },
+  {
+    "no": "0910",
+    "name_jpn": "アチゲータ",
+    "name_eng": "Crocalor",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      }
+    ]
+  },
+  {
+    "no": "0911",
+    "name_jpn": "ラウドボーン",
+    "name_eng": "Skeledirge",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      },
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "0912",
+    "name_jpn": "クワッス",
+    "name_eng": "Quaxly",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0913",
+    "name_jpn": "ウェルカモ",
+    "name_eng": "Quaxwell",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0914",
+    "name_jpn": "ウェーニバル",
+    "name_eng": "Quaquaval",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      }
+    ]
+  },
+  {
+    "no": "0915",
+    "name_jpn": "グルトン",
+    "name_eng": "Lechonk",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "0916",
+    "name_jpn": "パフュートン",
+    "name_eng": "Oinkologne",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "0916",
+    "name_jpn": "パフュートン",
+    "name_eng": "Oinkologne",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "0917",
+    "name_jpn": "タマンチュラ",
+    "name_eng": "Tarountula",
+    "types": [
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0918",
+    "name_jpn": "ワナイダー",
+    "name_eng": "Spidops",
+    "types": [
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0919",
+    "name_jpn": "マメバッタ",
+    "name_eng": "Nymble",
+    "types": [
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0920",
+    "name_jpn": "エクスレッグ",
+    "name_eng": "Lokix",
+    "types": [
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0187",
+    "name_jpn": "ハネッコ",
+    "name_eng": "Hoppip",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0188",
+    "name_jpn": "ポポッコ",
+    "name_eng": "Skiploom",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0189",
+    "name_jpn": "ワタッコ",
+    "name_eng": "Jumpluff",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0661",
+    "name_jpn": "ヤヤコマ",
+    "name_eng": "Fletchling",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0662",
+    "name_jpn": "ヒノヤコマ",
+    "name_eng": "Fletchinder",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0663",
+    "name_jpn": "ファイアロー",
+    "name_eng": "Talonflame",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0921",
+    "name_jpn": "パモ",
+    "name_eng": "Pawmi",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      }
+    ]
+  },
+  {
+    "no": "0922",
+    "name_jpn": "パモット",
+    "name_eng": "Pawmo",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      },
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      }
+    ]
+  },
+  {
+    "no": "0923",
+    "name_jpn": "パーモット",
+    "name_eng": "Pawmot",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      },
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      }
+    ]
+  },
+  {
+    "no": "0228",
+    "name_jpn": "デルビル",
+    "name_eng": "Houndour",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0229",
+    "name_jpn": "ヘルガー",
+    "name_eng": "Houndoom",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0734",
+    "name_jpn": "ヤングース",
+    "name_eng": "Yungoos",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "0735",
+    "name_jpn": "デカグース",
+    "name_eng": "Gumshoos",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "0819",
+    "name_jpn": "ホシガリス",
+    "name_eng": "Skwovet",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "0820",
+    "name_jpn": "ヨクバリス",
+    "name_eng": "Greedent",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "0191",
+    "name_jpn": "ヒマナッツ",
+    "name_eng": "Sunkern",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0192",
+    "name_jpn": "キマワリ",
+    "name_eng": "Sunflora",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0401",
+    "name_jpn": "コロボーシ",
+    "name_eng": "Kricketot",
+    "types": [
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0402",
+    "name_jpn": "コロトック",
+    "name_eng": "Kricketune",
+    "types": [
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0664",
+    "name_jpn": "コフキムシ",
+    "name_eng": "Scatterbug",
+    "types": [
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0665",
+    "name_jpn": "コフーライ",
+    "name_eng": "Spewpa",
+    "types": [
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0666",
+    "name_jpn": "ビビヨン",
+    "name_eng": "Vivillon",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0666",
+    "name_jpn": "ビビヨン",
+    "name_eng": "Vivillon",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0666",
+    "name_jpn": "ビビヨン",
+    "name_eng": "Vivillon",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0666",
+    "name_jpn": "ビビヨン",
+    "name_eng": "Vivillon",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0666",
+    "name_jpn": "ビビヨン",
+    "name_eng": "Vivillon",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0666",
+    "name_jpn": "ビビヨン",
+    "name_eng": "Vivillon",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0666",
+    "name_jpn": "ビビヨン",
+    "name_eng": "Vivillon",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0666",
+    "name_jpn": "ビビヨン",
+    "name_eng": "Vivillon",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0666",
+    "name_jpn": "ビビヨン",
+    "name_eng": "Vivillon",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0666",
+    "name_jpn": "ビビヨン",
+    "name_eng": "Vivillon",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0666",
+    "name_jpn": "ビビヨン",
+    "name_eng": "Vivillon",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0666",
+    "name_jpn": "ビビヨン",
+    "name_eng": "Vivillon",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0666",
+    "name_jpn": "ビビヨン",
+    "name_eng": "Vivillon",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0666",
+    "name_jpn": "ビビヨン",
+    "name_eng": "Vivillon",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0666",
+    "name_jpn": "ビビヨン",
+    "name_eng": "Vivillon",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0666",
+    "name_jpn": "ビビヨン",
+    "name_eng": "Vivillon",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0666",
+    "name_jpn": "ビビヨン",
+    "name_eng": "Vivillon",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0666",
+    "name_jpn": "ビビヨン",
+    "name_eng": "Vivillon",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0666",
+    "name_jpn": "ビビヨン",
+    "name_eng": "Vivillon",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0666",
+    "name_jpn": "ビビヨン",
+    "name_eng": "Vivillon",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0415",
+    "name_jpn": "ミツハニー",
+    "name_eng": "Combee",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0416",
+    "name_jpn": "ビークイン",
+    "name_eng": "Vespiquen",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0821",
+    "name_jpn": "ココガラ",
+    "name_eng": "Rookidee",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0822",
+    "name_jpn": "アオガラス",
+    "name_eng": "Corvisquire",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0823",
+    "name_jpn": "アーマーガア",
+    "name_eng": "Corviknight",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "はがね",
+        "eng": "Steel"
+      }
+    ]
+  },
+  {
+    "no": "0440",
+    "name_jpn": "ピンプク",
+    "name_eng": "Happiny",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "0113",
+    "name_jpn": "ラッキー",
+    "name_eng": "Chansey",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "0242",
+    "name_jpn": "ハピナス",
+    "name_eng": "Blissey",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "0298",
+    "name_jpn": "ルリリ",
+    "name_eng": "Azurill",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0183",
+    "name_jpn": "マリル",
+    "name_eng": "Marill",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0184",
+    "name_jpn": "マリルリ",
+    "name_eng": "Azumarill",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0283",
+    "name_jpn": "アメタマ",
+    "name_eng": "Surskit",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0284",
+    "name_jpn": "アメモース",
+    "name_eng": "Masquerain",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0418",
+    "name_jpn": "ブイゼル",
+    "name_eng": "Buizel",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0419",
+    "name_jpn": "フローゼル",
+    "name_eng": "Floatzel",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0194",
+    "name_jpn": "ウパー",
+    "name_eng": "Wooper",
+    "types": [
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      },
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      }
+    ]
+  },
+  {
+    "no": "0980",
+    "name_jpn": "ドオー",
+    "name_eng": "Clodsire",
+    "types": [
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      },
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      }
+    ]
+  },
+  {
+    "no": "0054",
+    "name_jpn": "コダック",
+    "name_eng": "Psyduck",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0055",
+    "name_jpn": "ゴルダック",
+    "name_eng": "Golduck",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0833",
+    "name_jpn": "カムカメ",
+    "name_eng": "Chewtle",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0834",
+    "name_jpn": "カジリガメ",
+    "name_eng": "Drednaw",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0174",
+    "name_jpn": "ププリン",
+    "name_eng": "Igglybuff",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0039",
+    "name_jpn": "プリン",
+    "name_eng": "Jigglypuff",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0040",
+    "name_jpn": "プクリン",
+    "name_eng": "Wigglytuff",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0280",
+    "name_jpn": "ラルトス",
+    "name_eng": "Ralts",
+    "types": [
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      },
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0281",
+    "name_jpn": "キルリア",
+    "name_eng": "Kirlia",
+    "types": [
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      },
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0282",
+    "name_jpn": "サーナイト",
+    "name_eng": "Gardevoir",
+    "types": [
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      },
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0475",
+    "name_jpn": "エルレイド",
+    "name_eng": "Gallade",
+    "types": [
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      },
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0096",
+    "name_jpn": "スリープ",
+    "name_eng": "Drowzee",
+    "types": [
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0097",
+    "name_jpn": "スリーパー",
+    "name_eng": "Hypno",
+    "types": [
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0092",
+    "name_jpn": "ゴース",
+    "name_eng": "Gastly",
+    "types": [
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      },
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "0093",
+    "name_jpn": "ゴースト",
+    "name_eng": "Haunter",
+    "types": [
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      },
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "0094",
+    "name_jpn": "ゲンガー",
+    "name_eng": "Gengar",
+    "types": [
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      },
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "0924",
+    "name_jpn": "ワッカネズミ",
+    "name_eng": "Tandemaus",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "0925",
+    "name_jpn": "イッカネズミ",
+    "name_eng": "Maushold",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "0925",
+    "name_jpn": "イッカネズミ",
+    "name_eng": "Maushold",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "0172",
+    "name_jpn": "ピチュー",
+    "name_eng": "Pichu",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      }
+    ]
+  },
+  {
+    "no": "0025",
+    "name_jpn": "ピカチュウ",
+    "name_eng": "Pikachu",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      }
+    ]
+  },
+  {
+    "no": "0026",
+    "name_jpn": "ライチュウ",
+    "name_eng": "Raichu",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      }
+    ]
+  },
+  {
+    "no": "0926",
+    "name_jpn": "パピモッチ",
+    "name_eng": "Fidough",
+    "types": [
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0927",
+    "name_jpn": "バウッツェル",
+    "name_eng": "Dachsbun",
+    "types": [
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0287",
+    "name_jpn": "ナマケロ",
+    "name_eng": "Slakoth",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "0288",
+    "name_jpn": "ヤルキモノ",
+    "name_eng": "Vigoroth",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "0289",
+    "name_jpn": "ケッキング",
+    "name_eng": "Slaking",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "0761",
+    "name_jpn": "アマカジ",
+    "name_eng": "Bounsweet",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0762",
+    "name_jpn": "アママイコ",
+    "name_eng": "Steenee",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0763",
+    "name_jpn": "アマージョ",
+    "name_eng": "Tsareena",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0928",
+    "name_jpn": "ミニーブ",
+    "name_eng": "Smoliv",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0929",
+    "name_jpn": "オリーニョ",
+    "name_eng": "Dolliv",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0930",
+    "name_jpn": "オリーヴァ",
+    "name_eng": "Arboliva",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0438",
+    "name_jpn": "ウソハチ",
+    "name_eng": "Bonsly",
+    "types": [
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0185",
+    "name_jpn": "ウソッキー",
+    "name_eng": "Sudowoodo",
+    "types": [
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0744",
+    "name_jpn": "イワンコ",
+    "name_eng": "Rockruff",
+    "types": [
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0745",
+    "name_jpn": "ルガルガン",
+    "name_eng": "Lycanroc",
+    "types": [
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0745",
+    "name_jpn": "ルガルガン",
+    "name_eng": "Lycanroc",
+    "types": [
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0745",
+    "name_jpn": "ルガルガン",
+    "name_eng": "Lycanroc",
+    "types": [
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0837",
+    "name_jpn": "タンドン",
+    "name_eng": "Rolycoly",
+    "types": [
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0838",
+    "name_jpn": "トロッゴン",
+    "name_eng": "Carkol",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      },
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0839",
+    "name_jpn": "セキタンザン",
+    "name_eng": "Coalossal",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      },
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0403",
+    "name_jpn": "コリンク",
+    "name_eng": "Shinx",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      }
+    ]
+  },
+  {
+    "no": "0404",
+    "name_jpn": "ルクシオ",
+    "name_eng": "Luxio",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      }
+    ]
+  },
+  {
+    "no": "0405",
+    "name_jpn": "レントラー",
+    "name_eng": "Luxray",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      }
+    ]
+  },
+  {
+    "no": "0396",
+    "name_jpn": "ムックル",
+    "name_eng": "Starly",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0397",
+    "name_jpn": "ムクバード",
+    "name_eng": "Staravia",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0398",
+    "name_jpn": "ムクホーク",
+    "name_eng": "Staraptor",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0741",
+    "name_jpn": "オドリドリ",
+    "name_eng": "Oricorio",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0741",
+    "name_jpn": "オドリドリ",
+    "name_eng": "Oricorio",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0741",
+    "name_jpn": "オドリドリ",
+    "name_eng": "Oricorio",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0741",
+    "name_jpn": "オドリドリ",
+    "name_eng": "Oricorio",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "0179",
+    "name_jpn": "メリープ",
+    "name_eng": "Mareep",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      }
+    ]
+  },
+  {
+    "no": "0180",
+    "name_jpn": "モココ",
+    "name_eng": "Flaaffy",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      }
+    ]
+  },
+  {
+    "no": "0181",
+    "name_jpn": "デンリュウ",
+    "name_eng": "Ampharos",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      }
+    ]
+  },
+  {
+    "no": "0548",
+    "name_jpn": "チュリネ",
+    "name_eng": "Petilil",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0549",
+    "name_jpn": "ドレディア",
+    "name_eng": "Lilligant",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0285",
+    "name_jpn": "キノココ",
+    "name_eng": "Shroomish",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0286",
+    "name_jpn": "キノガッサ",
+    "name_eng": "Breloom",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      }
+    ]
+  },
+  {
+    "no": "0840",
+    "name_jpn": "カジッチュ",
+    "name_eng": "Applin",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0841",
+    "name_jpn": "アップリュー",
+    "name_eng": "Flapple",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0842",
+    "name_jpn": "タルップル",
+    "name_eng": "Appletun",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0325",
+    "name_jpn": "バネブー",
+    "name_eng": "Spoink",
+    "types": [
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0326",
+    "name_jpn": "ブーピッグ",
+    "name_eng": "Grumpig",
+    "types": [
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0931",
+    "name_jpn": "イキリンコ",
+    "name_eng": "Squawkabilly",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0931",
+    "name_jpn": "イキリンコ",
+    "name_eng": "Squawkabilly",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0931",
+    "name_jpn": "イキリンコ",
+    "name_eng": "Squawkabilly",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0931",
+    "name_jpn": "イキリンコ",
+    "name_eng": "Squawkabilly",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0200",
+    "name_jpn": "ムウマ",
+    "name_eng": "Misdreavus",
+    "types": [
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "0429",
+    "name_jpn": "ムウマージ",
+    "name_eng": "Mismagius",
+    "types": [
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "0296",
+    "name_jpn": "マクノシタ",
+    "name_eng": "Makuhita",
+    "types": [
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      }
+    ]
+  },
+  {
+    "no": "0297",
+    "name_jpn": "ハリテヤマ",
+    "name_eng": "Hariyama",
+    "types": [
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      }
+    ]
+  },
+  {
+    "no": "0739",
+    "name_jpn": "マケンカニ",
+    "name_eng": "Crabrawler",
+    "types": [
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      }
+    ]
+  },
+  {
+    "no": "0740",
+    "name_jpn": "ケケンカニ",
+    "name_eng": "Crabominable",
+    "types": [
+      {
+        "jpn": "こおり",
+        "eng": "Ice"
+      },
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      }
+    ]
+  },
+  {
+    "no": "0757",
+    "name_jpn": "ヤトウモリ",
+    "name_eng": "Salandit",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      },
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      }
+    ]
+  },
+  {
+    "no": "0758",
+    "name_jpn": "エンニュート",
+    "name_eng": "Salazzle",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      },
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      }
+    ]
+  },
+  {
+    "no": "0231",
+    "name_jpn": "ゴマゾウ",
+    "name_eng": "Phanpy",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      }
+    ]
+  },
+  {
+    "no": "0232",
+    "name_jpn": "ドンファン",
+    "name_eng": "Donphan",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      }
+    ]
+  },
+  {
+    "no": "0878",
+    "name_jpn": "ゾウドウ",
+    "name_eng": "Cufant",
+    "types": [
+      {
+        "jpn": "はがね",
+        "eng": "Steel"
+      }
+    ]
+  },
+  {
+    "no": "0879",
+    "name_jpn": "ダイオウドウ",
+    "name_eng": "Copperajah",
+    "types": [
+      {
+        "jpn": "はがね",
+        "eng": "Steel"
+      }
+    ]
+  },
+  {
+    "no": "0443",
+    "name_jpn": "フカマル",
+    "name_eng": "Gible",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      },
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0444",
+    "name_jpn": "ガバイト",
+    "name_eng": "Gabite",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      },
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0445",
+    "name_jpn": "ガブリアス",
+    "name_eng": "Garchomp",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      },
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0932",
+    "name_jpn": "コジオ",
+    "name_eng": "Nacli",
+    "types": [
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0933",
+    "name_jpn": "ジオヅム",
+    "name_eng": "Naclstack",
+    "types": [
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0934",
+    "name_jpn": "キョジオーン",
+    "name_eng": "Garganacl",
+    "types": [
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0278",
+    "name_jpn": "キャモメ",
+    "name_eng": "Wingull",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0279",
+    "name_jpn": "ペリッパー",
+    "name_eng": "Pelipper",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0129",
+    "name_jpn": "コイキング",
+    "name_eng": "Magikarp",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0130",
+    "name_jpn": "ギャラドス",
+    "name_eng": "Gyarados",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0846",
+    "name_jpn": "サシカマス",
+    "name_eng": "Arrokuda",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0847",
+    "name_jpn": "カマスジョー",
+    "name_eng": "Barraskewda",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0550",
+    "name_jpn": "バスラオ",
+    "name_eng": "Basculin",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0550",
+    "name_jpn": "バスラオ",
+    "name_eng": "Basculin",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0316",
+    "name_jpn": "ゴクリン",
+    "name_eng": "Gulpin",
+    "types": [
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      }
+    ]
+  },
+  {
+    "no": "0317",
+    "name_jpn": "マルノーム",
+    "name_eng": "Swalot",
+    "types": [
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      }
+    ]
+  },
+  {
+    "no": "0052",
+    "name_jpn": "ニャース",
+    "name_eng": "Meowth",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "0052",
+    "name_jpn": "ニャース",
+    "name_eng": "Meowth",
+    "types": [
+      {
+        "jpn": "はがね",
+        "eng": "Steel"
+      }
+    ]
+  },
+  {
+    "no": "0053",
+    "name_jpn": "ペルシアン",
+    "name_eng": "Persian",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "0425",
+    "name_jpn": "フワンテ",
+    "name_eng": "Drifloon",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "0426",
+    "name_jpn": "フワライド",
+    "name_eng": "Drifblim",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "0669",
+    "name_jpn": "フラベベ",
+    "name_eng": "Flabébé",
+    "types": [
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0669",
+    "name_jpn": "フラベベ",
+    "name_eng": "Flabébé",
+    "types": [
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0669",
+    "name_jpn": "フラベベ",
+    "name_eng": "Flabébé",
+    "types": [
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0669",
+    "name_jpn": "フラベベ",
+    "name_eng": "Flabébé",
+    "types": [
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0669",
+    "name_jpn": "フラベベ",
+    "name_eng": "Flabébé",
+    "types": [
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0670",
+    "name_jpn": "フラエッテ",
+    "name_eng": "Floette",
+    "types": [
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0670",
+    "name_jpn": "フラエッテ",
+    "name_eng": "Floette",
+    "types": [
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0670",
+    "name_jpn": "フラエッテ",
+    "name_eng": "Floette",
+    "types": [
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0670",
+    "name_jpn": "フラエッテ",
+    "name_eng": "Floette",
+    "types": [
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0670",
+    "name_jpn": "フラエッテ",
+    "name_eng": "Floette",
+    "types": [
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0671",
+    "name_jpn": "フラージェス",
+    "name_eng": "Florges",
+    "types": [
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0671",
+    "name_jpn": "フラージェス",
+    "name_eng": "Florges",
+    "types": [
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0671",
+    "name_jpn": "フラージェス",
+    "name_eng": "Florges",
+    "types": [
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0671",
+    "name_jpn": "フラージェス",
+    "name_eng": "Florges",
+    "types": [
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0671",
+    "name_jpn": "フラージェス",
+    "name_eng": "Florges",
+    "types": [
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0050",
+    "name_jpn": "ディグダ",
+    "name_eng": "Diglett",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      }
+    ]
+  },
+  {
+    "no": "0051",
+    "name_jpn": "ダグトリオ",
+    "name_eng": "Dugtrio",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      }
+    ]
+  },
+  {
+    "no": "0324",
+    "name_jpn": "コータス",
+    "name_eng": "Torkoal",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      }
+    ]
+  },
+  {
+    "no": "0322",
+    "name_jpn": "ドンメル",
+    "name_eng": "Numel",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      },
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      }
+    ]
+  },
+  {
+    "no": "0323",
+    "name_jpn": "バクーダ",
+    "name_eng": "Camerupt",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      },
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      }
+    ]
+  },
+  {
+    "no": "0436",
+    "name_jpn": "ドーミラー",
+    "name_eng": "Bronzor",
+    "types": [
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      },
+      {
+        "jpn": "はがね",
+        "eng": "Steel"
+      }
+    ]
+  },
+  {
+    "no": "0437",
+    "name_jpn": "ドータクン",
+    "name_eng": "Bronzong",
+    "types": [
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      },
+      {
+        "jpn": "はがね",
+        "eng": "Steel"
+      }
+    ]
+  },
+  {
+    "no": "0610",
+    "name_jpn": "キバゴ",
+    "name_eng": "Axew",
+    "types": [
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0611",
+    "name_jpn": "オノンド",
+    "name_eng": "Fraxure",
+    "types": [
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0612",
+    "name_jpn": "オノノクス",
+    "name_eng": "Haxorus",
+    "types": [
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0056",
+    "name_jpn": "マンキー",
+    "name_eng": "Mankey",
+    "types": [
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      }
+    ]
+  },
+  {
+    "no": "0057",
+    "name_jpn": "オコリザル",
+    "name_eng": "Primeape",
+    "types": [
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      }
+    ]
+  },
+  {
+    "no": "0979",
+    "name_jpn": "コノヨザル",
+    "name_eng": "Annihilape",
+    "types": [
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      },
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "0307",
+    "name_jpn": "アサナン",
+    "name_eng": "Meditite",
+    "types": [
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      },
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0308",
+    "name_jpn": "チャーレム",
+    "name_eng": "Medicham",
+    "types": [
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      },
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0447",
+    "name_jpn": "リオル",
+    "name_eng": "Riolu",
+    "types": [
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      }
+    ]
+  },
+  {
+    "no": "0448",
+    "name_jpn": "ルカリオ",
+    "name_eng": "Lucario",
+    "types": [
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      },
+      {
+        "jpn": "はがね",
+        "eng": "Steel"
+      }
+    ]
+  },
+  {
+    "no": "0935",
+    "name_jpn": "カルボウ",
+    "name_eng": "Charcadet",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      }
+    ]
+  },
+  {
+    "no": "0936",
+    "name_jpn": "グレンアルマ",
+    "name_eng": "Armarouge",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      },
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0937",
+    "name_jpn": "ソウブレイズ",
+    "name_eng": "Ceruledge",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      },
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "0339",
+    "name_jpn": "ドジョッチ",
+    "name_eng": "Barboach",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      }
+    ]
+  },
+  {
+    "no": "0340",
+    "name_jpn": "ナマズン",
+    "name_eng": "Whiscash",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      }
+    ]
+  },
+  {
+    "no": "0938",
+    "name_jpn": "ズピカ",
+    "name_eng": "Tadbulb",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      }
+    ]
+  },
+  {
+    "no": "0939",
+    "name_jpn": "ハラバリー",
+    "name_eng": "Bellibolt",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      }
+    ]
+  },
+  {
+    "no": "0704",
+    "name_jpn": "ヌメラ",
+    "name_eng": "Goomy",
+    "types": [
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0705",
+    "name_jpn": "ヌメイル",
+    "name_eng": "Sliggoo",
+    "types": [
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0706",
+    "name_jpn": "ヌメルゴン",
+    "name_eng": "Goodra",
+    "types": [
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0453",
+    "name_jpn": "グレッグル",
+    "name_eng": "Croagunk",
+    "types": [
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      },
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      }
+    ]
+  },
+  {
+    "no": "0454",
+    "name_jpn": "ドクロッグ",
+    "name_eng": "Toxicroak",
+    "types": [
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      },
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      }
+    ]
+  },
+  {
+    "no": "0940",
+    "name_jpn": "カイデン",
+    "name_eng": "Wattrel",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0941",
+    "name_jpn": "タイカイデン",
+    "name_eng": "Kilowattrel",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0133",
+    "name_jpn": "イーブイ",
+    "name_eng": "Eevee",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "0134",
+    "name_jpn": "シャワーズ",
+    "name_eng": "Vaporeon",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0135",
+    "name_jpn": "サンダース",
+    "name_eng": "Jolteon",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      }
+    ]
+  },
+  {
+    "no": "0136",
+    "name_jpn": "ブースター",
+    "name_eng": "Flareon",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      }
+    ]
+  },
+  {
+    "no": "0196",
+    "name_jpn": "エーフィ",
+    "name_eng": "Espeon",
+    "types": [
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0197",
+    "name_jpn": "ブラッキー",
+    "name_eng": "Umbreon",
+    "types": [
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0470",
+    "name_jpn": "リーフィア",
+    "name_eng": "Leafeon",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0471",
+    "name_jpn": "グレイシア",
+    "name_eng": "Glaceon",
+    "types": [
+      {
+        "jpn": "こおり",
+        "eng": "Ice"
+      }
+    ]
+  },
+  {
+    "no": "0700",
+    "name_jpn": "ニンフィア",
+    "name_eng": "Sylveon",
+    "types": [
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0206",
+    "name_jpn": "ノコッチ",
+    "name_eng": "Dunsparce",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "0982",
+    "name_jpn": "ノココッチ",
+    "name_eng": "Dudunsparce",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "0982",
+    "name_jpn": "ノココッチ",
+    "name_eng": "Dudunsparce",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "0585",
+    "name_jpn": "シキジカ",
+    "name_eng": "Deerling",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0585",
+    "name_jpn": "シキジカ",
+    "name_eng": "Deerling",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0585",
+    "name_jpn": "シキジカ",
+    "name_eng": "Deerling",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0585",
+    "name_jpn": "シキジカ",
+    "name_eng": "Deerling",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0586",
+    "name_jpn": "メブキジカ",
+    "name_eng": "Sawsbuck",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0586",
+    "name_jpn": "メブキジカ",
+    "name_eng": "Sawsbuck",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0586",
+    "name_jpn": "メブキジカ",
+    "name_eng": "Sawsbuck",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0586",
+    "name_jpn": "メブキジカ",
+    "name_eng": "Sawsbuck",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0203",
+    "name_jpn": "キリンリキ",
+    "name_eng": "Girafarig",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0981",
+    "name_jpn": "リキキリン",
+    "name_eng": "Farigiraf",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0088",
+    "name_jpn": "ベトベター",
+    "name_eng": "Grimer",
+    "types": [
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      }
+    ]
+  },
+  {
+    "no": "0089",
+    "name_jpn": "ベトベトン",
+    "name_eng": "Muk",
+    "types": [
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      }
+    ]
+  },
+  {
+    "no": "0942",
+    "name_jpn": "オラチフ",
+    "name_eng": "Maschiff",
+    "types": [
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0943",
+    "name_jpn": "マフィティフ",
+    "name_eng": "Mabosstiff",
+    "types": [
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0848",
+    "name_jpn": "エレズン",
+    "name_eng": "Toxel",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      },
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      }
+    ]
+  },
+  {
+    "no": "0849",
+    "name_jpn": "ストリンダー",
+    "name_eng": "Toxtricity",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      },
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      }
+    ]
+  },
+  {
+    "no": "0849",
+    "name_jpn": "ストリンダー",
+    "name_eng": "Toxtricity",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      },
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      }
+    ]
+  },
+  {
+    "no": "0702",
+    "name_jpn": "デデンネ",
+    "name_eng": "Dedenne",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      },
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0417",
+    "name_jpn": "パチリス",
+    "name_eng": "Pachirisu",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      }
+    ]
+  },
+  {
+    "no": "0944",
+    "name_jpn": "シルシュルー",
+    "name_eng": "Shroodle",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      }
+    ]
+  },
+  {
+    "no": "0945",
+    "name_jpn": "タギングル",
+    "name_eng": "Grafaiai",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      }
+    ]
+  },
+  {
+    "no": "0234",
+    "name_jpn": "オドシシ",
+    "name_eng": "Stantler",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "0590",
+    "name_jpn": "タマゲタケ",
+    "name_eng": "Foongus",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      }
+    ]
+  },
+  {
+    "no": "0591",
+    "name_jpn": "モロバレル",
+    "name_eng": "Amoonguss",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      }
+    ]
+  },
+  {
+    "no": "0100",
+    "name_jpn": "ビリリダマ",
+    "name_eng": "Voltorb",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      }
+    ]
+  },
+  {
+    "no": "0101",
+    "name_jpn": "マルマイン",
+    "name_eng": "Electrode",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      }
+    ]
+  },
+  {
+    "no": "0081",
+    "name_jpn": "コイル",
+    "name_eng": "Magnemite",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      },
+      {
+        "jpn": "はがね",
+        "eng": "Steel"
+      }
+    ]
+  },
+  {
+    "no": "0082",
+    "name_jpn": "レアコイル",
+    "name_eng": "Magneton",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      },
+      {
+        "jpn": "はがね",
+        "eng": "Steel"
+      }
+    ]
+  },
+  {
+    "no": "0462",
+    "name_jpn": "ジバコイル",
+    "name_eng": "Magnezone",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      },
+      {
+        "jpn": "はがね",
+        "eng": "Steel"
+      }
+    ]
+  },
+  {
+    "no": "0132",
+    "name_jpn": "メタモン",
+    "name_eng": "Ditto",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "0058",
+    "name_jpn": "ガーディ",
+    "name_eng": "Growlithe",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      }
+    ]
+  },
+  {
+    "no": "0059",
+    "name_jpn": "ウインディ",
+    "name_eng": "Arcanine",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      }
+    ]
+  },
+  {
+    "no": "0216",
+    "name_jpn": "ヒメグマ",
+    "name_eng": "Teddiursa",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "0217",
+    "name_jpn": "リングマ",
+    "name_eng": "Ursaring",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "0335",
+    "name_jpn": "ザングース",
+    "name_eng": "Zangoose",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "0336",
+    "name_jpn": "ハブネーク",
+    "name_eng": "Seviper",
+    "types": [
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      }
+    ]
+  },
+  {
+    "no": "0333",
+    "name_jpn": "チルット",
+    "name_eng": "Swablu",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0334",
+    "name_jpn": "チルタリス",
+    "name_eng": "Altaria",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0672",
+    "name_jpn": "メェークル",
+    "name_eng": "Skiddo",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0673",
+    "name_jpn": "ゴーゴート",
+    "name_eng": "Gogoat",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0128",
+    "name_jpn": "ケンタロス",
+    "name_eng": "Tauros",
+    "types": [
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      }
+    ]
+  },
+  {
+    "no": "0128",
+    "name_jpn": "ケンタロス",
+    "name_eng": "Tauros",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      }
+    ]
+  },
+  {
+    "no": "0128",
+    "name_jpn": "ケンタロス",
+    "name_eng": "Tauros",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      },
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      }
+    ]
+  },
+  {
+    "no": "0667",
+    "name_jpn": "シシコ",
+    "name_eng": "Litleo",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      }
+    ]
+  },
+  {
+    "no": "0668",
+    "name_jpn": "カエンジシ",
+    "name_eng": "Pyroar",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      }
+    ]
+  },
+  {
+    "no": "0434",
+    "name_jpn": "スカンプー",
+    "name_eng": "Stunky",
+    "types": [
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0435",
+    "name_jpn": "スカタンク",
+    "name_eng": "Skuntank",
+    "types": [
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0570",
+    "name_jpn": "ゾロア",
+    "name_eng": "Zorua",
+    "types": [
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0571",
+    "name_jpn": "ゾロアーク",
+    "name_eng": "Zoroark",
+    "types": [
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0215",
+    "name_jpn": "ニューラ",
+    "name_eng": "Sneasel",
+    "types": [
+      {
+        "jpn": "こおり",
+        "eng": "Ice"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0461",
+    "name_jpn": "マニューラ",
+    "name_eng": "Weavile",
+    "types": [
+      {
+        "jpn": "こおり",
+        "eng": "Ice"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0198",
+    "name_jpn": "ヤミカラス",
+    "name_eng": "Murkrow",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0430",
+    "name_jpn": "ドンカラス",
+    "name_eng": "Honchkrow",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0574",
+    "name_jpn": "ゴチム",
+    "name_eng": "Gothita",
+    "types": [
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0575",
+    "name_jpn": "ゴチミル",
+    "name_eng": "Gothorita",
+    "types": [
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0576",
+    "name_jpn": "ゴチルゼル",
+    "name_eng": "Gothitelle",
+    "types": [
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0854",
+    "name_jpn": "ヤバチャ",
+    "name_eng": "Sinistea",
+    "types": [
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "0854",
+    "name_jpn": "ヤバチャ",
+    "name_eng": "Sinistea",
+    "types": [
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "0855",
+    "name_jpn": "ポットデス",
+    "name_eng": "Polteageist",
+    "types": [
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "0855",
+    "name_jpn": "ポットデス",
+    "name_eng": "Polteageist",
+    "types": [
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "0778",
+    "name_jpn": "ミミッキュ",
+    "name_eng": "Mimikyu",
+    "types": [
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      },
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0778",
+    "name_jpn": "ミミッキュ",
+    "name_eng": "Mimikyu",
+    "types": [
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      },
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0707",
+    "name_jpn": "クレッフィ",
+    "name_eng": "Klefki",
+    "types": [
+      {
+        "jpn": "はがね",
+        "eng": "Steel"
+      },
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0876",
+    "name_jpn": "イエッサン",
+    "name_eng": "Indeedee",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0876",
+    "name_jpn": "イエッサン",
+    "name_eng": "Indeedee",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0946",
+    "name_jpn": "アノクサ",
+    "name_eng": "Bramblin",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "0947",
+    "name_jpn": "アノホラグサ",
+    "name_eng": "Brambleghast",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "0948",
+    "name_jpn": "ノノクラゲ",
+    "name_eng": "Toedscool",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      }
+    ]
+  },
+  {
+    "no": "0949",
+    "name_jpn": "リククラゲ",
+    "name_eng": "Toedscruel",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      }
+    ]
+  },
+  {
+    "no": "0357",
+    "name_jpn": "トロピウス",
+    "name_eng": "Tropius",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0753",
+    "name_jpn": "カリキリ",
+    "name_eng": "Fomantis",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0754",
+    "name_jpn": "ラランテス",
+    "name_eng": "Lurantis",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0950",
+    "name_jpn": "ガケガニ",
+    "name_eng": "Klawf",
+    "types": [
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0951",
+    "name_jpn": "カプサイジ",
+    "name_eng": "Capsakid",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0952",
+    "name_jpn": "スコヴィラン",
+    "name_eng": "Scovillain",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      },
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0331",
+    "name_jpn": "サボネア",
+    "name_eng": "Cacnea",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0332",
+    "name_jpn": "ノクタス",
+    "name_eng": "Cacturne",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0953",
+    "name_jpn": "シガロコ",
+    "name_eng": "Rellor",
+    "types": [
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0954",
+    "name_jpn": "ベラカス",
+    "name_eng": "Rabsca",
+    "types": [
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0048",
+    "name_jpn": "コンパン",
+    "name_eng": "Venonat",
+    "types": [
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0049",
+    "name_jpn": "モルフォン",
+    "name_eng": "Venomoth",
+    "types": [
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0204",
+    "name_jpn": "クヌギダマ",
+    "name_eng": "Pineco",
+    "types": [
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0205",
+    "name_jpn": "フォレトス",
+    "name_eng": "Forretress",
+    "types": [
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      },
+      {
+        "jpn": "はがね",
+        "eng": "Steel"
+      }
+    ]
+  },
+  {
+    "no": "0123",
+    "name_jpn": "ストライク",
+    "name_eng": "Scyther",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0212",
+    "name_jpn": "ハッサム",
+    "name_eng": "Scizor",
+    "types": [
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      },
+      {
+        "jpn": "はがね",
+        "eng": "Steel"
+      }
+    ]
+  },
+  {
+    "no": "0214",
+    "name_jpn": "ヘラクロス",
+    "name_eng": "Heracross",
+    "types": [
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0955",
+    "name_jpn": "ヒラヒナ",
+    "name_eng": "Flittle",
+    "types": [
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0956",
+    "name_jpn": "クエスパトラ",
+    "name_eng": "Espathra",
+    "types": [
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0449",
+    "name_jpn": "ヒポポタス",
+    "name_eng": "Hippopotas",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      }
+    ]
+  },
+  {
+    "no": "0450",
+    "name_jpn": "カバルドン",
+    "name_eng": "Hippowdon",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      }
+    ]
+  },
+  {
+    "no": "0551",
+    "name_jpn": "メグロコ",
+    "name_eng": "Sandile",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0552",
+    "name_jpn": "ワルビル",
+    "name_eng": "Krokorok",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0553",
+    "name_jpn": "ワルビアル",
+    "name_eng": "Krookodile",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0843",
+    "name_jpn": "スナヘビ",
+    "name_eng": "Silicobra",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      }
+    ]
+  },
+  {
+    "no": "0844",
+    "name_jpn": "サダイジャ",
+    "name_eng": "Sandaconda",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      }
+    ]
+  },
+  {
+    "no": "0749",
+    "name_jpn": "ドロバンコ",
+    "name_eng": "Mudbray",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      }
+    ]
+  },
+  {
+    "no": "0750",
+    "name_jpn": "バンバドロ",
+    "name_eng": "Mudsdale",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      }
+    ]
+  },
+  {
+    "no": "0636",
+    "name_jpn": "メラルバ",
+    "name_eng": "Larvesta",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0637",
+    "name_jpn": "ウルガモス",
+    "name_eng": "Volcarona",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0371",
+    "name_jpn": "タツベイ",
+    "name_eng": "Bagon",
+    "types": [
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0372",
+    "name_jpn": "コモルー",
+    "name_eng": "Shelgon",
+    "types": [
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0373",
+    "name_jpn": "ボーマンダ",
+    "name_eng": "Salamence",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0957",
+    "name_jpn": "カヌチャン",
+    "name_eng": "Tinkatink",
+    "types": [
+      {
+        "jpn": "はがね",
+        "eng": "Steel"
+      },
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0958",
+    "name_jpn": "ナカヌチャン",
+    "name_eng": "Tinkatuff",
+    "types": [
+      {
+        "jpn": "はがね",
+        "eng": "Steel"
+      },
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0959",
+    "name_jpn": "デカヌチャン",
+    "name_eng": "Tinkaton",
+    "types": [
+      {
+        "jpn": "はがね",
+        "eng": "Steel"
+      },
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0856",
+    "name_jpn": "ミブリム",
+    "name_eng": "Hatenna",
+    "types": [
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0857",
+    "name_jpn": "テブリム",
+    "name_eng": "Hattrem",
+    "types": [
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0858",
+    "name_jpn": "ブリムオン",
+    "name_eng": "Hatterene",
+    "types": [
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      },
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0859",
+    "name_jpn": "ベロバー",
+    "name_eng": "Impidimp",
+    "types": [
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      },
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0860",
+    "name_jpn": "ギモー",
+    "name_eng": "Morgrem",
+    "types": [
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      },
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0861",
+    "name_jpn": "オーロンゲ",
+    "name_eng": "Grimmsnarl",
+    "types": [
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      },
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0960",
+    "name_jpn": "ウミディグダ",
+    "name_eng": "Wiglett",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0961",
+    "name_jpn": "ウミトリオ",
+    "name_eng": "Wugtrio",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0962",
+    "name_jpn": "オトシドリ",
+    "name_eng": "Bombirdier",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0963",
+    "name_jpn": "ナミイルカ",
+    "name_eng": "Finizen",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0964",
+    "name_jpn": "イルカマン",
+    "name_eng": "Palafin",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0964",
+    "name_jpn": "イルカマン",
+    "name_eng": "Palafin",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0965",
+    "name_jpn": "ブロロン",
+    "name_eng": "Varoom",
+    "types": [
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      },
+      {
+        "jpn": "はがね",
+        "eng": "Steel"
+      }
+    ]
+  },
+  {
+    "no": "0966",
+    "name_jpn": "ブロロローム",
+    "name_eng": "Revavroom",
+    "types": [
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      },
+      {
+        "jpn": "はがね",
+        "eng": "Steel"
+      }
+    ]
+  },
+  {
+    "no": "0967",
+    "name_jpn": "モトトカゲ",
+    "name_eng": "Cyclizar",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0968",
+    "name_jpn": "ミミズズ",
+    "name_eng": "Orthworm",
+    "types": [
+      {
+        "jpn": "はがね",
+        "eng": "Steel"
+      }
+    ]
+  },
+  {
+    "no": "0302",
+    "name_jpn": "ヤミラミ",
+    "name_eng": "Sableye",
+    "types": [
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0353",
+    "name_jpn": "カゲボウズ",
+    "name_eng": "Shuppet",
+    "types": [
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "0354",
+    "name_jpn": "ジュペッタ",
+    "name_eng": "Banette",
+    "types": [
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "0870",
+    "name_jpn": "タイレーツ",
+    "name_eng": "Falinks",
+    "types": [
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      }
+    ]
+  },
+  {
+    "no": "0701",
+    "name_jpn": "ルチャブル",
+    "name_eng": "Hawlucha",
+    "types": [
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0442",
+    "name_jpn": "ミカルゲ",
+    "name_eng": "Spiritomb",
+    "types": [
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0714",
+    "name_jpn": "オンバット",
+    "name_eng": "Noibat",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0715",
+    "name_jpn": "オンバーン",
+    "name_eng": "Noivern",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0885",
+    "name_jpn": "ドラメシヤ",
+    "name_eng": "Dreepy",
+    "types": [
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      },
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0886",
+    "name_jpn": "ドロンチ",
+    "name_eng": "Drakloak",
+    "types": [
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      },
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0887",
+    "name_jpn": "ドラパルト",
+    "name_eng": "Dragapult",
+    "types": [
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      },
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0969",
+    "name_jpn": "キラーメ",
+    "name_eng": "Glimmet",
+    "types": [
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      },
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0970",
+    "name_jpn": "キラフロル",
+    "name_eng": "Glimmora",
+    "types": [
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      },
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0479",
+    "name_jpn": "ロトム",
+    "name_eng": "Rotom",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      },
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "0479",
+    "name_jpn": "ロトム",
+    "name_eng": "Rotom",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      },
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      }
+    ]
+  },
+  {
+    "no": "0479",
+    "name_jpn": "ロトム",
+    "name_eng": "Rotom",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      }
+    ]
+  },
+  {
+    "no": "0479",
+    "name_jpn": "ロトム",
+    "name_eng": "Rotom",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      },
+      {
+        "jpn": "こおり",
+        "eng": "Ice"
+      }
+    ]
+  },
+  {
+    "no": "0479",
+    "name_jpn": "ロトム",
+    "name_eng": "Rotom",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0479",
+    "name_jpn": "ロトム",
+    "name_eng": "Rotom",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      },
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0971",
+    "name_jpn": "ボチ",
+    "name_eng": "Greavard",
+    "types": [
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "0972",
+    "name_jpn": "ハカドッグ",
+    "name_eng": "Houndstone",
+    "types": [
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "0765",
+    "name_jpn": "ヤレユータン",
+    "name_eng": "Oranguru",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0766",
+    "name_jpn": "ナゲツケサル",
+    "name_eng": "Passimian",
+    "types": [
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      }
+    ]
+  },
+  {
+    "no": "0775",
+    "name_jpn": "ネッコアラ",
+    "name_eng": "Komala",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "0246",
+    "name_jpn": "ヨーギラス",
+    "name_eng": "Larvitar",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      },
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0247",
+    "name_jpn": "サナギラス",
+    "name_eng": "Pupitar",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      },
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0248",
+    "name_jpn": "バンギラス",
+    "name_eng": "Tyranitar",
+    "types": [
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0874",
+    "name_jpn": "イシヘンジン",
+    "name_eng": "Stonjourner",
+    "types": [
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0875",
+    "name_jpn": "コオリッポ",
+    "name_eng": "Eiscue",
+    "types": [
+      {
+        "jpn": "こおり",
+        "eng": "Ice"
+      }
+    ]
+  },
+  {
+    "no": "0875",
+    "name_jpn": "コオリッポ",
+    "name_eng": "Eiscue",
+    "types": [
+      {
+        "jpn": "こおり",
+        "eng": "Ice"
+      }
+    ]
+  },
+  {
+    "no": "0871",
+    "name_jpn": "バチンウニ",
+    "name_eng": "Pincurchin",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      }
+    ]
+  },
+  {
+    "no": "0769",
+    "name_jpn": "スナバァ",
+    "name_eng": "Sandygast",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      },
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "0770",
+    "name_jpn": "シロデスナ",
+    "name_eng": "Palossand",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      },
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "0079",
+    "name_jpn": "ヤドン",
+    "name_eng": "Slowpoke",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0080",
+    "name_jpn": "ヤドラン",
+    "name_eng": "Slowbro",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0199",
+    "name_jpn": "ヤドキング",
+    "name_eng": "Slowking",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0422",
+    "name_jpn": "カラナクシ",
+    "name_eng": "Shellos",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0422",
+    "name_jpn": "カラナクシ",
+    "name_eng": "Shellos",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0423",
+    "name_jpn": "トリトドン",
+    "name_eng": "Gastrodon",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      }
+    ]
+  },
+  {
+    "no": "0423",
+    "name_jpn": "トリトドン",
+    "name_eng": "Gastrodon",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      }
+    ]
+  },
+  {
+    "no": "0090",
+    "name_jpn": "シェルダー",
+    "name_eng": "Shellder",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0091",
+    "name_jpn": "パルシェン",
+    "name_eng": "Cloyster",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "こおり",
+        "eng": "Ice"
+      }
+    ]
+  },
+  {
+    "no": "0211",
+    "name_jpn": "ハリーセン",
+    "name_eng": "Qwilfish",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      }
+    ]
+  },
+  {
+    "no": "0370",
+    "name_jpn": "ラブカス",
+    "name_eng": "Luvdisc",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0456",
+    "name_jpn": "ケイコウオ",
+    "name_eng": "Finneon",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0457",
+    "name_jpn": "ネオラント",
+    "name_eng": "Lumineon",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0779",
+    "name_jpn": "ハギギシリ",
+    "name_eng": "Bruxish",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0594",
+    "name_jpn": "ママンボウ",
+    "name_eng": "Alomomola",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0690",
+    "name_jpn": "クズモー",
+    "name_eng": "Skrelp",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      }
+    ]
+  },
+  {
+    "no": "0691",
+    "name_jpn": "ドラミドロ",
+    "name_eng": "Dragalge",
+    "types": [
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      },
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0692",
+    "name_jpn": "ウデッポウ",
+    "name_eng": "Clauncher",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0693",
+    "name_jpn": "ブロスター",
+    "name_eng": "Clawitzer",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0602",
+    "name_jpn": "シビシラス",
+    "name_eng": "Tynamo",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      }
+    ]
+  },
+  {
+    "no": "0603",
+    "name_jpn": "シビビール",
+    "name_eng": "Eelektrik",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      }
+    ]
+  },
+  {
+    "no": "0604",
+    "name_jpn": "シビルドン",
+    "name_eng": "Eelektross",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      }
+    ]
+  },
+  {
+    "no": "0747",
+    "name_jpn": "ヒドイデ",
+    "name_eng": "Mareanie",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      }
+    ]
+  },
+  {
+    "no": "0748",
+    "name_jpn": "ドヒドイデ",
+    "name_eng": "Toxapex",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      }
+    ]
+  },
+  {
+    "no": "0973",
+    "name_jpn": "カラミンゴ",
+    "name_eng": "Flamigo",
+    "types": [
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0147",
+    "name_jpn": "ミニリュウ",
+    "name_eng": "Dratini",
+    "types": [
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0148",
+    "name_jpn": "ハクリュー",
+    "name_eng": "Dragonair",
+    "types": [
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0149",
+    "name_jpn": "カイリュー",
+    "name_eng": "Dragonite",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0872",
+    "name_jpn": "ユキハミ",
+    "name_eng": "Snom",
+    "types": [
+      {
+        "jpn": "こおり",
+        "eng": "Ice"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0873",
+    "name_jpn": "モスノウ",
+    "name_eng": "Frosmoth",
+    "types": [
+      {
+        "jpn": "こおり",
+        "eng": "Ice"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0459",
+    "name_jpn": "ユキカブリ",
+    "name_eng": "Snover",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "こおり",
+        "eng": "Ice"
+      }
+    ]
+  },
+  {
+    "no": "0460",
+    "name_jpn": "ユキノオー",
+    "name_eng": "Abomasnow",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "こおり",
+        "eng": "Ice"
+      }
+    ]
+  },
+  {
+    "no": "0225",
+    "name_jpn": "デリバード",
+    "name_eng": "Delibird",
+    "types": [
+      {
+        "jpn": "こおり",
+        "eng": "Ice"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0613",
+    "name_jpn": "クマシュン",
+    "name_eng": "Cubchoo",
+    "types": [
+      {
+        "jpn": "こおり",
+        "eng": "Ice"
+      }
+    ]
+  },
+  {
+    "no": "0614",
+    "name_jpn": "ツンベアー",
+    "name_eng": "Beartic",
+    "types": [
+      {
+        "jpn": "こおり",
+        "eng": "Ice"
+      }
+    ]
+  },
+  {
+    "no": "0361",
+    "name_jpn": "ユキワラシ",
+    "name_eng": "Snorunt",
+    "types": [
+      {
+        "jpn": "こおり",
+        "eng": "Ice"
+      }
+    ]
+  },
+  {
+    "no": "0362",
+    "name_jpn": "オニゴーリ",
+    "name_eng": "Glalie",
+    "types": [
+      {
+        "jpn": "こおり",
+        "eng": "Ice"
+      }
+    ]
+  },
+  {
+    "no": "0478",
+    "name_jpn": "ユキメノコ",
+    "name_eng": "Froslass",
+    "types": [
+      {
+        "jpn": "こおり",
+        "eng": "Ice"
+      },
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "0615",
+    "name_jpn": "フリージオ",
+    "name_eng": "Cryogonal",
+    "types": [
+      {
+        "jpn": "こおり",
+        "eng": "Ice"
+      }
+    ]
+  },
+  {
+    "no": "0974",
+    "name_jpn": "アルクジラ",
+    "name_eng": "Cetoddle",
+    "types": [
+      {
+        "jpn": "こおり",
+        "eng": "Ice"
+      }
+    ]
+  },
+  {
+    "no": "0975",
+    "name_jpn": "ハルクジラ",
+    "name_eng": "Cetitan",
+    "types": [
+      {
+        "jpn": "こおり",
+        "eng": "Ice"
+      }
+    ]
+  },
+  {
+    "no": "0712",
+    "name_jpn": "カチコール",
+    "name_eng": "Bergmite",
+    "types": [
+      {
+        "jpn": "こおり",
+        "eng": "Ice"
+      }
+    ]
+  },
+  {
+    "no": "0713",
+    "name_jpn": "クレベース",
+    "name_eng": "Avalugg",
+    "types": [
+      {
+        "jpn": "こおり",
+        "eng": "Ice"
+      }
+    ]
+  },
+  {
+    "no": "0627",
+    "name_jpn": "ワシボン",
+    "name_eng": "Rufflet",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0628",
+    "name_jpn": "ウォーグル",
+    "name_eng": "Braviary",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0624",
+    "name_jpn": "コマタナ",
+    "name_eng": "Pawniard",
+    "types": [
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      },
+      {
+        "jpn": "はがね",
+        "eng": "Steel"
+      }
+    ]
+  },
+  {
+    "no": "0625",
+    "name_jpn": "キリキザン",
+    "name_eng": "Bisharp",
+    "types": [
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      },
+      {
+        "jpn": "はがね",
+        "eng": "Steel"
+      }
+    ]
+  },
+  {
+    "no": "0983",
+    "name_jpn": "ドドゲザン",
+    "name_eng": "Kingambit",
+    "types": [
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      },
+      {
+        "jpn": "はがね",
+        "eng": "Steel"
+      }
+    ]
+  },
+  {
+    "no": "0633",
+    "name_jpn": "モノズ",
+    "name_eng": "Deino",
+    "types": [
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0634",
+    "name_jpn": "ジヘッド",
+    "name_eng": "Zweilous",
+    "types": [
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0635",
+    "name_jpn": "サザンドラ",
+    "name_eng": "Hydreigon",
+    "types": [
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0976",
+    "name_jpn": "ミガルーサ",
+    "name_eng": "Veluza",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0977",
+    "name_jpn": "ヘイラッシャ",
+    "name_eng": "Dondozo",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0978",
+    "name_jpn": "シャリタツ",
+    "name_eng": "Tatsugiri",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0978",
+    "name_jpn": "シャリタツ",
+    "name_eng": "Tatsugiri",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0978",
+    "name_jpn": "シャリタツ",
+    "name_eng": "Tatsugiri",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0984",
+    "name_jpn": "イダイナキバ",
+    "name_eng": "Great Tusk",
+    "types": [
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      },
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      }
+    ]
+  },
+  {
+    "no": "0985",
+    "name_jpn": "サケブシッポ",
+    "name_eng": "Scream Tail",
+    "types": [
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      },
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0986",
+    "name_jpn": "アラブルタケ",
+    "name_eng": "Brute Bonnet",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0987",
+    "name_jpn": "ハバタクカミ",
+    "name_eng": "Flutter Mane",
+    "types": [
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      },
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0988",
+    "name_jpn": "チヲハウハネ",
+    "name_eng": "Slither Wing",
+    "types": [
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0989",
+    "name_jpn": "スナノケガワ",
+    "name_eng": "Sandy Shocks",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      },
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      }
+    ]
+  },
+  {
+    "no": "0990",
+    "name_jpn": "テツノワダチ",
+    "name_eng": "Iron Treads",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      },
+      {
+        "jpn": "はがね",
+        "eng": "Steel"
+      }
+    ]
+  },
+  {
+    "no": "0991",
+    "name_jpn": "テツノツツミ",
+    "name_eng": "Iron Bundle",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "こおり",
+        "eng": "Ice"
+      }
+    ]
+  },
+  {
+    "no": "0992",
+    "name_jpn": "テツノカイナ",
+    "name_eng": "Iron Hands",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      },
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      }
+    ]
+  },
+  {
+    "no": "0993",
+    "name_jpn": "テツノコウベ",
+    "name_eng": "Iron Jugulis",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0994",
+    "name_jpn": "テツノドクガ",
+    "name_eng": "Iron Moth",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      },
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      }
+    ]
+  },
+  {
+    "no": "0995",
+    "name_jpn": "テツノイバラ",
+    "name_eng": "Iron Thorns",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      },
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0996",
+    "name_jpn": "セビエ",
+    "name_eng": "Frigibax",
+    "types": [
+      {
+        "jpn": "こおり",
+        "eng": "Ice"
+      },
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0997",
+    "name_jpn": "セゴール",
+    "name_eng": "Arctibax",
+    "types": [
+      {
+        "jpn": "こおり",
+        "eng": "Ice"
+      },
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0998",
+    "name_jpn": "セグレイブ",
+    "name_eng": "Baxcalibur",
+    "types": [
+      {
+        "jpn": "こおり",
+        "eng": "Ice"
+      },
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0999",
+    "name_jpn": "コレクレー",
+    "name_eng": "Gimmighoul",
+    "types": [
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "0999",
+    "name_jpn": "コレクレー",
+    "name_eng": "Gimmighoul",
+    "types": [
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "1000",
+    "name_jpn": "サーフゴー",
+    "name_eng": "Gholdengo",
+    "types": [
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      },
+      {
+        "jpn": "はがね",
+        "eng": "Steel"
+      }
+    ]
+  },
+  {
+    "no": "1001",
+    "name_jpn": "チオンジェン",
+    "name_eng": "Wo-Chien",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "1002",
+    "name_jpn": "パオジアン",
+    "name_eng": "Chien-Pao",
+    "types": [
+      {
+        "jpn": "こおり",
+        "eng": "Ice"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "1003",
+    "name_jpn": "ディンルー",
+    "name_eng": "Ting-Lu",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "1004",
+    "name_jpn": "イーユイ",
+    "name_eng": "Chi-Yu",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "1005",
+    "name_jpn": "トドロクツキ",
+    "name_eng": "Roaring Moon",
+    "types": [
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "1006",
+    "name_jpn": "テツノブジン",
+    "name_eng": "Iron Valiant",
+    "types": [
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      },
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "1007",
+    "name_jpn": "コライドン",
+    "name_eng": "Koraidon",
+    "types": [
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      },
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "1007",
+    "name_jpn": "コライドン",
+    "name_eng": "Koraidon",
+    "types": [
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      },
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "1008",
+    "name_jpn": "ミライドン",
+    "name_eng": "Miraidon",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      },
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "1008",
+    "name_jpn": "ミライドン",
+    "name_eng": "Miraidon",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      },
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0167",
+    "name_jpn": "イトマル",
+    "name_eng": "Spinarak",
+    "types": [
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0168",
+    "name_jpn": "アリアドス",
+    "name_eng": "Ariados",
+    "types": [
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0193",
+    "name_jpn": "ヤンヤンマ",
+    "name_eng": "Yanma",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0469",
+    "name_jpn": "メガヤンマ",
+    "name_eng": "Yanmega",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0194",
+    "name_jpn": "ウパー",
+    "name_eng": "Wooper",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      }
+    ]
+  },
+  {
+    "no": "0195",
+    "name_jpn": "ヌオー",
+    "name_eng": "Quagsire",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      }
+    ]
+  },
+  {
+    "no": "0261",
+    "name_jpn": "ポチエナ",
+    "name_eng": "Poochyena",
+    "types": [
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0262",
+    "name_jpn": "グラエナ",
+    "name_eng": "Mightyena",
+    "types": [
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0313",
+    "name_jpn": "バルビート",
+    "name_eng": "Volbeat",
+    "types": [
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0314",
+    "name_jpn": "イルミーゼ",
+    "name_eng": "Illumise",
+    "types": [
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0341",
+    "name_jpn": "ヘイガニ",
+    "name_eng": "Corphish",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0342",
+    "name_jpn": "シザリガー",
+    "name_eng": "Crawdaunt",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0540",
+    "name_jpn": "クルミル",
+    "name_eng": "Sewaddle",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0541",
+    "name_jpn": "クルマユ",
+    "name_eng": "Swadloon",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0542",
+    "name_jpn": "ハハコモリ",
+    "name_eng": "Leavanny",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0742",
+    "name_jpn": "アブリー",
+    "name_eng": "Cutiefly",
+    "types": [
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      },
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0743",
+    "name_jpn": "アブリボン",
+    "name_eng": "Ribombee",
+    "types": [
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      },
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0023",
+    "name_jpn": "アーボ",
+    "name_eng": "Ekans",
+    "types": [
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      }
+    ]
+  },
+  {
+    "no": "0024",
+    "name_jpn": "アーボック",
+    "name_eng": "Arbok",
+    "types": [
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      }
+    ]
+  },
+  {
+    "no": "0069",
+    "name_jpn": "マダツボミ",
+    "name_eng": "Bellsprout",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      }
+    ]
+  },
+  {
+    "no": "0070",
+    "name_jpn": "ウツドン",
+    "name_eng": "Weepinbell",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      }
+    ]
+  },
+  {
+    "no": "0071",
+    "name_jpn": "ウツボット",
+    "name_eng": "Victreebel",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      }
+    ]
+  },
+  {
+    "no": "0161",
+    "name_jpn": "オタチ",
+    "name_eng": "Sentret",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "0162",
+    "name_jpn": "オオタチ",
+    "name_eng": "Furret",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "1011",
+    "name_jpn": "カミッチュ",
+    "name_eng": "Dipplin",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0037",
+    "name_jpn": "ロコン",
+    "name_eng": "Vulpix",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      }
+    ]
+  },
+  {
+    "no": "0038",
+    "name_jpn": "キュウコン",
+    "name_eng": "Ninetales",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      }
+    ]
+  },
+  {
+    "no": "0060",
+    "name_jpn": "ニョロモ",
+    "name_eng": "Poliwag",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0061",
+    "name_jpn": "ニョロゾ",
+    "name_eng": "Poliwhirl",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0062",
+    "name_jpn": "ニョロボン",
+    "name_eng": "Poliwrath",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      }
+    ]
+  },
+  {
+    "no": "0186",
+    "name_jpn": "ニョロトノ",
+    "name_eng": "Politoed",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0163",
+    "name_jpn": "ホーホー",
+    "name_eng": "Hoothoot",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0164",
+    "name_jpn": "ヨルノズク",
+    "name_eng": "Noctowl",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0190",
+    "name_jpn": "エイパム",
+    "name_eng": "Aipom",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "0424",
+    "name_jpn": "エテボース",
+    "name_eng": "Ambipom",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "0220",
+    "name_jpn": "ウリムー",
+    "name_eng": "Swinub",
+    "types": [
+      {
+        "jpn": "こおり",
+        "eng": "Ice"
+      },
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      }
+    ]
+  },
+  {
+    "no": "0221",
+    "name_jpn": "イノムー",
+    "name_eng": "Piloswine",
+    "types": [
+      {
+        "jpn": "こおり",
+        "eng": "Ice"
+      },
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      }
+    ]
+  },
+  {
+    "no": "0473",
+    "name_jpn": "マンムー",
+    "name_eng": "Mamoswine",
+    "types": [
+      {
+        "jpn": "こおり",
+        "eng": "Ice"
+      },
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      }
+    ]
+  },
+  {
+    "no": "0273",
+    "name_jpn": "タネボー",
+    "name_eng": "Seedot",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0274",
+    "name_jpn": "コノハナ",
+    "name_eng": "Nuzleaf",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0275",
+    "name_jpn": "ダーテング",
+    "name_eng": "Shiftry",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0708",
+    "name_jpn": "ボクレー",
+    "name_eng": "Phantump",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "0709",
+    "name_jpn": "オーロット",
+    "name_eng": "Trevenant",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "1012",
+    "name_jpn": "チャデス",
+    "name_eng": "Poltchageist",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "1012",
+    "name_jpn": "チャデス",
+    "name_eng": "Poltchageist",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "1013",
+    "name_jpn": "ヤバソチャ",
+    "name_eng": "Sinistcha",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "1013",
+    "name_jpn": "ヤバソチャ",
+    "name_eng": "Sinistcha",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "0074",
+    "name_jpn": "イシツブテ",
+    "name_eng": "Geodude",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      },
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0075",
+    "name_jpn": "ゴローン",
+    "name_eng": "Graveler",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      },
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0076",
+    "name_jpn": "ゴローニャ",
+    "name_eng": "Golem",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      },
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0532",
+    "name_jpn": "ドッコラー",
+    "name_eng": "Timburr",
+    "types": [
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      }
+    ]
+  },
+  {
+    "no": "0533",
+    "name_jpn": "ドテッコツ",
+    "name_eng": "Gurdurr",
+    "types": [
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      }
+    ]
+  },
+  {
+    "no": "0534",
+    "name_jpn": "ローブシン",
+    "name_eng": "Conkeldurr",
+    "types": [
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      }
+    ]
+  },
+  {
+    "no": "0877",
+    "name_jpn": "モルペコ",
+    "name_eng": "Morpeko",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0877",
+    "name_jpn": "モルペコ",
+    "name_eng": "Morpeko",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0446",
+    "name_jpn": "ゴンベ",
+    "name_eng": "Munchlax",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "0143",
+    "name_jpn": "カビゴン",
+    "name_eng": "Snorlax",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "0270",
+    "name_jpn": "ハスボー",
+    "name_eng": "Lotad",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0271",
+    "name_jpn": "ハスブレロ",
+    "name_eng": "Lombre",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0272",
+    "name_jpn": "ルンパッパ",
+    "name_eng": "Ludicolo",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0299",
+    "name_jpn": "ノズパス",
+    "name_eng": "Nosepass",
+    "types": [
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0476",
+    "name_jpn": "ダイノーズ",
+    "name_eng": "Probopass",
+    "types": [
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      },
+      {
+        "jpn": "はがね",
+        "eng": "Steel"
+      }
+    ]
+  },
+  {
+    "no": "0736",
+    "name_jpn": "アゴジムシ",
+    "name_eng": "Grubbin",
+    "types": [
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0737",
+    "name_jpn": "デンヂムシ",
+    "name_eng": "Charjabug",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0738",
+    "name_jpn": "クワガノン",
+    "name_eng": "Vikavolt",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0027",
+    "name_jpn": "サンド",
+    "name_eng": "Sandshrew",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      }
+    ]
+  },
+  {
+    "no": "0028",
+    "name_jpn": "サンドパン",
+    "name_eng": "Sandslash",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      }
+    ]
+  },
+  {
+    "no": "0207",
+    "name_jpn": "グライガー",
+    "name_eng": "Gligar",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0472",
+    "name_jpn": "グライオン",
+    "name_eng": "Gliscor",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0629",
+    "name_jpn": "バルチャイ",
+    "name_eng": "Vullaby",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0630",
+    "name_jpn": "バルジーナ",
+    "name_eng": "Mandibuzz",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0782",
+    "name_jpn": "ジャラコ",
+    "name_eng": "Jangmo-o",
+    "types": [
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0783",
+    "name_jpn": "ジャランゴ",
+    "name_eng": "Hakamo-o",
+    "types": [
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      },
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0784",
+    "name_jpn": "ジャラランガ",
+    "name_eng": "Kommo-o",
+    "types": [
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      },
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0109",
+    "name_jpn": "ドガース",
+    "name_eng": "Koffing",
+    "types": [
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      }
+    ]
+  },
+  {
+    "no": "0110",
+    "name_jpn": "マタドガス",
+    "name_eng": "Weezing",
+    "types": [
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      }
+    ]
+  },
+  {
+    "no": "0619",
+    "name_jpn": "コジョフー",
+    "name_eng": "Mienfoo",
+    "types": [
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      }
+    ]
+  },
+  {
+    "no": "0620",
+    "name_jpn": "コジョンド",
+    "name_eng": "Mienshao",
+    "types": [
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      }
+    ]
+  },
+  {
+    "no": "0355",
+    "name_jpn": "ヨマワル",
+    "name_eng": "Duskull",
+    "types": [
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "0356",
+    "name_jpn": "サマヨール",
+    "name_eng": "Dusclops",
+    "types": [
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "0477",
+    "name_jpn": "ヨノワール",
+    "name_eng": "Dusknoir",
+    "types": [
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "0433",
+    "name_jpn": "リーシャン",
+    "name_eng": "Chingling",
+    "types": [
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0358",
+    "name_jpn": "チリーン",
+    "name_eng": "Chimecho",
+    "types": [
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0218",
+    "name_jpn": "マグマッグ",
+    "name_eng": "Slugma",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      }
+    ]
+  },
+  {
+    "no": "0219",
+    "name_jpn": "マグカルゴ",
+    "name_eng": "Magcargo",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      },
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0607",
+    "name_jpn": "ヒトモシ",
+    "name_eng": "Litwick",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      },
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "0608",
+    "name_jpn": "ランプラー",
+    "name_eng": "Lampent",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      },
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "0609",
+    "name_jpn": "シャンデラ",
+    "name_eng": "Chandelure",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      },
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "0173",
+    "name_jpn": "ピィ",
+    "name_eng": "Cleffa",
+    "types": [
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0035",
+    "name_jpn": "ピッピ",
+    "name_eng": "Clefairy",
+    "types": [
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0036",
+    "name_jpn": "ピクシー",
+    "name_eng": "Clefable",
+    "types": [
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0349",
+    "name_jpn": "ヒンバス",
+    "name_eng": "Feebas",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0350",
+    "name_jpn": "ミロカロス",
+    "name_eng": "Milotic",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0703",
+    "name_jpn": "メレシー",
+    "name_eng": "Carbink",
+    "types": [
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      },
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0580",
+    "name_jpn": "コアルヒー",
+    "name_eng": "Ducklett",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0581",
+    "name_jpn": "スワンナ",
+    "name_eng": "Swanna",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0845",
+    "name_jpn": "ウッウ",
+    "name_eng": "Cramorant",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0845",
+    "name_jpn": "ウッウ",
+    "name_eng": "Cramorant",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0845",
+    "name_jpn": "ウッウ",
+    "name_eng": "Cramorant",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0902",
+    "name_jpn": "イダイトウ",
+    "name_eng": "Basculegion",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "0902",
+    "name_jpn": "イダイトウ",
+    "name_eng": "Basculegion",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "0901",
+    "name_jpn": "ガチグマ",
+    "name_eng": "Ursaluna",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      }
+    ]
+  },
+  {
+    "no": "1014",
+    "name_jpn": "イイネイヌ",
+    "name_eng": "Okidogi",
+    "types": [
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      },
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      }
+    ]
+  },
+  {
+    "no": "1015",
+    "name_jpn": "マシマシラ",
+    "name_eng": "Munkidori",
+    "types": [
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      },
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "1016",
+    "name_jpn": "キチキギス",
+    "name_eng": "Fezandipiti",
+    "types": [
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      },
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "1017",
+    "name_jpn": "オーガポン",
+    "name_eng": "Ogerpon",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "1017",
+    "name_jpn": "オーガポン",
+    "name_eng": "Ogerpon",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "1017",
+    "name_jpn": "オーガポン",
+    "name_eng": "Ogerpon",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      },
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "1017",
+    "name_jpn": "オーガポン",
+    "name_eng": "Ogerpon",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0084",
+    "name_jpn": "ドードー",
+    "name_eng": "Doduo",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0085",
+    "name_jpn": "ドードリオ",
+    "name_eng": "Dodrio",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0102",
+    "name_jpn": "タマタマ",
+    "name_eng": "Exeggcute",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0103",
+    "name_jpn": "ナッシー",
+    "name_eng": "Exeggutor",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0103",
+    "name_jpn": "ナッシー",
+    "name_eng": "Exeggutor",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0111",
+    "name_jpn": "サイホーン",
+    "name_eng": "Rhyhorn",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      },
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0112",
+    "name_jpn": "サイドン",
+    "name_eng": "Rhydon",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      },
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0464",
+    "name_jpn": "ドサイドン",
+    "name_eng": "Rhyperior",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      },
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0239",
+    "name_jpn": "エレキッド",
+    "name_eng": "Elekid",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      }
+    ]
+  },
+  {
+    "no": "0125",
+    "name_jpn": "エレブー",
+    "name_eng": "Electabuzz",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      }
+    ]
+  },
+  {
+    "no": "0466",
+    "name_jpn": "エレキブル",
+    "name_eng": "Electivire",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      }
+    ]
+  },
+  {
+    "no": "0240",
+    "name_jpn": "ブビィ",
+    "name_eng": "Magby",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      }
+    ]
+  },
+  {
+    "no": "0126",
+    "name_jpn": "ブーバー",
+    "name_eng": "Magmar",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      }
+    ]
+  },
+  {
+    "no": "0467",
+    "name_jpn": "ブーバーン",
+    "name_eng": "Magmortar",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      }
+    ]
+  },
+  {
+    "no": "0900",
+    "name_jpn": "バサギリ",
+    "name_eng": "Kleavor",
+    "types": [
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      },
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0128",
+    "name_jpn": "ケンタロス",
+    "name_eng": "Tauros",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "0522",
+    "name_jpn": "シママ",
+    "name_eng": "Blitzle",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      }
+    ]
+  },
+  {
+    "no": "0523",
+    "name_jpn": "ゼブライカ",
+    "name_eng": "Zebstrika",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      }
+    ]
+  },
+  {
+    "no": "0235",
+    "name_jpn": "ドーブル",
+    "name_eng": "Smeargle",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "0868",
+    "name_jpn": "マホミル",
+    "name_eng": "Milcery",
+    "types": [
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0869",
+    "name_jpn": "マホイップ",
+    "name_eng": "Alcremie",
+    "types": [
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0869",
+    "name_jpn": "マホイップ",
+    "name_eng": "Alcremie",
+    "types": [
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0869",
+    "name_jpn": "マホイップ",
+    "name_eng": "Alcremie",
+    "types": [
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0869",
+    "name_jpn": "マホイップ",
+    "name_eng": "Alcremie",
+    "types": [
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0869",
+    "name_jpn": "マホイップ",
+    "name_eng": "Alcremie",
+    "types": [
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0869",
+    "name_jpn": "マホイップ",
+    "name_eng": "Alcremie",
+    "types": [
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0869",
+    "name_jpn": "マホイップ",
+    "name_eng": "Alcremie",
+    "types": [
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0869",
+    "name_jpn": "マホイップ",
+    "name_eng": "Alcremie",
+    "types": [
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0869",
+    "name_jpn": "マホイップ",
+    "name_eng": "Alcremie",
+    "types": [
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0328",
+    "name_jpn": "ナックラー",
+    "name_eng": "Trapinch",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      }
+    ]
+  },
+  {
+    "no": "0329",
+    "name_jpn": "ビブラーバ",
+    "name_eng": "Vibrava",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      },
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0330",
+    "name_jpn": "フライゴン",
+    "name_eng": "Flygon",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      },
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0731",
+    "name_jpn": "ツツケラ",
+    "name_eng": "Pikipek",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0732",
+    "name_jpn": "ケララッパ",
+    "name_eng": "Trumbeak",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0733",
+    "name_jpn": "ドデカバシ",
+    "name_eng": "Toucannon",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0072",
+    "name_jpn": "メノクラゲ",
+    "name_eng": "Tentacool",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      }
+    ]
+  },
+  {
+    "no": "0073",
+    "name_jpn": "ドククラゲ",
+    "name_eng": "Tentacruel",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      }
+    ]
+  },
+  {
+    "no": "0116",
+    "name_jpn": "タッツー",
+    "name_eng": "Horsea",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0117",
+    "name_jpn": "シードラ",
+    "name_eng": "Seadra",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0230",
+    "name_jpn": "キングドラ",
+    "name_eng": "Kingdra",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0546",
+    "name_jpn": "モンメン",
+    "name_eng": "Cottonee",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0547",
+    "name_jpn": "エルフーン",
+    "name_eng": "Whimsicott",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0764",
+    "name_jpn": "キュワワー",
+    "name_eng": "Comfey",
+    "types": [
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0043",
+    "name_jpn": "ナゾノクサ",
+    "name_eng": "Oddish",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      }
+    ]
+  },
+  {
+    "no": "0044",
+    "name_jpn": "クサイハナ",
+    "name_eng": "Gloom",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      }
+    ]
+  },
+  {
+    "no": "0045",
+    "name_jpn": "ラフレシア",
+    "name_eng": "Vileplume",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      }
+    ]
+  },
+  {
+    "no": "0182",
+    "name_jpn": "キレイハナ",
+    "name_eng": "Bellossom",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0050",
+    "name_jpn": "ディグダ",
+    "name_eng": "Diglett",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      },
+      {
+        "jpn": "はがね",
+        "eng": "Steel"
+      }
+    ]
+  },
+  {
+    "no": "0051",
+    "name_jpn": "ダグトリオ",
+    "name_eng": "Dugtrio",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      },
+      {
+        "jpn": "はがね",
+        "eng": "Steel"
+      }
+    ]
+  },
+  {
+    "no": "0088",
+    "name_jpn": "ベトベター",
+    "name_eng": "Grimer",
+    "types": [
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0089",
+    "name_jpn": "ベトベトン",
+    "name_eng": "Muk",
+    "types": [
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0079",
+    "name_jpn": "ヤドン",
+    "name_eng": "Slowpoke",
+    "types": [
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0080",
+    "name_jpn": "ヤドラン",
+    "name_eng": "Slowbro",
+    "types": [
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      },
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0199",
+    "name_jpn": "ヤドキング",
+    "name_eng": "Slowking",
+    "types": [
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      },
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0170",
+    "name_jpn": "チョンチー",
+    "name_eng": "Chinchou",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      }
+    ]
+  },
+  {
+    "no": "0171",
+    "name_jpn": "ランターン",
+    "name_eng": "Lanturn",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      }
+    ]
+  },
+  {
+    "no": "0686",
+    "name_jpn": "マーイーカ",
+    "name_eng": "Inkay",
+    "types": [
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0687",
+    "name_jpn": "カラマネロ",
+    "name_eng": "Malamar",
+    "types": [
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0751",
+    "name_jpn": "シズクモ",
+    "name_eng": "Dewpider",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0752",
+    "name_jpn": "オニシズクモ",
+    "name_eng": "Araquanid",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0236",
+    "name_jpn": "バルキー",
+    "name_eng": "Tyrogue",
+    "types": [
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      }
+    ]
+  },
+  {
+    "no": "0106",
+    "name_jpn": "サワムラー",
+    "name_eng": "Hitmonlee",
+    "types": [
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      }
+    ]
+  },
+  {
+    "no": "0107",
+    "name_jpn": "エビワラー",
+    "name_eng": "Hitmonchan",
+    "types": [
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      }
+    ]
+  },
+  {
+    "no": "0237",
+    "name_jpn": "カポエラー",
+    "name_eng": "Hitmontop",
+    "types": [
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      }
+    ]
+  },
+  {
+    "no": "0074",
+    "name_jpn": "イシツブテ",
+    "name_eng": "Geodude",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      },
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0075",
+    "name_jpn": "ゴローン",
+    "name_eng": "Graveler",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      },
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0076",
+    "name_jpn": "ゴローニャ",
+    "name_eng": "Golem",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      },
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0529",
+    "name_jpn": "モグリュー",
+    "name_eng": "Drilbur",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      }
+    ]
+  },
+  {
+    "no": "0530",
+    "name_jpn": "ドリュウズ",
+    "name_eng": "Excadrill",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      },
+      {
+        "jpn": "はがね",
+        "eng": "Steel"
+      }
+    ]
+  },
+  {
+    "no": "0677",
+    "name_jpn": "ニャスパー",
+    "name_eng": "Espurr",
+    "types": [
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0678",
+    "name_jpn": "ニャオニクス",
+    "name_eng": "Meowstic",
+    "types": [
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0678",
+    "name_jpn": "ニャオニクス",
+    "name_eng": "Meowstic",
+    "types": [
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0774",
+    "name_jpn": "メテノ",
+    "name_eng": "Minior",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0774",
+    "name_jpn": "メテノ",
+    "name_eng": "Minior",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0774",
+    "name_jpn": "メテノ",
+    "name_eng": "Minior",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0774",
+    "name_jpn": "メテノ",
+    "name_eng": "Minior",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0774",
+    "name_jpn": "メテノ",
+    "name_eng": "Minior",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0774",
+    "name_jpn": "メテノ",
+    "name_eng": "Minior",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0774",
+    "name_jpn": "メテノ",
+    "name_eng": "Minior",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0774",
+    "name_jpn": "メテノ",
+    "name_eng": "Minior",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0408",
+    "name_jpn": "ズガイドス",
+    "name_eng": "Cranidos",
+    "types": [
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0409",
+    "name_jpn": "ラムパルド",
+    "name_eng": "Rampardos",
+    "types": [
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "0410",
+    "name_jpn": "タテトプス",
+    "name_eng": "Shieldon",
+    "types": [
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      },
+      {
+        "jpn": "はがね",
+        "eng": "Steel"
+      }
+    ]
+  },
+  {
+    "no": "0411",
+    "name_jpn": "トリデプス",
+    "name_eng": "Bastiodon",
+    "types": [
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      },
+      {
+        "jpn": "はがね",
+        "eng": "Steel"
+      }
+    ]
+  },
+  {
+    "no": "0572",
+    "name_jpn": "チラーミィ",
+    "name_eng": "Minccino",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "0573",
+    "name_jpn": "チラチーノ",
+    "name_eng": "Cinccino",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "0227",
+    "name_jpn": "エアームド",
+    "name_eng": "Skarmory",
+    "types": [
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      },
+      {
+        "jpn": "はがね",
+        "eng": "Steel"
+      }
+    ]
+  },
+  {
+    "no": "0311",
+    "name_jpn": "プラスル",
+    "name_eng": "Plusle",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      }
+    ]
+  },
+  {
+    "no": "0312",
+    "name_jpn": "マイナン",
+    "name_eng": "Minun",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      }
+    ]
+  },
+  {
+    "no": "0559",
+    "name_jpn": "ズルッグ",
+    "name_eng": "Scraggy",
+    "types": [
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0560",
+    "name_jpn": "ズルズキン",
+    "name_eng": "Scrafty",
+    "types": [
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0622",
+    "name_jpn": "ゴビット",
+    "name_eng": "Golett",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      },
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "0623",
+    "name_jpn": "ゴルーグ",
+    "name_eng": "Golurk",
+    "types": [
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      },
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "0137",
+    "name_jpn": "ポリゴン",
+    "name_eng": "Porygon",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "0233",
+    "name_jpn": "ポリゴン２",
+    "name_eng": "Porygon2",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "0474",
+    "name_jpn": "ポリゴンＺ",
+    "name_eng": "Porygon-Z",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "0595",
+    "name_jpn": "バチュル",
+    "name_eng": "Joltik",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0596",
+    "name_jpn": "デンチュラ",
+    "name_eng": "Galvantula",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      },
+      {
+        "jpn": "むし",
+        "eng": "Bug"
+      }
+    ]
+  },
+  {
+    "no": "0374",
+    "name_jpn": "ダンバル",
+    "name_eng": "Beldum",
+    "types": [
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      },
+      {
+        "jpn": "はがね",
+        "eng": "Steel"
+      }
+    ]
+  },
+  {
+    "no": "0375",
+    "name_jpn": "メタング",
+    "name_eng": "Metang",
+    "types": [
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      },
+      {
+        "jpn": "はがね",
+        "eng": "Steel"
+      }
+    ]
+  },
+  {
+    "no": "0376",
+    "name_jpn": "メタグロス",
+    "name_eng": "Metagross",
+    "types": [
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      },
+      {
+        "jpn": "はがね",
+        "eng": "Steel"
+      }
+    ]
+  },
+  {
+    "no": "0086",
+    "name_jpn": "パウワウ",
+    "name_eng": "Seel",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0087",
+    "name_jpn": "ジュゴン",
+    "name_eng": "Dewgong",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "こおり",
+        "eng": "Ice"
+      }
+    ]
+  },
+  {
+    "no": "0131",
+    "name_jpn": "ラプラス",
+    "name_eng": "Lapras",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "こおり",
+        "eng": "Ice"
+      }
+    ]
+  },
+  {
+    "no": "0211",
+    "name_jpn": "ハリーセン",
+    "name_eng": "Qwilfish",
+    "types": [
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0904",
+    "name_jpn": "ハリーマン",
+    "name_eng": "Overqwil",
+    "types": [
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0577",
+    "name_jpn": "ユニラン",
+    "name_eng": "Solosis",
+    "types": [
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0578",
+    "name_jpn": "ダブラン",
+    "name_eng": "Duosion",
+    "types": [
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0579",
+    "name_jpn": "ランクルス",
+    "name_eng": "Reuniclus",
+    "types": [
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0209",
+    "name_jpn": "ブルー",
+    "name_eng": "Snubbull",
+    "types": [
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0210",
+    "name_jpn": "グランブル",
+    "name_eng": "Granbull",
+    "types": [
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0027",
+    "name_jpn": "サンド",
+    "name_eng": "Sandshrew",
+    "types": [
+      {
+        "jpn": "こおり",
+        "eng": "Ice"
+      },
+      {
+        "jpn": "はがね",
+        "eng": "Steel"
+      }
+    ]
+  },
+  {
+    "no": "0028",
+    "name_jpn": "サンドパン",
+    "name_eng": "Sandslash",
+    "types": [
+      {
+        "jpn": "こおり",
+        "eng": "Ice"
+      },
+      {
+        "jpn": "はがね",
+        "eng": "Steel"
+      }
+    ]
+  },
+  {
+    "no": "0037",
+    "name_jpn": "ロコン",
+    "name_eng": "Vulpix",
+    "types": [
+      {
+        "jpn": "こおり",
+        "eng": "Ice"
+      }
+    ]
+  },
+  {
+    "no": "0038",
+    "name_jpn": "キュウコン",
+    "name_eng": "Ninetales",
+    "types": [
+      {
+        "jpn": "こおり",
+        "eng": "Ice"
+      }
+    ]
+  },
+  {
+    "no": "0884",
+    "name_jpn": "ジュラルドン",
+    "name_eng": "Duraludon",
+    "types": [
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      },
+      {
+        "jpn": "はがね",
+        "eng": "Steel"
+      }
+    ]
+  },
+  {
+    "no": "1018",
+    "name_jpn": "ブリジュラス",
+    "name_eng": "Archaludon",
+    "types": [
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      },
+      {
+        "jpn": "はがね",
+        "eng": "Steel"
+      }
+    ]
+  },
+  {
+    "no": "1019",
+    "name_jpn": "カミツオロチ",
+    "name_eng": "Hydrapple",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "0001",
+    "name_jpn": "フシギダネ",
+    "name_eng": "Bulbasaur",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      }
+    ]
+  },
+  {
+    "no": "0002",
+    "name_jpn": "フシギソウ",
+    "name_eng": "Ivysaur",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      }
+    ]
+  },
+  {
+    "no": "0003",
+    "name_jpn": "フシギバナ",
+    "name_eng": "Venusaur",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      }
+    ]
+  },
+  {
+    "no": "0004",
+    "name_jpn": "ヒトカゲ",
+    "name_eng": "Charmander",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      }
+    ]
+  },
+  {
+    "no": "0005",
+    "name_jpn": "リザード",
+    "name_eng": "Charmeleon",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      }
+    ]
+  },
+  {
+    "no": "0006",
+    "name_jpn": "リザードン",
+    "name_eng": "Charizard",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0007",
+    "name_jpn": "ゼニガメ",
+    "name_eng": "Squirtle",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0008",
+    "name_jpn": "カメール",
+    "name_eng": "Wartortle",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0009",
+    "name_jpn": "カメックス",
+    "name_eng": "Blastoise",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0152",
+    "name_jpn": "チコリータ",
+    "name_eng": "Chikorita",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0153",
+    "name_jpn": "ベイリーフ",
+    "name_eng": "Bayleef",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0154",
+    "name_jpn": "メガニウム",
+    "name_eng": "Meganium",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0155",
+    "name_jpn": "ヒノアラシ",
+    "name_eng": "Cyndaquil",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      }
+    ]
+  },
+  {
+    "no": "0156",
+    "name_jpn": "マグマラシ",
+    "name_eng": "Quilava",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      }
+    ]
+  },
+  {
+    "no": "0157",
+    "name_jpn": "バクフーン",
+    "name_eng": "Typhlosion",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      }
+    ]
+  },
+  {
+    "no": "0158",
+    "name_jpn": "ワニノコ",
+    "name_eng": "Totodile",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0159",
+    "name_jpn": "アリゲイツ",
+    "name_eng": "Croconaw",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0160",
+    "name_jpn": "オーダイル",
+    "name_eng": "Feraligatr",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0252",
+    "name_jpn": "キモリ",
+    "name_eng": "Treecko",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0253",
+    "name_jpn": "ジュプトル",
+    "name_eng": "Grovyle",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0254",
+    "name_jpn": "ジュカイン",
+    "name_eng": "Sceptile",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0255",
+    "name_jpn": "アチャモ",
+    "name_eng": "Torchic",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      }
+    ]
+  },
+  {
+    "no": "0256",
+    "name_jpn": "ワカシャモ",
+    "name_eng": "Combusken",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      },
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      }
+    ]
+  },
+  {
+    "no": "0257",
+    "name_jpn": "バシャーモ",
+    "name_eng": "Blaziken",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      },
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      }
+    ]
+  },
+  {
+    "no": "0258",
+    "name_jpn": "ミズゴロウ",
+    "name_eng": "Mudkip",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0259",
+    "name_jpn": "ヌマクロー",
+    "name_eng": "Marshtomp",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      }
+    ]
+  },
+  {
+    "no": "0260",
+    "name_jpn": "ラグラージ",
+    "name_eng": "Swampert",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      }
+    ]
+  },
+  {
+    "no": "0387",
+    "name_jpn": "ナエトル",
+    "name_eng": "Turtwig",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0388",
+    "name_jpn": "ハヤシガメ",
+    "name_eng": "Grotle",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0389",
+    "name_jpn": "ドダイトス",
+    "name_eng": "Torterra",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "じめん",
+        "eng": "Ground"
+      }
+    ]
+  },
+  {
+    "no": "0390",
+    "name_jpn": "ヒコザル",
+    "name_eng": "Chimchar",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      }
+    ]
+  },
+  {
+    "no": "0391",
+    "name_jpn": "モウカザル",
+    "name_eng": "Monferno",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      },
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      }
+    ]
+  },
+  {
+    "no": "0392",
+    "name_jpn": "ゴウカザル",
+    "name_eng": "Infernape",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      },
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      }
+    ]
+  },
+  {
+    "no": "0393",
+    "name_jpn": "ポッチャマ",
+    "name_eng": "Piplup",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0394",
+    "name_jpn": "ポッタイシ",
+    "name_eng": "Prinplup",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0395",
+    "name_jpn": "エンペルト",
+    "name_eng": "Empoleon",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "はがね",
+        "eng": "Steel"
+      }
+    ]
+  },
+  {
+    "no": "0495",
+    "name_jpn": "ツタージャ",
+    "name_eng": "Snivy",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0496",
+    "name_jpn": "ジャノビー",
+    "name_eng": "Servine",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0497",
+    "name_jpn": "ジャローダ",
+    "name_eng": "Serperior",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0498",
+    "name_jpn": "ポカブ",
+    "name_eng": "Tepig",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      }
+    ]
+  },
+  {
+    "no": "0499",
+    "name_jpn": "チャオブー",
+    "name_eng": "Pignite",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      },
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      }
+    ]
+  },
+  {
+    "no": "0500",
+    "name_jpn": "エンブオー",
+    "name_eng": "Emboar",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      },
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      }
+    ]
+  },
+  {
+    "no": "0501",
+    "name_jpn": "ミジュマル",
+    "name_eng": "Oshawott",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0502",
+    "name_jpn": "フタチマル",
+    "name_eng": "Dewott",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0503",
+    "name_jpn": "ダイケンキ",
+    "name_eng": "Samurott",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0650",
+    "name_jpn": "ハリマロン",
+    "name_eng": "Chespin",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0651",
+    "name_jpn": "ハリボーグ",
+    "name_eng": "Quilladin",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0652",
+    "name_jpn": "ブリガロン",
+    "name_eng": "Chesnaught",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "かくとう",
+        "eng": "Fighting"
+      }
+    ]
+  },
+  {
+    "no": "0653",
+    "name_jpn": "フォッコ",
+    "name_eng": "Fennekin",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      }
+    ]
+  },
+  {
+    "no": "0654",
+    "name_jpn": "テールナー",
+    "name_eng": "Braixen",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      }
+    ]
+  },
+  {
+    "no": "0655",
+    "name_jpn": "マフォクシー",
+    "name_eng": "Delphox",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      },
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "0656",
+    "name_jpn": "ケロマツ",
+    "name_eng": "Froakie",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0657",
+    "name_jpn": "ゲコガシラ",
+    "name_eng": "Frogadier",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0658",
+    "name_jpn": "ゲッコウガ",
+    "name_eng": "Greninja",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0722",
+    "name_jpn": "モクロー",
+    "name_eng": "Rowlet",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0723",
+    "name_jpn": "フクスロー",
+    "name_eng": "Dartrix",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "ひこう",
+        "eng": "Flying"
+      }
+    ]
+  },
+  {
+    "no": "0724",
+    "name_jpn": "ジュナイパー",
+    "name_eng": "Decidueye",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  },
+  {
+    "no": "0725",
+    "name_jpn": "ニャビー",
+    "name_eng": "Litten",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      }
+    ]
+  },
+  {
+    "no": "0726",
+    "name_jpn": "ニャヒート",
+    "name_eng": "Torracat",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      }
+    ]
+  },
+  {
+    "no": "0727",
+    "name_jpn": "ガオガエン",
+    "name_eng": "Incineroar",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      },
+      {
+        "jpn": "あく",
+        "eng": "Dark"
+      }
+    ]
+  },
+  {
+    "no": "0728",
+    "name_jpn": "アシマリ",
+    "name_eng": "Popplio",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0729",
+    "name_jpn": "オシャマリ",
+    "name_eng": "Brionne",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0730",
+    "name_jpn": "アシレーヌ",
+    "name_eng": "Primarina",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "フェアリー",
+        "eng": "Fairy"
+      }
+    ]
+  },
+  {
+    "no": "0810",
+    "name_jpn": "サルノリ",
+    "name_eng": "Grookey",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0811",
+    "name_jpn": "バチンキー",
+    "name_eng": "Thwackey",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0812",
+    "name_jpn": "ゴリランダー",
+    "name_eng": "Rillaboom",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      }
+    ]
+  },
+  {
+    "no": "0813",
+    "name_jpn": "ヒバニー",
+    "name_eng": "Scorbunny",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      }
+    ]
+  },
+  {
+    "no": "0814",
+    "name_jpn": "ラビフット",
+    "name_eng": "Raboot",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      }
+    ]
+  },
+  {
+    "no": "0815",
+    "name_jpn": "エースバーン",
+    "name_eng": "Cinderace",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      }
+    ]
+  },
+  {
+    "no": "0816",
+    "name_jpn": "メッソン",
+    "name_eng": "Sobble",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0817",
+    "name_jpn": "ジメレオン",
+    "name_eng": "Drizzile",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "0818",
+    "name_jpn": "インテレオン",
+    "name_eng": "Inteleon",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      }
+    ]
+  },
+  {
+    "no": "1020",
+    "name_jpn": "ウガツホムラ",
+    "name_eng": "Gouging Fire",
+    "types": [
+      {
+        "jpn": "ほのお",
+        "eng": "Fire"
+      },
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "1021",
+    "name_jpn": "タケルライコ",
+    "name_eng": "Raging Bolt",
+    "types": [
+      {
+        "jpn": "でんき",
+        "eng": "Electric"
+      },
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "1023",
+    "name_jpn": "テツノカシラ",
+    "name_eng": "Iron Crown",
+    "types": [
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      },
+      {
+        "jpn": "はがね",
+        "eng": "Steel"
+      }
+    ]
+  },
+  {
+    "no": "1022",
+    "name_jpn": "テツノイワオ",
+    "name_eng": "Iron Boulder",
+    "types": [
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      },
+      {
+        "jpn": "いわ",
+        "eng": "Rock"
+      }
+    ]
+  },
+  {
+    "no": "1024",
+    "name_jpn": "テラパゴス",
+    "name_eng": "Terapagos",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "1024",
+    "name_jpn": "テラパゴス",
+    "name_eng": "Terapagos",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "1024",
+    "name_jpn": "テラパゴス",
+    "name_eng": "Terapagos",
+    "types": [
+      {
+        "jpn": "ノーマル",
+        "eng": "Normal"
+      }
+    ]
+  },
+  {
+    "no": "1009",
+    "name_jpn": "ウネルミナモ",
+    "name_eng": "Walking Wake",
+    "types": [
+      {
+        "jpn": "みず",
+        "eng": "Water"
+      },
+      {
+        "jpn": "ドラゴン",
+        "eng": "Dragon"
+      }
+    ]
+  },
+  {
+    "no": "1010",
+    "name_jpn": "テツノイサハ",
+    "name_eng": "Iron Leaves",
+    "types": [
+      {
+        "jpn": "くさ",
+        "eng": "Grass"
+      },
+      {
+        "jpn": "エスパー",
+        "eng": "Psychic"
+      }
+    ]
+  },
+  {
+    "no": "1025",
+    "name_jpn": "モモワロウ",
+    "name_eng": "Pecharunt",
+    "types": [
+      {
+        "jpn": "どく",
+        "eng": "Poison"
+      },
+      {
+        "jpn": "ゴースト",
+        "eng": "Ghost"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
## 概要

マンホール詳細ページを「写真+場所情報」から「Pokemon Discovery ページ」に進化させ、SEO強化・多言語対応・内部回遊導線を追加しました。

## 主な変更

### 1. Pokemonメタデータ統合
- `pokemon_metadata.json` (479KB, 1025エントリー) を非同期読み込み
- メタデータ取得失敗時も既存機能は正常動作（graceful degradation）

### 2. Pokemon Info Card
```
ロコン / Vulpix

タイプ: ほのお (Fire)
世代: 第1世代
Vulpix / 식스테일 / 六尾
```

- タイプをバイリンガルバッジで表示
- 世代情報を表示
- 多言語名（英語/韓国語/中国語）を表示
- メタデータがない場合は非表示

### 3. 同じポケモンのポケふたセクション
```
同じポケモンのポケふた
・新潟県 小千谷 (コイキング・ギャラドス)
・北海道 恵庭 (ロコン)
・宮城県 石巻 (ラプラス)
```

- 最大5件まで表示
- 自治体名 + Pokemon名で表示
- **重複排除**: マンホールID単位でdedupe
- **自身を除外**: 現在表示中のマンホールは非表示
- 0件の場合はセクションごと非表示
- 都道府県 → 市区町村でソート

### 4. SEO強化

#### Meta Tags
- **Title**: `ロコンのポケふた | 北海道恵庭市 | Pokefuta Map`
- **Description**: `北海道恵庭市にあるロコン（Vulpix）のポケふた。場所・写真・訪問記録を地図で確認できます。`
- **Keywords**: 日本語・英語・韓国語のPokemon名を含む

#### JSON-LD (schema.org)
- Pokemon名の英訳を含むdescription
- 多言語keywordsでSEO強化
- 標準Place schemaに準拠

### 5. UI改善
- upload-banner (sibling-site-banner) 廃止
- travel-friendlyデザイン維持
- モバイルBottom Sheet安定性確保
- CLSなし（カードは既存コンテンツの下に追加）

## 技術仕様

### 安全性
✅ **Non-blocking**: メタデータは非同期読み込み、初期レンダリングをブロックしない  
✅ **Graceful degradation**: メタデータなしでも全機能動作  
✅ **No CLS**: レイアウトシフトなし  
✅ **Error handling**: 全メタデータ操作にtry-catch  
✅ **既存機能保持**: マップ・ポップアップ・フィルタは全て変更なし  

### パフォーマンス
- Pokemon metadata: 479KB (許容範囲)
- メモリ内Map構造で高速lookup
- 初期表示に影響なし

## テスト確認項目

- [x] メタデータなしで既存ポップアップが正常表示
- [x] ロコン: タイプ「ほのお (Fire)」表示
- [x] アローラロコン: タイプ「こおり (Ice)」表示
- [x] 同じPokemonセクションに重複なし
- [x] 自身のマンホールが一覧に出ない
- [x] 0件の場合セクション非表示
- [x] モバイルBottom Sheet安定
- [x] title/descriptionが自然

## 変更ファイル

- `apps/web/index.html`: Pokemon loader, SEO強化, 同じPokemonセクション
- `apps/web/assets/pokefuta-map.css`: Pokemon card & section styling
- `apps/web/pokemon_metadata.json`: 1025 Pokemon entries (新規)
- `docs/pokemon_metadata.json`: ソースデータ (新規)
- `docs/pokemon_types_bilingual.json`: タイプ翻訳データ (新規)

## スクリーンショット

実装例:
- トップページ: http://localhost:8000/
- マンホール詳細: http://localhost:8000/?manhole=1

## SEO効果

- **多言語キーワード**: Vulpix, 식스테일, 六尾 で国際検索対応
- **内部リンク網**: Pokemon軸でのナビゲーション強化
- **リッチメタタグ**: Pokemon文脈を含む説明文
- **Structured Data**: schema.org Place + Pokemon keywords

## マージ条件

✅ 同じPokemon一覧に重複なし  
✅ 自身のマンホールは一覧に出ない  
✅ 最大5件まで表示  
✅ 0件ならセクション非表示  
✅ 既存ポップアップ表示が正常  

🤖 Generated with [Claude Code](https://claude.com/claude-code)