### PR TITLE
Add SEO-optimized static manhole detail pages

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - 'apps/web/**' # HTML and assets changes
       - 'apps/scraper/generate_sitemap.py' # sitemap generator used during deploy
+      - 'apps/scraper/generate_manhole_pages.py' # manhole page generator
       - 'docs/**'     # dataset changes copied into dist/
       - 'dataset/manhole/image/**' # local popup photos
 
@@ -34,7 +35,9 @@ jobs:
         run: |
           set -e
           mkdir -p dist/assets
-          echo "[dist] Generate sitemap with manhole photo URLs"
+          echo "[dist] Generate static manhole detail pages"
+          python3 apps/scraper/generate_manhole_pages.py
+          echo "[dist] Generate sitemap with manhole URLs"
           python3 apps/scraper/generate_sitemap.py
           echo "[dist] Copy HTML sources"
           cp apps/web/index.html dist/index.html
@@ -54,6 +57,7 @@ jobs:
           cp docs/pokefuta.ndjson dist/pokefuta.ndjson || true
           cp docs/gmanhole.ndjson dist/gmanhole.ndjson || true
           cp docs/latest-manhole-photos.json dist/latest-manhole-photos.json
+          cp docs/pokemon_metadata.json dist/pokemon_metadata.json || true
           echo "[dist] Listing dist contents"
           find dist -maxdepth 2 -type f -print | sort
 

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -46,7 +46,6 @@ jobs:
           cp apps/web/nearby_manholes.html dist/nearby.html
           cp apps/web/gmanhole_map.html dist/gmanhole_map.html
           cp apps/web/sitemap.xml dist/sitemap.xml
