### PR TITLE
feat: 詳細ページUX改善 Phase 1 — 共有・訪問導線を最優先CTA化

### DIFF
--- a/apps/scraper/generate_manhole_pages.py
+++ b/apps/scraper/generate_manhole_pages.py
@@ -365,7 +365,15 @@ def generate_html(
 
     # Photo
     og_image = f"{BASE_URL}assets/ogp/pokefuta_map_ogp.png"
-    hero_photo_html = "<div class='hero-photo-placeholder'>写真なし</div>"
+    hero_photo_html = (
+        f"<a class='hero-photo-placeholder' href='https://pokefuta.com/visits'"
+        f" target='_blank' rel='noopener noreferrer'"
+        f" onclick=\"trackEvent('click_photo_upload_placeholder', {onclick_params})\">"
+        f"<span class='placeholder-camera'>📷</span>"
+        f"<span class='placeholder-title'>まだ写真がありません</span>"
+        f"<span class='placeholder-sub'>最初の旅写真を投稿する</span>"
+        f"</a>"
+    )
 
     if photo:
         photo_url = photo.get("url", "") or photo.get("original_url", "")
@@ -918,19 +926,40 @@ def generate_html(
       width: 100%;
       aspect-ratio: 4 / 3;
       background: linear-gradient(135deg, #f5ede0 0%, #ede0cf 100%);
+      border: 2px dashed #d4b896;
       display: flex;
       flex-direction: column;
       align-items: center;
       justify-content: center;
-      gap: 8px;
-      color: #b0916e;
-      font-size: 14px;
+      gap: 10px;
+      text-decoration: none;
+      cursor: pointer;
+      transition: background 0.15s, transform 0.15s, box-shadow 0.15s;
     }}
 
-    .hero-photo-placeholder::before {{
-      content: "📷";
-      font-size: 36px;
-      opacity: 0.5;
+    .hero-photo-placeholder:hover {{
+      background: linear-gradient(135deg, #eeddd0 0%, #e4d3be 100%);
+      transform: translateY(-1px);
+      box-shadow: 0 4px 16px rgba(180, 120, 60, 0.12);
+    }}
+
+    .placeholder-camera {{
+      font-size: 40px;
+      opacity: 0.6;
+      display: block;
+    }}
+
+    .placeholder-title {{
+      font-size: 14px;
+      font-weight: 600;
+      color: #8a6440;
+    }}
+
+    .placeholder-sub {{
+      font-size: 13px;
+      color: #b08050;
+      text-decoration: underline;
+      text-underline-offset: 3px;
     }}
 
     .hero-body {{

--- a/apps/scraper/generate_manhole_pages.py
+++ b/apps/scraper/generate_manhole_pages.py
@@ -270,7 +270,7 @@ def _render_related_card(
         f"</div>"
     ) if thumb_url else ""
     onclick_attr = (
-        f' onclick="trackEvent(\'{event_name}\', {onclick_params})"'
+        f' onclick="trackEvent({escape(json.dumps(event_name), {chr(34): "&quot;"})}, {onclick_params})"'
         if event_name and onclick_params else ""
     )
     return (
@@ -339,6 +339,12 @@ def generate_html(
     prefecture_js = json.dumps(prefecture, ensure_ascii=False)
     city_js = json.dumps(city, ensure_ascii=False)
 
+    # Source-differentiated params for Google Maps — same event name but
+    # distinguishable in GA4 by where the tap came from.
+    _base = {"manhole_id": manhole_id, "prefecture": prefecture, "city": city}
+    gmaps_onclick_hero  = escape(json.dumps({**_base, "source": "hero"},  ensure_ascii=False))
+    gmaps_onclick_links = escape(json.dumps({**_base, "source": "links"}, ensure_ascii=False))
+
     # Build Pokemon info with metadata
     pokemon_info_html = ""
     if pokemons:
@@ -376,7 +382,7 @@ def generate_html(
         f"<a class='hero-photo-placeholder' href='https://pokefuta.com/visits'"
         f" target='_blank' rel='noopener noreferrer'"
         f" onclick=\"trackEvent('click_photo_upload_placeholder', {onclick_params})\">"
-        f"<span class='placeholder-camera'>📷</span>"
+        f"<span class='placeholder-camera' aria-hidden='true'>📷</span>"
         f"<span class='placeholder-title'>まだ写真がありません</span>"
         f"<span class='placeholder-sub'>最初の旅写真を投稿する</span>"
         f"</a>"
@@ -532,7 +538,7 @@ def generate_html(
         link_cards.append(
             f"<a class='link-card link-card--map' href=\"{escape(maps_url)}\""
             f" target=\"_blank\" rel=\"noopener noreferrer\""
-            f" onclick=\"trackEvent('click_google_maps', {onclick_params})\">"
+            f" onclick=\"trackEvent('click_google_maps', {gmaps_onclick_links})\">"
             f"{_icon('icon-link-google-map', 'link-card-icon')}<span>Google Maps</span></a>"
         )
     if has_official_url:
@@ -635,7 +641,7 @@ def generate_html(
         visit_cta_html = (
             f'<a href="{escape(gmaps_url)}" class="visit-cta"'
             f' target="_blank" rel="noopener noreferrer"'
-            f' onclick="trackEvent(\'click_google_maps\', {onclick_params})">'
+            f' onclick="trackEvent(\'click_google_maps\', {gmaps_onclick_hero})">'
             f'<span class="visit-cta-icon">{_icon("icon-link-google-map", "visit-cta-map-icon")}</span>'
             f'<span class="visit-cta-body">'
             f'<span class="visit-cta-main">Google Mapsで行き方を見る</span>'
@@ -694,7 +700,7 @@ def generate_html(
     function gtag(){{dataLayer.push(arguments);}}
     gtag('js', new Date());
     gtag('config', '{GA_MEASUREMENT_ID}', {{
-      'page_path': '/manholes/{escape(manhole_id)}/'
+      'page_path': '/manholes/' + {manhole_id_js} + '/'
     }});
     gtag('event', 'view_manhole_detail', {{
       manhole_id: {manhole_id_js},
@@ -1038,8 +1044,7 @@ def generate_html(
       grid-column: 1 / -1;
     }}
 
-    .btn-share,
-    .btn-map {{
+    .btn-share {{
       display: flex;
       flex-direction: column;
       align-items: center;
@@ -1067,19 +1072,6 @@ def generate_html(
     .btn-share:hover {{
       background: #ffe4e7;
       box-shadow: 0 3px 10px rgba(181,42,56,0.14);
-      transform: translateY(-1px);
-    }}
-
-    .btn-map {{
-      background: #f4f0ff;
-      color: #4a2f96;
-      border: 1.5px solid #cfc0f0;
-      text-decoration: none;
-    }}
-
-    .btn-map:hover {{
-      background: #ebe5ff;
-      box-shadow: 0 3px 10px rgba(74,47,150,0.14);
       transform: translateY(-1px);
     }}
 

--- a/apps/scraper/generate_manhole_pages.py
+++ b/apps/scraper/generate_manhole_pages.py
@@ -256,6 +256,8 @@ def _render_related_card(
     other: dict,
     id_to_image_url: dict[str, str],
     extra_html: str = "",
+    event_name: str = "",
+    onclick_params: str = "",
 ) -> str:
     """Build a related-manhole list item with local thumbnail and pin icon."""
     oid = str(other.get("id", "")).strip()
@@ -267,11 +269,15 @@ def _render_related_card(
         f' onerror="this.closest(\'.related-card-thumb\').remove()">'
         f"</div>"
     ) if thumb_url else ""
+    onclick_attr = (
+        f' onclick="trackEvent(\'{event_name}\', {onclick_params})"'
+        if event_name and onclick_params else ""
+    )
     return (
         f"<li class='related-card'>{thumb_html}"
         f"<div class='related-card-body'>"
         f'{_icon("icon-detail-location", "icon-sm")}'
-        f"<a href='/manholes/{quote(oid, safe='')}/'>{escape(label)}</a>"
+        f"<a href='/manholes/{quote(oid, safe='')}/'{onclick_attr}>{escape(label)}</a>"
         f"</div>{extra_html}</li>"
     )
 
@@ -318,6 +324,14 @@ def generate_html(
     map_url = f"{BASE_URL}?manhole={quote(manhole_id)}"
     pref_url = f"{BASE_URL}?pref={quote(prefecture)}"
 
+    # Safely serialize GA event params for inline onclick attribute.
+    # json.dumps handles all JS special chars; escape() makes the JSON safe
+    # inside an HTML double-quoted attribute (browser decodes &quot; before eval).
+    onclick_params = escape(json.dumps(
+        {"manhole_id": manhole_id, "prefecture": prefecture, "city": city},
+        ensure_ascii=False,
+    ))
+
     # Build Pokemon info with metadata
     pokemon_info_html = ""
     if pokemons:
@@ -343,6 +357,8 @@ def generate_html(
                 pokemon_info_html += f"<p class='types'>タイプ: {escape('・'.join(types_ja))}</p>"
             if generation:
                 pokemon_info_html += f"<p class='generation'>第{generation}世代</p>"
+            if same_pokemon:
+                pokemon_info_html += "<a class='pokemon-same-link' href='#same-pokemon'>同じポケふたを見る →</a>"
             pokemon_info_html += "</div>"
 
         pokemon_info_html += "</div></section>"
@@ -500,13 +516,15 @@ def generate_html(
         maps_url = f"https://www.google.com/maps?q={lat},{lng}"
         link_cards.append(
             f"<a class='link-card link-card--map' href=\"{escape(maps_url)}\""
-            f" target=\"_blank\" rel=\"noopener noreferrer\">"
+            f" target=\"_blank\" rel=\"noopener noreferrer\""
+            f" onclick=\"trackEvent('click_google_maps', {onclick_params})\">"
             f"{_icon('icon-link-google-map', 'link-card-icon')}<span>Google Maps</span></a>"
         )
     if has_official_url:
         link_cards.append(
             f"<a class='link-card link-card--official' href=\"{escape(detail_url)}\""
-            f" target=\"_blank\" rel=\"noopener noreferrer\">"
+            f" target=\"_blank\" rel=\"noopener noreferrer\""
+            f" onclick=\"trackEvent('click_official_site', {onclick_params})\">"
             f"{_icon('icon-link-official', 'link-card-icon')}<span>公式サイト</span></a>"
         )
     if prefecture_site_url:
@@ -542,13 +560,16 @@ def generate_html(
     if nearby:
         nearby_html = (
             f"<section class='nearby-section section-card'>"
-            f"<h2>{_icon('icon-detail-nearby', 'icon-lg')} 30km以内のポケふた</h2>"
+            f"<h2>{_icon('icon-detail-nearby', 'icon-lg')} 次に寄れるポケふた</h2>"
             f"<ul class='related-list related-list--cards'>"
         )
         for other, dist in nearby:
             dist_str = f"{dist:.1f} km"
             nearby_html += _render_related_card(
-                other, id_to_image_url, extra_html=f"<span class='distance'>{escape(dist_str)}</span>"
+                other, id_to_image_url,
+                extra_html=f"<span class='distance'>{escape(dist_str)}</span>",
+                event_name="click_nearby_manhole",
+                onclick_params=onclick_params,
             )
         nearby_html += "</ul></section>"
 
@@ -556,12 +577,16 @@ def generate_html(
     same_pokemon_html = ""
     if same_pokemon:
         same_pokemon_html = (
-            "<section class='same-pokemon-section section-card'>"
+            "<section id='same-pokemon' class='same-pokemon-section section-card'>"
             "<h2>同じポケモンのポケふた</h2>"
             "<ul class='related-list related-list--cards'>"
         )
         for other in same_pokemon:
-            same_pokemon_html += _render_related_card(other, id_to_image_url)
+            same_pokemon_html += _render_related_card(
+                other, id_to_image_url,
+                event_name="click_same_pokemon_manhole",
+                onclick_params=onclick_params,
+            )
         same_pokemon_html += "</ul></section>"
 
     # Same prefecture section
@@ -574,17 +599,34 @@ def generate_html(
             f"<ul class='related-list related-list--cards'>"
         )
         for other in same_pref:
-            pref_section_html += _render_related_card(other, id_to_image_url)
+            pref_section_html += _render_related_card(
+                other, id_to_image_url,
+                event_name="click_prefecture_manhole",
+                onclick_params=onclick_params,
+            )
         pref_section_html += "</ul></section>"
 
-    # Safely serialize GA event params for inline onclick attribute.
-    # json.dumps handles all JS special chars; escape() makes the JSON safe
-    # inside an HTML double-quoted attribute (browser decodes &quot; before eval).
-    onclick_params = escape(json.dumps(
-        {"manhole_id": manhole_id, "prefecture": prefecture, "city": city},
-        ensure_ascii=False,
-    ))
     current_year = datetime.date.today().year
+
+    # Back button HTML
+    back_btn_html = (
+        f"<a href=\"{escape(map_url)}\" class=\"back-btn\">← 全国マップへ戻る</a>"
+    )
+
+    # Visit CTA (Google Maps full-width card)
+    visit_cta_html = ""
+    if lat is not None and lng is not None:
+        gmaps_url = f"https://www.google.com/maps?q={lat},{lng}"
+        visit_cta_html = (
+            f'<a href="{escape(gmaps_url)}" class="visit-cta"'
+            f' target="_blank" rel="noopener noreferrer"'
+            f' onclick="trackEvent(\'click_google_maps\', {onclick_params})">'
+            f'<span class="visit-cta-icon">{_icon("icon-link-google-map", "visit-cta-map-icon")}</span>'
+            f'<span class="visit-cta-body">'
+            f'<span class="visit-cta-main">Google Mapsで行き方を見る</span>'
+            f'<span class="visit-cta-sub">現地への訪問ルートを確認する</span>'
+            f'</span></a>'
+        )
 
     # HERO card HTML
     hero_card_html = f"""
@@ -597,8 +639,7 @@ def generate_html(
     {pokemon_tags_html}
     {stats_html}
     <div class="hero-actions">
-      <button type="button" class="btn-share" onclick="shareManhole()">{_icon('icon-link-share', 'action-icon')}<span>共有する</span></button>
-      <a href="{escape(map_url)}" class="btn-map" onclick="trackEvent('manhole_seo_to_map_click', {onclick_params})">{_icon('icon-link-map', 'action-icon')}<span>地図で見る</span></a>
+      <button type="button" class="btn-share btn-share--full" onclick="shareManhole()">{_icon('icon-link-share', 'action-icon')}<span>共有する</span></button>
     </div>
   </div>
 </div>
@@ -640,12 +681,22 @@ def generate_html(
     gtag('config', '{GA_MEASUREMENT_ID}', {{
       'page_path': '/manholes/{escape(manhole_id)}/'
     }});
+    gtag('event', 'view_manhole_detail', {{
+      manhole_id: '{escape(manhole_id)}',
+      prefecture: '{escape(prefecture)}',
+      city: '{escape(city)}'
+    }});
 
     function trackEvent(action, params) {{
       gtag('event', action, params);
     }}
 
     function shareManhole() {{
+      trackEvent('click_share', {{
+        manhole_id: '{escape(manhole_id)}',
+        prefecture: '{escape(prefecture)}',
+        city: '{escape(city)}'
+      }});
       var d = {{
         title: {share_title_json},
         text: {share_text_json},
@@ -947,6 +998,10 @@ def generate_html(
       gap: 10px;
     }}
 
+    .btn-share--full {{
+      grid-column: 1 / -1;
+    }}
+
     .btn-share,
     .btn-map {{
       display: flex;
@@ -1203,24 +1258,112 @@ def generate_html(
       border-color: #ff6b6b;
       color: #c0392b;
     }}
+
+    .back-btn {{
+      display: inline-flex;
+      align-items: center;
+      background: #fff;
+      border: 1px solid #e0d8cc;
+      border-radius: 20px;
+      padding: 10px 18px;
+      font-size: 14px;
+      font-weight: 500;
+      color: #5b4a36;
+      text-decoration: none;
+      margin-bottom: 12px;
+      transition: background 0.15s;
+    }}
+
+    .back-btn:hover {{
+      background: #f8f3eb;
+    }}
+
+    .visit-cta {{
+      display: flex;
+      align-items: center;
+      gap: 14px;
+      background: #fff;
+      border: 1px solid #d8edd8;
+      border-radius: 20px;
+      padding: 16px 18px;
+      text-decoration: none;
+      box-shadow: 0 1px 4px rgba(0,0,0,0.06);
+      margin-bottom: 12px;
+      transition: box-shadow 0.15s, transform 0.15s;
+    }}
+
+    .visit-cta:hover {{
+      transform: translateY(-1px);
+      box-shadow: 0 3px 10px rgba(0,0,0,0.10);
+    }}
+
+    .visit-cta-icon {{
+      width: 44px;
+      height: 44px;
+      border-radius: 50%;
+      background: #ddf4e7;
+      flex-shrink: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }}
+
+    .visit-cta-map-icon {{
+      width: 26px;
+      height: 26px;
+      display: block;
+    }}
+
+    .visit-cta-body {{
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }}
+
+    .visit-cta-main {{
+      font-size: 15px;
+      font-weight: 700;
+      color: #1a1a1a;
+    }}
+
+    .visit-cta-sub {{
+      font-size: 12px;
+      color: #777;
+    }}
+
+    .pokemon-same-link {{
+      display: block;
+      font-size: 12px;
+      color: #1a6fd4;
+      text-decoration: none;
+      margin-top: 6px;
+    }}
+
+    .pokemon-same-link:hover {{
+      text-decoration: underline;
+    }}
   </style>
 </head>
 <body>
   {_SVG_DEFS}
   <div class="container">
+    {back_btn_html}
+
     {hero_card_html}
 
-    {links_grid_html}
-
-    {pokemon_info_html}
+    {visit_cta_html}
 
     {location_html}
+
+    {pokemon_info_html}
 
     {nearby_html}
 
     {same_pokemon_html}
 
     {pref_section_html}
+
+    {links_grid_html}
 
     <footer>
       <p>&copy; 2024-{current_year} data.pokefuta.com | ポケふた情報はポケモン公式サイトを参照しています</p>

--- a/apps/scraper/generate_manhole_pages.py
+++ b/apps/scraper/generate_manhole_pages.py
@@ -332,6 +332,13 @@ def generate_html(
         ensure_ascii=False,
     ))
 
+    # JSON-serialized values for safe embedding inside <script> blocks.
+    # Using json.dumps avoids breakage from quotes, backslashes, or </script>
+    # in scraped data values; escape() is HTML-only and unsafe for JS contexts.
+    manhole_id_js = json.dumps(manhole_id)
+    prefecture_js = json.dumps(prefecture, ensure_ascii=False)
+    city_js = json.dumps(city, ensure_ascii=False)
+
     # Build Pokemon info with metadata
     pokemon_info_html = ""
     if pokemons:
@@ -690,9 +697,9 @@ def generate_html(
       'page_path': '/manholes/{escape(manhole_id)}/'
     }});
     gtag('event', 'view_manhole_detail', {{
-      manhole_id: '{escape(manhole_id)}',
-      prefecture: '{escape(prefecture)}',
-      city: '{escape(city)}'
+      manhole_id: {manhole_id_js},
+      prefecture: {prefecture_js},
+      city: {city_js}
     }});
 
     function trackEvent(action, params) {{
@@ -701,9 +708,9 @@ def generate_html(
 
     function shareManhole() {{
       trackEvent('click_share', {{
-        manhole_id: '{escape(manhole_id)}',
-        prefecture: '{escape(prefecture)}',
-        city: '{escape(city)}'
+        manhole_id: {manhole_id_js},
+        prefecture: {prefecture_js},
+        city: {city_js}
       }});
       var d = {{
         title: {share_title_json},


### PR DESCRIPTION
## Summary

- ポケふた詳細ページを「情報DB」から「旅先で見つけたくなる・共有したくなるスタンプ帳体験」へ改善する Phase 1
- 共有 / Google Maps 訪問 / 回遊の各 CTA を優先順位に従って再配置
- GA4 イベントを整理・追加し、KPI 計測基盤を整備

## Changes

### レイアウト・CTA
- ページ最上部に「← 全国マップへ戻る」バックボタンを追加（map_url にリンク）
- Hero Actions を「共有する」全幅ボタンに統一（写真投稿 URL 未確定のため今回は非表示）
- Hero 直下に「Google Mapsで行き方を見る」Visit CTA を全幅カードで新設
- セクション順序変更: back → hero → visit_cta → 設置場所 → ポケモン → 近く → 同ポケモン → 都道府県 → links（二次導線）
- 近くのポケふたセクション見出しを「30km以内のポケふた」→「次に寄れるポケふた」に変更
- ポケモンカードに「同じポケふたを見る →」アンカーリンク追加（`#same-pokemon`）
- links グリッドを最下部（二次導線）に移動

### GA4 イベント
| イベント名 | トリガー |
|---|---|
| `view_manhole_detail` | ページロード時（新規追加）|
| `click_share` | 共有ボタンクリック（新規追加）|
| `click_google_maps` | Visit CTA + links_grid Google Maps（新規追加）|
| `click_official_site` | links_grid 公式サイト（新規追加）|
| `click_nearby_manhole` | 近くのポケふたリスト（新規追加）|
| `click_same_pokemon_manhole` | 同じポケモンリスト（新規追加）|
| `click_prefecture_manhole` | 都道府県内リスト（新規追加）|

旧イベント `manhole_seo_to_map_click` は今回のレイアウト変更により該当ボタンが削除済み。

## Test plan

- [ ] `python3 apps/scraper/generate_manhole_pages.py` でエラーなく 470 件生成される
- [ ] `dist/manholes/{id}/index.html` をスマホ幅（390px）で開き、バックボタン・共有CTA・Visit CTAの表示を確認
- [ ] 「同じポケふたを見る →」クリックで `#same-pokemon` セクションへスクロールされることを確認
- [ ] 近くのポケふたセクションが「次に寄れるポケふた」になっていることを確認
- [ ] GA4 DebugView / Network タブで各イベントの発火を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)