-          cp docs/latest-manhole-photos.json dist/latest-manhole-photos.json
           echo '<!doctype html><meta http-equiv="refresh" content="0; url=./nearby.html">' > dist/nearby_manholes.html
           echo "[dist] Copy assets (CSS + images)"
           cp -r apps/web/assets/* dist/assets/ || true

--- a/apps/scraper/generate_manhole_pages.py
+++ b/apps/scraper/generate_manhole_pages.py
@@ -491,7 +491,8 @@ def generate_all_pages(
     manholes: list[dict],
     photos: dict[str, dict],
     pokemon_meta: dict[str, dict],
-    output_dir: Path
+    output_dir: Path,
+    image_dir: Path,
 ) -> tuple[int, int, int]:
     """Generate HTML pages for all manholes.
 
@@ -510,6 +511,13 @@ def generate_all_pages(
 
         norm_id = normalize_id(manhole_id)
         photo = photos.get(norm_id)
+
+        # Prefer local repo image over Cloudflare URL when available
+        local_image = image_dir / f"{manhole_id}_latest.jpeg"
+        if local_image.exists():
+            local_url = f"{BASE_URL}manhole/image/{manhole_id}_latest.jpeg"
+            photo = dict(photo or {}, url=local_url)
+            logger.debug(f"Using local image for manhole {manhole_id}")
 
         if photo:
             photos_applied += 1
@@ -548,6 +556,11 @@ def main() -> int:
         help="Path to Pokemon metadata JSON file"
     )
     parser.add_argument(
+        "--image-dir",
+        default="dataset/manhole/image",
+        help="Directory containing {id}_latest.jpeg local images"
+    )
+    parser.add_argument(
         "--output",
         default="dist",
         help="Output directory (will create manholes/ subdirectory)"
@@ -578,7 +591,7 @@ def main() -> int:
     output_dir.mkdir(parents=True, exist_ok=True)
 
     total, photos_applied, photos_missing = generate_all_pages(
-        manholes, photos, pokemon_meta, output_dir
+        manholes, photos, pokemon_meta, output_dir, Path(args.image_dir)
     )
 
     print(f"[generate_manhole_pages] total manholes: {len(manholes)}")

--- a/apps/scraper/generate_manhole_pages.py
+++ b/apps/scraper/generate_manhole_pages.py
@@ -9,6 +9,7 @@ photos, Pokemon metadata, and CTAs for map navigation with GA4 tracking.
 from __future__ import annotations
 
 import argparse
+import datetime
 import json
 import logging
 from pathlib import Path
@@ -221,8 +222,10 @@ def generate_html(manhole: dict, photo: Optional[dict], pokemon_meta: dict[str, 
             "longitude": lng
         }
 
-    if photo and photo.get("url"):
-        jsonld["image"] = photo["url"]
+    if photo:
+        photo_image_url = photo.get("url") or photo.get("original_url")
+        if photo_image_url:
+            jsonld["image"] = photo_image_url
 
     jsonld_str = json.dumps(jsonld, ensure_ascii=False, indent=2)
 
@@ -234,6 +237,15 @@ def generate_html(manhole: dict, photo: Optional[dict], pokemon_meta: dict[str, 
   <a href="{escape(detail_url)}" target="_blank" rel="noopener noreferrer">公式サイトを見る</a>
 </p>
 """
+
+    # Safely serialize GA event params for inline onclick attribute.
+    # json.dumps handles all JS special chars; escape() makes the JSON safe
+    # inside an HTML double-quoted attribute (browser decodes &quot; before eval).
+    onclick_params = escape(json.dumps(
+        {"manhole_id": manhole_id, "prefecture": prefecture, "city": city},
+        ensure_ascii=False,
+    ))
+    current_year = datetime.date.today().year
 
     # Complete HTML
     html = f"""<!doctype html>
@@ -443,7 +455,7 @@ def generate_html(manhole: dict, photo: Optional[dict], pokemon_meta: dict[str, 
   <div class="container">
     <h1>{escape(h1)}</h1>
 
-    <a href="{escape(map_url)}" class="cta-primary" onclick="trackEvent('manhole_seo_to_map_click', {{manhole_id: '{escape(manhole_id)}', prefecture: '{escape(prefecture)}', city: '{escape(city)}'}})">
+    <a href="{escape(map_url)}" class="cta-primary" onclick="trackEvent('manhole_seo_to_map_click', {onclick_params})">
       📍 地図でこのポケふたを見る
     </a>
 
@@ -464,7 +476,7 @@ def generate_html(manhole: dict, photo: Optional[dict], pokemon_meta: dict[str, 
     {official_html}
 
     <footer>
-      <p>&copy; 2024-2026 data.pokefuta.com | ポケふた情報はポケモン公式サイトを参照しています</p>
+      <p>&copy; 2024-{current_year} data.pokefuta.com | ポケふた情報はポケモン公式サイトを参照しています</p>
     </footer>
   </div>
 </body>

--- a/apps/scraper/generate_manhole_pages.py
+++ b/apps/scraper/generate_manhole_pages.py
@@ -1,0 +1,580 @@
+#!/usr/bin/env python3
+"""Generate static SEO-optimized HTML pages for individual manholes.
+
+This script creates /manholes/{id}/index.html for each manhole in the dataset.
+Each page includes unique title, description, h1, canonical URL, JSON-LD,
+photos, Pokemon metadata, and CTAs for map navigation with GA4 tracking.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Any, Optional
+from urllib.parse import quote
+from xml.sax.saxutils import escape
+
+# Constants
+BASE_URL = "https://data.pokefuta.com/"
+GA_MEASUREMENT_ID = "G-K18NR4GZG2"
+
+logger = logging.getLogger(__name__)
+
+
+def normalize_id(value: Any) -> str:
+    """Normalize manhole ID for consistent joining across datasets."""
+    if value is None:
+        return ""
+    s = str(value).strip()
+    # Remove leading zeros for comparison but keep original format
+    return s.lstrip('0') or '0'
+
+
+def load_manholes(path: Path) -> list[dict]:
+    """Load manholes from NDJSON file."""
+    manholes = []
+    if not path.exists():
+        logger.warning(f"Manhole data file not found: {path}")
+        return manholes
+
+    for line_num, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if not line.strip():
+            continue
+        try:
+            record = json.loads(line)
+            manholes.append(record)
+        except json.JSONDecodeError as e:
+            logger.warning(f"Failed to parse line {line_num}: {e}")
+
+    logger.info(f"Loaded {len(manholes)} manholes from {path}")
+    return manholes
+
+
+def load_photos(path: Path) -> dict[str, dict]:
+    """Load manhole photos data."""
+    if not path.exists():
+        logger.warning(f"Photos file not found: {path}")
+        return {}
+
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        photos = data.get("photos", {})
+        logger.info(f"Loaded {len(photos)} photo entries from {path}")
+
+        # Normalize keys
+        normalized = {}
+        for manhole_id, photo_data in photos.items():
+            norm_id = normalize_id(manhole_id)
+            normalized[norm_id] = photo_data
+
+        return normalized
+    except json.JSONDecodeError as e:
+        logger.error(f"Failed to parse photos JSON: {e}")
+        return {}
+
+
+def load_pokemon_metadata(path: Path) -> dict[str, dict]:
+    """Load Pokemon metadata indexed by Japanese name."""
+    if not path.exists():
+        logger.warning(f"Pokemon metadata file not found: {path}")
+        return {}
+
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        # Index by Japanese name for quick lookup
+        metadata = {}
+        for pokemon in data:
+            if isinstance(pokemon, dict):
+                names = pokemon.get("names", {})
+                ja_name = names.get("ja", "")
+                if ja_name:
+                    metadata[ja_name] = pokemon
+
+        logger.info(f"Loaded metadata for {len(metadata)} Pokemon")
+        return metadata
+    except json.JSONDecodeError as e:
+        logger.error(f"Failed to parse Pokemon metadata: {e}")
+        return {}
+
+
+def filter_pokemons(pokemons: list) -> list[str]:
+    """Filter out prefecture site links from Pokemon list."""
+    if not isinstance(pokemons, list):
+        return []
+
+    return [
+        p for p in pokemons
+        if isinstance(p, str) and p.strip() and "ローカルActs" not in p
+    ]
+
+
+def generate_html(manhole: dict, photo: Optional[dict], pokemon_meta: dict[str, dict]) -> str:
+    """Generate complete HTML for a manhole detail page."""
+    manhole_id = str(manhole.get("id", "")).strip()
+    prefecture = manhole.get("prefecture", "")
+    city = manhole.get("city", "")
+    address = manhole.get("address", "")
+    pokemons = filter_pokemons(manhole.get("pokemons", []))
+    detail_url = manhole.get("detail_url", "")
+    lat = manhole.get("lat")
+    lng = manhole.get("lng")
+
+    # Generate unique title and description
+    pokemon_text = "・".join(pokemons) if pokemons else "ポケモン"
+
+    title = f"{prefecture}{city}のポケふた｜{pokemon_text} | data.pokefuta.com"
+
+    description = (
+        f"{prefecture}{city}に設置されているポケふた。"
+        f"{pokemon_text}が描かれています。"
+        f"場所・写真・地図・周辺のポケふた情報を掲載。"
+    )
+
+    h1 = f"{prefecture}{city}のポケふた"
+    if pokemons:
+        h1 += f"（{pokemon_text}）"
+
+    canonical_url = f"{BASE_URL}manholes/{quote(manhole_id)}/"
+    map_url = f"{BASE_URL}?manhole={quote(manhole_id)}"
+    pref_url = f"{BASE_URL}?pref={quote(prefecture)}"
+
+    # Build Pokemon info with metadata
+    pokemon_info_html = ""
+    if pokemons:
+        pokemon_info_html = "<section class='pokemon-section'><h2>登場ポケモン</h2><div class='pokemon-list'>"
+        for poke_name in pokemons:
+            meta = pokemon_meta.get(poke_name, {})
+            names = meta.get("names", {})
+            en_name = names.get("en", "")
+            types_data = meta.get("types", [])
+            types_ja = [t.get("ja", "") for t in types_data if isinstance(t, dict)]
+            generation = meta.get("generation")
+
+            pokemon_info_html += f"<div class='pokemon-card'>"
+            pokemon_info_html += f"<h3>{escape(poke_name)}</h3>"
+            if en_name:
+                pokemon_info_html += f"<p class='en-name'>{escape(en_name)}</p>"
+            if types_ja:
+                pokemon_info_html += f"<p class='types'>タイプ: {escape('・'.join(types_ja))}</p>"
+            if generation:
+                pokemon_info_html += f"<p class='generation'>第{generation}世代</p>"
+            pokemon_info_html += "</div>"
+
+        pokemon_info_html += "</div></section>"
+
+    # Photo section
+    photo_html = ""
+    og_image = f"{BASE_URL}assets/ogp/pokefuta_map_ogp.png"
+
+    if photo:
+        photo_url = photo.get("url", "") or photo.get("original_url", "")
+        if photo_url:
+            og_image = photo_url
+            photo_html = f"""
+<section class='photo-section'>
+  <h2>写真</h2>
+  <img src="{escape(photo_url)}" alt="{escape(h1)}の写真" loading="lazy">
+</section>
+"""
+
+    # Location info
+    location_html = f"""
+<section class='location-section'>
+  <h2>設置場所</h2>
+  <dl>
+    <dt>都道府県</dt>
+    <dd>{escape(prefecture)}</dd>
+    <dt>市区町村</dt>
+    <dd>{escape(city)}</dd>
+"""
+    if address:
+        location_html += f"""
+    <dt>住所</dt>
+    <dd>{escape(address)}</dd>
+"""
+    location_html += """
+  </dl>
+</section>
+"""
+
+    # JSON-LD structured data
+    jsonld = {
+        "@context": "https://schema.org",
+        "@type": "TouristAttraction",
+        "name": h1,
+        "description": description,
+        "url": canonical_url,
+        "address": {
+            "@type": "PostalAddress",
+            "addressRegion": prefecture,
+            "addressLocality": city,
+            "streetAddress": address
+        }
+    }
+
+    if lat and lng:
+        jsonld["geo"] = {
+            "@type": "GeoCoordinates",
+            "latitude": lat,
+            "longitude": lng
+        }
+
+    if photo and photo.get("url"):
+        jsonld["image"] = photo["url"]
+
+    jsonld_str = json.dumps(jsonld, ensure_ascii=False, indent=2)
+
+    # Official site link (if available)
+    official_html = ""
+    if detail_url and "local.pokemon.jp" in detail_url:
+        official_html = f"""
+<p class='official-link'>
+  <a href="{escape(detail_url)}" target="_blank" rel="noopener noreferrer">公式サイトを見る</a>
+</p>
+"""
+
+    # Complete HTML
+    html = f"""<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{escape(title)}</title>
+  <meta name="description" content="{escape(description)}">
+  <meta name="robots" content="index,follow">
+  <link rel="canonical" href="{escape(canonical_url)}">
+
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="ja_JP">
+  <meta property="og:title" content="{escape(title)}">
+  <meta property="og:description" content="{escape(description)}">
+  <meta property="og:url" content="{escape(canonical_url)}">
+  <meta property="og:image" content="{escape(og_image)}">
+
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="{escape(title)}">
+  <meta name="twitter:description" content="{escape(description)}">
+  <meta name="twitter:image" content="{escape(og_image)}">
+
+  <script type="application/ld+json">
+{jsonld_str}
+  </script>
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id={GA_MEASUREMENT_ID}"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){{dataLayer.push(arguments);}}
+    gtag('js', new Date());
+    gtag('config', '{GA_MEASUREMENT_ID}', {{
+      'page_path': '/manholes/{escape(manhole_id)}/'
+    }});
+
+    function trackEvent(action, params) {{
+      gtag('event', action, params);
+    }}
+  </script>
+
+  <style>
+    * {{
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }}
+
+    body {{
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+      line-height: 1.6;
+      color: #333;
+      background: #f5f5f5;
+      padding: 16px;
+    }}
+
+    .container {{
+      max-width: 800px;
+      margin: 0 auto;
+      background: white;
+      border-radius: 8px;
+      padding: 24px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    }}
+
+    h1 {{
+      font-size: 24px;
+      margin-bottom: 16px;
+      color: #1a1a1a;
+    }}
+
+    h2 {{
+      font-size: 20px;
+      margin: 24px 0 12px;
+      padding-bottom: 8px;
+      border-bottom: 2px solid #e0e0e0;
+    }}
+
+    h3 {{
+      font-size: 18px;
+      margin-bottom: 8px;
+    }}
+
+    .cta-primary {{
+      display: block;
+      background: #dc3545;
+      color: white;
+      text-align: center;
+      padding: 16px 24px;
+      border-radius: 8px;
+      text-decoration: none;
+      font-size: 18px;
+      font-weight: bold;
+      margin: 24px 0;
+      transition: background 0.2s;
+    }}
+
+    .cta-primary:hover {{
+      background: #c82333;
+    }}
+
+    .cta-secondary {{
+      display: inline-block;
+      background: #007bff;
+      color: white;
+      padding: 12px 20px;
+      border-radius: 6px;
+      text-decoration: none;
+      margin: 8px 8px 8px 0;
+      transition: background 0.2s;
+    }}
+
+    .cta-secondary:hover {{
+      background: #0056b3;
+    }}
+
+    .photo-section img {{
+      max-width: 100%;
+      height: auto;
+      border-radius: 8px;
+      margin-top: 12px;
+    }}
+
+    .pokemon-list {{
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+      gap: 16px;
+      margin-top: 12px;
+    }}
+
+    .pokemon-card {{
+      background: #f8f9fa;
+      padding: 16px;
+      border-radius: 8px;
+      border: 1px solid #e0e0e0;
+    }}
+
+    .pokemon-card .en-name {{
+      color: #666;
+      font-size: 14px;
+    }}
+
+    .pokemon-card .types,
+    .pokemon-card .generation {{
+      font-size: 14px;
+      margin-top: 4px;
+    }}
+
+    dl {{
+      margin-top: 12px;
+    }}
+
+    dt {{
+      font-weight: bold;
+      margin-top: 8px;
+    }}
+
+    dd {{
+      margin-left: 16px;
+      color: #555;
+    }}
+
+    .official-link {{
+      margin-top: 16px;
+    }}
+
+    .official-link a {{
+      color: #007bff;
+      text-decoration: none;
+    }}
+
+    .official-link a:hover {{
+      text-decoration: underline;
+    }}
+
+    footer {{
+      margin-top: 32px;
+      padding-top: 16px;
+      border-top: 1px solid #e0e0e0;
+      text-align: center;
+      color: #666;
+      font-size: 14px;
+    }}
+
+    @media (max-width: 600px) {{
+      body {{
+        padding: 8px;
+      }}
+
+      .container {{
+        padding: 16px;
+      }}
+
+      h1 {{
+        font-size: 20px;
+      }}
+
+      .pokemon-list {{
+        grid-template-columns: 1fr;
+      }}
+    }}
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>{escape(h1)}</h1>
+
+    <a href="{escape(map_url)}" class="cta-primary" onclick="trackEvent('manhole_seo_to_map_click', {{manhole_id: '{escape(manhole_id)}', prefecture: '{escape(prefecture)}', city: '{escape(city)}'}})">
+      📍 地図でこのポケふたを見る
+    </a>
+
+    {photo_html}
+
+    {pokemon_info_html}
+
+    {location_html}
+
+    <section class='navigation-section'>
+      <h2>他のポケふたを見る</h2>
+      <p>
+        <a href="{escape(pref_url)}" class="cta-secondary">同じ都道府県のポケふたを見る</a>
+        <a href="{BASE_URL}" class="cta-secondary">全国マップを見る</a>
+      </p>
+    </section>
+
+    {official_html}
+
+    <footer>
+      <p>&copy; 2024-2026 data.pokefuta.com | ポケふた情報はポケモン公式サイトを参照しています</p>
+    </footer>
+  </div>
+</body>
+</html>
+"""
+
+    return html
+
+
+def generate_all_pages(
+    manholes: list[dict],
+    photos: dict[str, dict],
+    pokemon_meta: dict[str, dict],
+    output_dir: Path
+) -> tuple[int, int, int]:
+    """Generate HTML pages for all manholes.
+
+    Returns:
+        (total_generated, photos_applied, photos_missing)
+    """
+    total = 0
+    photos_applied = 0
+    photos_missing = 0
+
+    for manhole in manholes:
+        manhole_id = str(manhole.get("id", "")).strip()
+        if not manhole_id:
+            logger.warning("Skipping manhole with missing ID")
+            continue
+
+        norm_id = normalize_id(manhole_id)
+        photo = photos.get(norm_id)
+
+        if photo:
+            photos_applied += 1
+        else:
+            photos_missing += 1
+            logger.debug(f"No photo found for manhole {manhole_id} (normalized: {norm_id})")
+
+        html = generate_html(manhole, photo, pokemon_meta)
+
+        page_dir = output_dir / "manholes" / manhole_id
+        page_dir.mkdir(parents=True, exist_ok=True)
+
+        index_file = page_dir / "index.html"
+        index_file.write_text(html, encoding="utf-8")
+
+        total += 1
+
+    return total, photos_applied, photos_missing
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--manholes",
+        default="docs/pokefuta.ndjson",
+        help="Path to manholes NDJSON file"
+    )
+    parser.add_argument(
+        "--photos",
+        default="docs/latest-manhole-photos.json",
+        help="Path to photos JSON file"
+    )
+    parser.add_argument(
+        "--pokemon",
+        default="docs/pokemon_metadata.json",
+        help="Path to Pokemon metadata JSON file"
+    )
+    parser.add_argument(
+        "--output",
+        default="dist",
+        help="Output directory (will create manholes/ subdirectory)"
+    )
+    parser.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        help="Logging level"
+    )
+
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(levelname)s: %(message)s"
+    )
+
+    manholes = load_manholes(Path(args.manholes))
+    if not manholes:
+        logger.error("No manholes loaded, exiting")
+        return 1
+
+    photos = load_photos(Path(args.photos))
+    pokemon_meta = load_pokemon_metadata(Path(args.pokemon))
+
+    output_dir = Path(args.output)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    total, photos_applied, photos_missing = generate_all_pages(
+        manholes, photos, pokemon_meta, output_dir
+    )
+
+    print(f"[generate_manhole_pages] total manholes: {len(manholes)}")
+    print(f"[generate_manhole_pages] generated manhole pages: {total}")
+    print(f"[generate_manhole_pages] photo applied: {photos_applied}")
+    print(f"[generate_manhole_pages] photo missing: {photos_missing}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/scraper/generate_manhole_pages.py
+++ b/apps/scraper/generate_manhole_pages.py
@@ -14,7 +14,7 @@ import json
 import logging
 from pathlib import Path
 from typing import Any, Optional
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 from xml.sax.saxutils import escape
 
 # Constants
@@ -215,7 +215,7 @@ def generate_html(manhole: dict, photo: Optional[dict], pokemon_meta: dict[str, 
         }
     }
 
-    if lat and lng:
+    if lat is not None and lng is not None:
         jsonld["geo"] = {
             "@type": "GeoCoordinates",
             "latitude": lat,
@@ -231,7 +231,8 @@ def generate_html(manhole: dict, photo: Optional[dict], pokemon_meta: dict[str, 
 
     # Official site link (if available)
     official_html = ""
-    if detail_url and "local.pokemon.jp" in detail_url:
+    _parsed = urlparse(detail_url) if detail_url else None
+    if _parsed and _parsed.scheme == "https" and _parsed.hostname == "local.pokemon.jp":
         official_html = f"""
 <p class='official-link'>
   <a href="{escape(detail_url)}" target="_blank" rel="noopener noreferrer">公式サイトを見る</a>

--- a/apps/scraper/generate_sitemap.py
+++ b/apps/scraper/generate_sitemap.py
@@ -64,10 +64,11 @@ PREFECTURES = [
 ]
 
 
-def read_known_manhole_ids(path: Path) -> Optional[set[str]]:
-    ids: set[str] = set()
+def read_all_manhole_ids(path: Path) -> list[str]:
+    """Read all manhole IDs from the dataset."""
+    ids = []
     if not path.exists():
-        return None
+        return ids
 
     for line in path.read_text(encoding="utf-8").splitlines():
         if not line.strip():
@@ -78,19 +79,8 @@ def read_known_manhole_ids(path: Path) -> Optional[set[str]]:
             continue
         manhole_id = str(record.get("id") or "").strip()
         if manhole_id:
-            ids.add(manhole_id)
-    return ids
-
-
-def read_photo_manhole_ids(image_dir: Path, known_ids: Optional[set[str]]) -> list[str]:
-    if not image_dir.exists():
-        return []
-
-    ids = []
-    for image_path in image_dir.glob("*_latest.jpeg"):
-        manhole_id = image_path.name.removesuffix("_latest.jpeg").strip()
-        if manhole_id and (known_ids is None or manhole_id in known_ids):
             ids.append(manhole_id)
+
     return sorted(set(ids), key=lambda value: (len(value), value))
 
 
@@ -106,7 +96,7 @@ def url_entry(loc: str, changefreq: str, priority: str) -> str:
     )
 
 
-def build_sitemap(photo_ids: list[str]) -> str:
+def build_sitemap(manhole_ids: list[str]) -> str:
     entries = [
         url_entry(BASE_URL, "daily", "1.0"),
         url_entry(f"{BASE_URL}summary", "weekly", "0.8"),
@@ -119,9 +109,10 @@ def build_sitemap(photo_ids: list[str]) -> str:
             url_entry(f"{BASE_URL}?pref={quote(prefecture)}", "weekly", "0.7")
         )
 
-    for manhole_id in photo_ids:
+    # Add static manhole detail pages (primary SEO target)
+    for manhole_id in manhole_ids:
         entries.append(
-            url_entry(f"{BASE_URL}?manhole={quote(manhole_id)}", "weekly", "0.8")
+            url_entry(f"{BASE_URL}manholes/{quote(manhole_id)}/", "weekly", "0.8")
         )
 
     return "\n".join(
@@ -138,16 +129,18 @@ def build_sitemap(photo_ids: list[str]) -> str:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--data", default="docs/pokefuta.ndjson")
-    parser.add_argument("--image-dir", default="dataset/manhole/image")
     parser.add_argument("--output", default="apps/web/sitemap.xml")
     args = parser.parse_args()
 
-    known_ids = read_known_manhole_ids(Path(args.data))
-    photo_ids = read_photo_manhole_ids(Path(args.image_dir), known_ids)
+    manhole_ids = read_all_manhole_ids(Path(args.data))
+    if not manhole_ids:
+        print("No manhole IDs found in dataset")
+        return 1
+
     output_path = Path(args.output)
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(build_sitemap(photo_ids), encoding="utf-8")
-    print(f"wrote {output_path} with {len(photo_ids)} manhole photo URLs")
+    output_path.write_text(build_sitemap(manhole_ids), encoding="utf-8")
+    print(f"[generate_sitemap] wrote {output_path} with {len(manhole_ids)} manhole URLs")
     return 0
 
 

--- a/apps/scraper/generate_sitemap.py
+++ b/apps/scraper/generate_sitemap.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
-from typing import Optional
 from urllib.parse import quote
 from xml.sax.saxutils import escape
 

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -540,6 +540,7 @@
       cityLabel: '市町村:',
       officialDetail: '📝 公式詳細',
       officialDetailCta: '公式詳細を見る',
+      detailPageCta: '詳細ページを見る',
       prefectureSite: 'サイト'
     };
 
@@ -548,19 +549,6 @@
 
     // Validate prefecture site URL (whitelist check)
     function validatePrefectureSiteUrl(rawUrl) {
-      try {
-        const url = new URL(rawUrl);
-        const allowedHost = 'local.pokemon.jp';
-        if (url.protocol === 'https:' && url.hostname === allowedHost) {
-          return url;
-        }
-      } catch {
-        return null;
-      }
-      return null;
-    }
-
-    function validateDetailUrl(rawUrl) {
       try {
         const url = new URL(rawUrl);
         const allowedHost = 'local.pokemon.jp';
@@ -730,7 +718,7 @@
         const anchor = document.createElement('a');
         anchor.href = manholeDetailUrl;
         anchor.className = 'travel-popup-action travel-popup-action--primary';
-        anchor.textContent = '詳細ページを見る';
+        anchor.textContent = UI_TEXT.detailPageCta;
         const safeTitleJs = escapeJs(d.title || d.id);
         const safeIdJs = escapeJs(d.id);
         anchor.setAttribute('onclick', `if(window.trackEvent){window.trackEvent('click_detail_page',{event_category:'navigation',event_label:'${safeTitleJs}',manhole_id:'${safeIdJs}'});}`);

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -725,21 +725,16 @@
         }
         return '';
       })() : '';
-      const officialDetailLink = d.detail_url ? (function() {
-        const validatedUrl = validateDetailUrl(d.detail_url);
-        if (validatedUrl) {
-          const anchor = document.createElement('a');
-          anchor.href = validatedUrl.href;
-          anchor.target = '_blank';
-          anchor.rel = 'noopener noreferrer';
-          anchor.className = 'travel-popup-action travel-popup-action--primary';
-          anchor.textContent = UI_TEXT.officialDetailCta;
-          const safeTitleJs = escapeJs(d.title || d.id);
-          const safeIdJs = escapeJs(d.id);
-          anchor.setAttribute('onclick', `if(window.trackEvent){window.trackEvent('click_official_link',{event_category:'outbound',event_label:'${safeTitleJs}',manhole_id:'${safeIdJs}'});}`);
-          return anchor.outerHTML;
-        }
-        return '';
+      const officialDetailLink = d.id ? (function() {
+        const manholeDetailUrl = `${window.SITE_BASE_URL}manholes/${encodeURIComponent(d.id)}/`;
+        const anchor = document.createElement('a');
+        anchor.href = manholeDetailUrl;
+        anchor.className = 'travel-popup-action travel-popup-action--primary';
+        anchor.textContent = '詳細ページを見る';
+        const safeTitleJs = escapeJs(d.title || d.id);
+        const safeIdJs = escapeJs(d.id);
+        anchor.setAttribute('onclick', `if(window.trackEvent){window.trackEvent('click_detail_page',{event_category:'navigation',event_label:'${safeTitleJs}',manhole_id:'${safeIdJs}'});}`);
+        return anchor.outerHTML;
       })() : '';
       const links = [
         officialDetailLink,

--- a/apps/web/sitemap.xml
+++ b/apps/web/sitemap.xml
@@ -256,572 +256,2352 @@
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=23</loc>
+    <loc>https://data.pokefuta.com/manholes/1/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=59</loc>
+    <loc>https://data.pokefuta.com/manholes/2/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=60</loc>
+    <loc>https://data.pokefuta.com/manholes/3/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=61</loc>
+    <loc>https://data.pokefuta.com/manholes/4/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=62</loc>
+    <loc>https://data.pokefuta.com/manholes/5/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=63</loc>
+    <loc>https://data.pokefuta.com/manholes/6/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=64</loc>
+    <loc>https://data.pokefuta.com/manholes/7/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=65</loc>
+    <loc>https://data.pokefuta.com/manholes/8/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=66</loc>
+    <loc>https://data.pokefuta.com/manholes/9/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=67</loc>
+    <loc>https://data.pokefuta.com/manholes/10/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=68</loc>
+    <loc>https://data.pokefuta.com/manholes/11/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=69</loc>
+    <loc>https://data.pokefuta.com/manholes/12/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=70</loc>
+    <loc>https://data.pokefuta.com/manholes/13/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=71</loc>
+    <loc>https://data.pokefuta.com/manholes/14/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=74</loc>
+    <loc>https://data.pokefuta.com/manholes/15/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=78</loc>
+    <loc>https://data.pokefuta.com/manholes/16/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=79</loc>
+    <loc>https://data.pokefuta.com/manholes/17/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=105</loc>
+    <loc>https://data.pokefuta.com/manholes/18/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=140</loc>
+    <loc>https://data.pokefuta.com/manholes/19/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=142</loc>
+    <loc>https://data.pokefuta.com/manholes/20/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=143</loc>
+    <loc>https://data.pokefuta.com/manholes/21/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=148</loc>
+    <loc>https://data.pokefuta.com/manholes/22/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=149</loc>
+    <loc>https://data.pokefuta.com/manholes/23/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=151</loc>
+    <loc>https://data.pokefuta.com/manholes/28/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=174</loc>
+    <loc>https://data.pokefuta.com/manholes/29/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=175</loc>
+    <loc>https://data.pokefuta.com/manholes/30/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=176</loc>
+    <loc>https://data.pokefuta.com/manholes/31/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=187</loc>
+    <loc>https://data.pokefuta.com/manholes/32/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=188</loc>
+    <loc>https://data.pokefuta.com/manholes/33/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=192</loc>
+    <loc>https://data.pokefuta.com/manholes/34/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=193</loc>
+    <loc>https://data.pokefuta.com/manholes/35/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=214</loc>
+    <loc>https://data.pokefuta.com/manholes/36/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=217</loc>
+    <loc>https://data.pokefuta.com/manholes/37/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=218</loc>
+    <loc>https://data.pokefuta.com/manholes/38/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=219</loc>
+    <loc>https://data.pokefuta.com/manholes/39/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=220</loc>
+    <loc>https://data.pokefuta.com/manholes/40/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=229</loc>
+    <loc>https://data.pokefuta.com/manholes/41/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=240</loc>
+    <loc>https://data.pokefuta.com/manholes/42/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=241</loc>
+    <loc>https://data.pokefuta.com/manholes/43/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=242</loc>
+    <loc>https://data.pokefuta.com/manholes/44/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=243</loc>
+    <loc>https://data.pokefuta.com/manholes/45/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=244</loc>
+    <loc>https://data.pokefuta.com/manholes/46/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=246</loc>
+    <loc>https://data.pokefuta.com/manholes/47/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=255</loc>
+    <loc>https://data.pokefuta.com/manholes/48/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=256</loc>
+    <loc>https://data.pokefuta.com/manholes/49/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=257</loc>
+    <loc>https://data.pokefuta.com/manholes/50/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=271</loc>
+    <loc>https://data.pokefuta.com/manholes/51/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=272</loc>
+    <loc>https://data.pokefuta.com/manholes/52/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=273</loc>
+    <loc>https://data.pokefuta.com/manholes/53/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=274</loc>
+    <loc>https://data.pokefuta.com/manholes/54/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=278</loc>
+    <loc>https://data.pokefuta.com/manholes/55/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=292</loc>
+    <loc>https://data.pokefuta.com/manholes/56/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=293</loc>
+    <loc>https://data.pokefuta.com/manholes/57/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=295</loc>
+    <loc>https://data.pokefuta.com/manholes/58/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=296</loc>
+    <loc>https://data.pokefuta.com/manholes/59/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=297</loc>
+    <loc>https://data.pokefuta.com/manholes/60/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=300</loc>
+    <loc>https://data.pokefuta.com/manholes/61/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=301</loc>
+    <loc>https://data.pokefuta.com/manholes/62/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=302</loc>
+    <loc>https://data.pokefuta.com/manholes/63/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=303</loc>
+    <loc>https://data.pokefuta.com/manholes/64/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=304</loc>
+    <loc>https://data.pokefuta.com/manholes/65/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=305</loc>
+    <loc>https://data.pokefuta.com/manholes/66/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=306</loc>
+    <loc>https://data.pokefuta.com/manholes/67/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=307</loc>
+    <loc>https://data.pokefuta.com/manholes/68/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=308</loc>
+    <loc>https://data.pokefuta.com/manholes/69/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=309</loc>
+    <loc>https://data.pokefuta.com/manholes/70/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=310</loc>
+    <loc>https://data.pokefuta.com/manholes/71/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=311</loc>
+    <loc>https://data.pokefuta.com/manholes/72/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=312</loc>
+    <loc>https://data.pokefuta.com/manholes/73/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=313</loc>
+    <loc>https://data.pokefuta.com/manholes/74/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=314</loc>
+    <loc>https://data.pokefuta.com/manholes/75/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=324</loc>
+    <loc>https://data.pokefuta.com/manholes/76/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=330</loc>
+    <loc>https://data.pokefuta.com/manholes/77/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=331</loc>
+    <loc>https://data.pokefuta.com/manholes/78/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=332</loc>
+    <loc>https://data.pokefuta.com/manholes/79/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=334</loc>
+    <loc>https://data.pokefuta.com/manholes/80/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=335</loc>
+    <loc>https://data.pokefuta.com/manholes/81/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=336</loc>
+    <loc>https://data.pokefuta.com/manholes/82/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=338</loc>
+    <loc>https://data.pokefuta.com/manholes/83/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=339</loc>
+    <loc>https://data.pokefuta.com/manholes/84/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=340</loc>
+    <loc>https://data.pokefuta.com/manholes/85/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=341</loc>
+    <loc>https://data.pokefuta.com/manholes/86/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=342</loc>
+    <loc>https://data.pokefuta.com/manholes/87/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=343</loc>
+    <loc>https://data.pokefuta.com/manholes/88/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=344</loc>
+    <loc>https://data.pokefuta.com/manholes/89/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=345</loc>
+    <loc>https://data.pokefuta.com/manholes/90/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=346</loc>
+    <loc>https://data.pokefuta.com/manholes/91/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=347</loc>
+    <loc>https://data.pokefuta.com/manholes/92/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=348</loc>
+    <loc>https://data.pokefuta.com/manholes/93/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=352</loc>
+    <loc>https://data.pokefuta.com/manholes/94/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=353</loc>
+    <loc>https://data.pokefuta.com/manholes/95/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=359</loc>
+    <loc>https://data.pokefuta.com/manholes/96/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=361</loc>
+    <loc>https://data.pokefuta.com/manholes/97/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=362</loc>
+    <loc>https://data.pokefuta.com/manholes/98/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=383</loc>
+    <loc>https://data.pokefuta.com/manholes/99/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=384</loc>
+    <loc>https://data.pokefuta.com/manholes/100/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=385</loc>
+    <loc>https://data.pokefuta.com/manholes/101/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=386</loc>
+    <loc>https://data.pokefuta.com/manholes/102/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=387</loc>
+    <loc>https://data.pokefuta.com/manholes/103/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=388</loc>
+    <loc>https://data.pokefuta.com/manholes/104/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=389</loc>
+    <loc>https://data.pokefuta.com/manholes/105/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=404</loc>
+    <loc>https://data.pokefuta.com/manholes/106/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=405</loc>
+    <loc>https://data.pokefuta.com/manholes/107/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=406</loc>
+    <loc>https://data.pokefuta.com/manholes/108/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=407</loc>
+    <loc>https://data.pokefuta.com/manholes/109/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=408</loc>
+    <loc>https://data.pokefuta.com/manholes/110/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=415</loc>
+    <loc>https://data.pokefuta.com/manholes/111/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=438</loc>
+    <loc>https://data.pokefuta.com/manholes/112/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=439</loc>
+    <loc>https://data.pokefuta.com/manholes/113/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=440</loc>
+    <loc>https://data.pokefuta.com/manholes/114/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=441</loc>
+    <loc>https://data.pokefuta.com/manholes/115/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=442</loc>
+    <loc>https://data.pokefuta.com/manholes/116/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=443</loc>
+    <loc>https://data.pokefuta.com/manholes/117/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/?manhole=444</loc>
+    <loc>https://data.pokefuta.com/manholes/118/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/119/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/120/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/121/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/122/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/123/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/124/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/125/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/126/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/127/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/128/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/129/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/130/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/131/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/132/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/133/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/134/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/135/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/136/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/137/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/138/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/139/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/140/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/141/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/142/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/143/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/144/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/145/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/146/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/147/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/148/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/149/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/150/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/151/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/152/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/153/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/154/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/155/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/156/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/157/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/158/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/159/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/160/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/161/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/162/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/163/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/164/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/165/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/166/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/167/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/168/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/169/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/170/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/171/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/172/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/173/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/174/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/175/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/176/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/177/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/178/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/179/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/180/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/181/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/182/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/183/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/184/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/185/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/186/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/187/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/188/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/189/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/190/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/191/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/192/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/193/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/194/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/195/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/196/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/197/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/198/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/199/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/200/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/201/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/202/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/203/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/204/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/205/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/206/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/207/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/208/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/209/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/210/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/211/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/212/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/213/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/214/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/215/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/216/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/217/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/218/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/219/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/220/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/221/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/222/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/223/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/224/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/225/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/226/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/227/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/228/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/229/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/230/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/231/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/232/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/233/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/234/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/235/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/236/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/237/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/238/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/239/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/240/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/241/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/242/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/243/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/244/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/245/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/246/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/247/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/248/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/249/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/250/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/251/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/252/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/253/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/254/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/255/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/256/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/257/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/258/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/259/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/260/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/261/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/262/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/263/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/264/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/265/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/266/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/267/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/268/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/269/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/270/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/271/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/272/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/273/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/274/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/275/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/276/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/277/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/278/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/279/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/280/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/281/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/282/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/283/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/284/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/285/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/286/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/287/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/288/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/289/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/290/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/291/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/292/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/293/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/294/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/295/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/296/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/297/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/298/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/299/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/300/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/301/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/302/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/303/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/304/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/305/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/306/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/307/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/308/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/309/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/310/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/311/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/312/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/313/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/314/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/315/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/316/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/317/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/318/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/319/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/320/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/321/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/322/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/323/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/324/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/325/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/326/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/327/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/328/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/329/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/330/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/331/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/332/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/333/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/334/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/335/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/336/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/337/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/338/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/339/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/340/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/341/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/342/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/343/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/344/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/345/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/346/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/347/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/348/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/349/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/350/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/351/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/352/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/353/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/354/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/355/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/356/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/357/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/358/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/359/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/360/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/361/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/362/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/363/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/364/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/365/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/366/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/367/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/368/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/369/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/370/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/371/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/372/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/373/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/374/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/375/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/376/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/377/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/378/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/379/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/380/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/381/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/382/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/383/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/384/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/385/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/386/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/387/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/388/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/389/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/390/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/391/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/392/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/393/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/394/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/395/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/396/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/397/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/398/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/399/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/400/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/401/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/402/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/403/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/404/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/405/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/406/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/407/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/408/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/409/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/410/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/411/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/412/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/413/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/414/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/415/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/416/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/417/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/418/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/419/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/420/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/421/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/422/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/423/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/424/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/425/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/426/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/427/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/428/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/429/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/430/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/431/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/432/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/433/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/434/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/435/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/436/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/437/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/438/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/439/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/440/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/441/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/442/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/443/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/444/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/445/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/446/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/447/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/448/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/449/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/450/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/451/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/452/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/453/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/454/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/455/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/456/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/457/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/458/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/459/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/460/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/461/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/462/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/463/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/464/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/465/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/466/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/467/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/468/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/469/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/470/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/471/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/472/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/473/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://data.pokefuta.com/manholes/474/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>


### PR DESCRIPTION
## Summary

Implemented static HTML generation for all 470 manhole detail pages to improve SEO and create a funnel from organic search traffic to the interactive map UI.

## Implementation Details

### 1. Static Page Generator (`apps/scraper/generate_manhole_pages.py`)
- Generates `/manholes/{id}/index.html` for all 470 manholes
- **SEO optimizations:**
  - Unique title, description, h1 per page
  - Canonical URL: `https://data.pokefuta.com/manholes/{id}/`
  - JSON-LD structured data (TouristAttraction schema)
  - OGP tags with actual photos when available
  - Google Analytics tracking (G-K18NR4GZG2)
- **Photo integration:**
  - 114 photos applied from `latest-manhole-photos.json`
  - 356 manholes without photos use default OGP image
- **Pokemon metadata display:**
  - Type (くさ/みず/ほのお etc.)
  - Generation (第1世代 etc.)
  - English name
- **Navigation CTAs:**
  - Primary: "📍 地図でこのポケふたを見る" → `/?manhole={id}`
  - Secondary: "同じ都道府県のポケふたを見る" → `/?pref={prefecture}`
  - Tertiary: "全国マップを見る" → `/`
  - External: "公式サイトを見る" (subdued)

### 2. Sitemap Update (`apps/scraper/generate_sitemap.py`)
- Changed from `/?manhole={id}` to `/manholes/{id}/`
- All 470 manhole URLs now in sitemap with `priority: 0.8`

### 3. Map UI Navigation Update (`apps/web/index.html`)
- Changed popup "公式詳細を見る" link destination
- Now points to `/manholes/{id}/` instead of external official site
- Updated tracking event: `click_detail_page`

### 4. GitHub Actions Workflow Update (`.github/workflows/pages-deploy.yml`)
- Added `generate_manhole_pages.py` execution step
- Fixed missing `pokemon_metadata.json` copy (was causing 404s)
- Added script to workflow trigger paths

## Generated Output

```
[generate_manhole_pages] total manholes: 470
[generate_manhole_pages] generated manhole pages: 470
[generate_manhole_pages] photo applied: 114
[generate_manhole_pages] photo missing: 356

[generate_sitemap] wrote apps/web/sitemap.xml with 470 manhole URLs
```

## Test URLs (after deployment)
- Example page: https://data.pokefuta.com/manholes/174/
- Sitemap: https://data.pokefuta.com/sitemap.xml

## PDCA Metrics
After deployment, monitor:
- **Search Console:** `/manholes/` impressions, clicks, index count
- **GA4:**
  - `page_view` for `/manholes/{id}/`
  - `manhole_seo_to_map_click` (funnel conversion)
  - `manhole_official_click`
- **Key metric:** `/manholes/{id}/ → /?manhole={id}` transition rate

## SEO Checklist
- ✅ Unique title/description/h1 per page
- ✅ Canonical URL correct
- ✅ No noindex
- ✅ Content in initial HTML (not JS-only)
- ✅ JSON-LD structured data
- ✅ OGP images (real photos when available)
- ✅ GA4 tracking enabled
- ✅ Clear navigation back to map UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)