### PR TITLE
feat: SEO Phase 3 — ポケモンLP内部リンク強化

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -11,6 +11,7 @@ on:
       - 'apps/scraper/generate_manhole_pages.py' # manhole page generator
       - 'apps/scraper/generate_manhole_ogp.py' # OGP image generator
       - 'apps/scraper/generate_pokemon_pages.py' # Pokemon LP generator
+      - 'apps/scraper/generate_pokemon_index_page.py' # Pokemon index page generator
       - 'docs/**'     # dataset changes copied into dist/
       - 'dataset/manhole/image/**' # local popup photos
 
@@ -55,6 +56,8 @@ jobs:
           python3 apps/scraper/generate_manhole_pages.py
           echo "[dist] Generate static Pokemon LP pages"
           python3 apps/scraper/generate_pokemon_pages.py
+          echo "[dist] Generate Pokemon index page"
+          python3 apps/scraper/generate_pokemon_index_page.py
           echo "[dist] Generate sitemap with manhole + pokemon URLs"
           python3 apps/scraper/generate_sitemap.py
           echo "[dist] Copy HTML sources"

--- a/apps/scraper/generate_manhole_pages.py
+++ b/apps/scraper/generate_manhole_pages.py
@@ -13,28 +13,18 @@ import datetime
 import json
 import logging
 import math
+import sys
 from pathlib import Path
 from typing import Any, Optional
 from urllib.parse import quote, urlparse
 from xml.sax.saxutils import escape
 
+sys.path.insert(0, str(Path(__file__).parent))
+from generate_pokemon_pages import _FORM_PREFIX, _normalize_katakana  # noqa: E402
+
 # Constants
 BASE_URL = "https://data.pokefuta.com/"
 GA_MEASUREMENT_ID = "G-K18NR4GZG2"
-
-_FORM_PREFIX: dict[str, str] = {
-    "alola": "アローラ",
-    "galar": "ガラル",
-    "hisui": "ヒスイ",
-    "paldea": "パルデア",
-}
-
-
-def _normalize_katakana(text: str) -> str:
-    return "".join(
-        chr(ord(c) + 0x60) if "ぁ" <= c <= "ゖ" else c
-        for c in text
-    )
 
 
 def build_ja_to_slug(raw_data: list) -> dict[str, str]:
@@ -434,7 +424,7 @@ def generate_html(
             _slug = (ja_to_slug or {}).get(poke_name) or (ja_to_slug or {}).get(_normalize_katakana(poke_name), "")
             pokemon_info_html += f"<div class='pokemon-card'>"
             if _slug:
-                pokemon_info_html += f"<h3><a href='/pokemon/{quote(_slug)}/' style='color:inherit;text-decoration:none;'>{escape(poke_name)}</a></h3>"
+                pokemon_info_html += f"<h3><a href='/pokemon/{quote(_slug)}/'>{escape(poke_name)}</a></h3>"
             else:
                 pokemon_info_html += f"<h3>{escape(poke_name)}</h3>"
             if multilingual_parts:
@@ -1006,6 +996,13 @@ def generate_html(
       padding: 16px;
       border-radius: 8px;
       border: 1px solid #e0e0e0;
+    }}
+    .pokemon-card h3 a {{
+      color: inherit;
+      text-decoration: none;
+    }}
+    .pokemon-card h3 a:hover, .pokemon-card h3 a:focus {{
+      text-decoration: underline;
     }}
 
     .pokemon-card .en-name {{
@@ -1825,7 +1822,11 @@ def main() -> int:
 
     photos = load_photos(Path(args.photos))
     pokemon_meta = load_pokemon_metadata(Path(args.pokemon))
-    _raw_pokemon = json.loads(Path(args.pokemon).read_text(encoding="utf-8")) if Path(args.pokemon).exists() else []
+    try:
+        _raw_pokemon = json.loads(Path(args.pokemon).read_text(encoding="utf-8")) if Path(args.pokemon).exists() else []
+    except (json.JSONDecodeError, OSError) as e:
+        logger.warning(f"Could not load pokemon metadata for slug map: {e}")
+        _raw_pokemon = []
     ja_to_slug = build_ja_to_slug(_raw_pokemon)
 
     output_dir = Path(args.output)

--- a/apps/scraper/generate_manhole_pages.py
+++ b/apps/scraper/generate_manhole_pages.py
@@ -22,6 +22,46 @@ from xml.sax.saxutils import escape
 BASE_URL = "https://data.pokefuta.com/"
 GA_MEASUREMENT_ID = "G-K18NR4GZG2"
 
+_FORM_PREFIX: dict[str, str] = {
+    "alola": "アローラ",
+    "galar": "ガラル",
+    "hisui": "ヒスイ",
+    "paldea": "パルデア",
+}
+
+
+def _normalize_katakana(text: str) -> str:
+    return "".join(
+        chr(ord(c) + 0x60) if "ぁ" <= c <= "ゖ" else c
+        for c in text
+    )
+
+
+def build_ja_to_slug(raw_data: list) -> dict[str, str]:
+    """Build ja_name → slug map with regional form and katakana normalization."""
+    result: dict[str, str] = {}
+    for pokemon in raw_data:
+        if not isinstance(pokemon, dict):
+            continue
+        names = pokemon.get("names", {})
+        ja_name = names.get("ja", "")
+        slug = pokemon.get("slug", "")
+        form = pokemon.get("form") or ""
+        if not ja_name or not slug:
+            continue
+        if ja_name not in result or not form:
+            result[ja_name] = slug
+        prefix = _FORM_PREFIX.get(form, "")
+        if prefix:
+            combined = prefix + ja_name
+            if combined not in result:
+                result[combined] = slug
+    for key in list(result.keys()):
+        normalized = _normalize_katakana(key)
+        if normalized != key and normalized not in result:
+            result[normalized] = result[key]
+    return result
+
 PREFECTURE_EN: dict[str, str] = {
     "北海道": "Hokkaido",
     "青森県": "Aomori Prefecture",
@@ -324,6 +364,7 @@ def generate_html(
     same_pokemon_total: int = 0,
     nearby_count: int = 0,
     ogp_dir: Optional[Path] = None,
+    ja_to_slug: dict[str, str] | None = None,
 ) -> str:
     """Generate complete HTML for a manhole detail page."""
     manhole_id = str(manhole.get("id", "")).strip()
@@ -390,8 +431,12 @@ def generate_html(
             zh_hant = names.get("zh-Hant", "")
             multilingual_parts = [n for n in [en_name, ko_name, zh_hans, zh_hant] if n]
 
+            _slug = (ja_to_slug or {}).get(poke_name) or (ja_to_slug or {}).get(_normalize_katakana(poke_name), "")
             pokemon_info_html += f"<div class='pokemon-card'>"
-            pokemon_info_html += f"<h3>{escape(poke_name)}</h3>"
+            if _slug:
+                pokemon_info_html += f"<h3><a href='/pokemon/{quote(_slug)}/' style='color:inherit;text-decoration:none;'>{escape(poke_name)}</a></h3>"
+            else:
+                pokemon_info_html += f"<h3>{escape(poke_name)}</h3>"
             if multilingual_parts:
                 pokemon_info_html += f"<p class='multilingual-names'>{escape(' / '.join(multilingual_parts))}</p>"
             if types_ja:
@@ -1601,6 +1646,7 @@ def generate_all_pages(
     pokemon_meta: dict[str, dict],
     output_dir: Path,
     image_dir: Path,
+    ja_to_slug: dict[str, str] | None = None,
 ) -> tuple[int, int, int]:
     """Generate HTML pages for all manholes.
 
@@ -1717,7 +1763,7 @@ def generate_all_pages(
             manhole, photo, pokemon_meta, nearby, same_pref, pref_total, same_pokemon,
             id_to_image_url,
             city_total=city_total, same_pokemon_total=same_pokemon_total, nearby_count=nearby_count,
-            ogp_dir=ogp_dir,
+            ogp_dir=ogp_dir, ja_to_slug=ja_to_slug,
         )
 
         page_dir = output_dir / "manholes" / manhole_id
@@ -1779,12 +1825,15 @@ def main() -> int:
 
     photos = load_photos(Path(args.photos))
     pokemon_meta = load_pokemon_metadata(Path(args.pokemon))
+    _raw_pokemon = json.loads(Path(args.pokemon).read_text(encoding="utf-8")) if Path(args.pokemon).exists() else []
+    ja_to_slug = build_ja_to_slug(_raw_pokemon)
 
     output_dir = Path(args.output)
     output_dir.mkdir(parents=True, exist_ok=True)
 
     total, photos_applied, photos_missing = generate_all_pages(
-        manholes, photos, pokemon_meta, output_dir, Path(args.image_dir)
+        manholes, photos, pokemon_meta, output_dir, Path(args.image_dir),
+        ja_to_slug=ja_to_slug,
     )
 
     print(f"[generate_manhole_pages] total manholes: {len(manholes)}")

--- a/apps/scraper/generate_manhole_pages.py
+++ b/apps/scraper/generate_manhole_pages.py
@@ -421,7 +421,8 @@ def generate_html(
             zh_hant = names.get("zh-Hant", "")
             multilingual_parts = [n for n in [en_name, ko_name, zh_hans, zh_hant] if n]
 
-            _slug = (ja_to_slug or {}).get(poke_name) or (ja_to_slug or {}).get(_normalize_katakana(poke_name), "")
+            _jts = ja_to_slug or {}
+            _slug = _jts.get(poke_name) or _jts.get(_normalize_katakana(poke_name), "")
             pokemon_info_html += f"<div class='pokemon-card'>"
             if _slug:
                 pokemon_info_html += f"<h3><a href='/pokemon/{quote(_slug)}/'>{escape(poke_name)}</a></h3>"

--- a/apps/scraper/generate_pokemon_index_page.py
+++ b/apps/scraper/generate_pokemon_index_page.py
@@ -55,7 +55,12 @@ def _get_display_name(slug: str, meta: dict) -> tuple[str, str]:
 
 def _region_summary(manholes: list[dict], count: int) -> str:
     prefs = sorted({m.get("prefecture", "") for m in manholes if m.get("prefecture")})
-    region_text = prefs[0] if len(prefs) == 1 else f"{len(prefs)}都道府県"
+    if not prefs:
+        region_text = "所在地不明"
+    elif len(prefs) == 1:
+        region_text = prefs[0]
+    else:
+        region_text = f"{len(prefs)}都道府県"
     return f"{count}枚 / {region_text}"
 
 

--- a/apps/scraper/generate_pokemon_index_page.py
+++ b/apps/scraper/generate_pokemon_index_page.py
@@ -70,7 +70,7 @@ def _card_html(slug: str, meta: dict, manholes: list[dict], css_class: str = "po
         f"<span class='poke-name'>{escape(name_ja)}</span>"
         f"{en_html}"
         f"<span class='poke-summary'>{escape(summary)}</span>"
-        f"</a></li>\n"
+        f"</a></li>"
     )
 
 
@@ -78,7 +78,7 @@ def generate_html(pokemon_index: dict[str, tuple[dict, list[dict]]]) -> str:
     total_count = len(pokemon_index)
 
     # 地域連携セクション
-    regional_items_html = ""
+    regional_items: list[str] = []
     for slug, tagline in REGIONAL_POKEMON:
         if slug not in pokemon_index:
             continue
@@ -87,25 +87,27 @@ def generate_html(pokemon_index: dict[str, tuple[dict, list[dict]]]) -> str:
         count = len(manholes)
         summary = _region_summary(manholes, count)
         en_html = f"<span class='poke-en'>{escape(name_en)}</span>" if name_en else ""
-        regional_items_html += (
+        regional_items.append(
             f"<li class='regional-item'>"
             f"<a href='/pokemon/{quote(slug)}/'>"
             f"<span class='poke-name'>{escape(name_ja)}</span>"
             f"{en_html}"
             f"<span class='poke-tagline'>{escape(tagline)}</span>"
             f"<span class='poke-summary'>{escape(summary)}</span>"
-            f"</a></li>\n"
+            f"</a></li>"
         )
+    regional_items_html = "\n".join(regional_items) + "\n" if regional_items else ""
 
     # 全ポケモン一覧（登場マンホール数の多い順）
     sorted_slugs = sorted(
         pokemon_index.keys(),
         key=lambda s: -len(pokemon_index[s][1]),
     )
-    items_html = ""
+    items: list[str] = []
     for slug in sorted_slugs:
         meta, manholes = pokemon_index[slug]
-        items_html += _card_html(slug, meta, manholes)
+        items.append(_card_html(slug, meta, manholes))
+    items_html = "".join(items)
 
     jsonld_collection = json.dumps({
         "@context": "https://schema.org",
@@ -121,7 +123,7 @@ def generate_html(pokemon_index: dict[str, tuple[dict, list[dict]]]) -> str:
         "@type": "BreadcrumbList",
         "itemListElement": [
             {"@type": "ListItem", "position": 1, "name": "全国マップ", "item": BASE_URL},
-            {"@type": "ListItem", "position": 2, "name": "ポケモン一覧"},
+            {"@type": "ListItem", "position": 2, "name": "ポケモン一覧", "item": CANONICAL_URL},
         ],
     }, ensure_ascii=False, indent=2)
 

--- a/apps/scraper/generate_pokemon_index_page.py
+++ b/apps/scraper/generate_pokemon_index_page.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Generate /pokemon/index.html — a hub page listing all Pokemon with pokefuta."""
+"""Generate /pokemon/index.html — SEO hub listing all Pokemon with pokefuta."""
 
 from __future__ import annotations
 
@@ -17,7 +17,6 @@ from generate_pokemon_pages import (
     DEFAULT_OGP_IMAGE,
     GA_MEASUREMENT_ID,
     _FORM_PREFIX,
-    _normalize_katakana,
     build_pokemon_index,
     load_pokemon_metadata,
     read_manholes,
@@ -29,13 +28,23 @@ logger = logging.getLogger(__name__)
 CANONICAL_URL = f"{BASE_URL}pokemon/"
 TITLE = "ポケふたに登場するポケモン一覧 | 全国のポケモンマンホールマップ"
 DESCRIPTION = (
-    "全国のポケふた（ポケモンマンホール）に登場するポケモンの一覧です。"
-    "気になるポケモンをタップすると、そのポケモンが描かれたポケふたを地図で探せます。"
+    "全国各地に設置された「ポケふた（ポケモンマンホール）」に登場するポケモン一覧です。"
+    "北海道のロコンや香川県のヤドン、宮城県のラプラスなど、地域を応援するポケモンとして"
+    "描かれたポケふたも人気があります。気になるポケモンから、全国のポケふたや設置自治体を探せます。"
 )
+
+# 地域連携ポケモン（slug → 紹介文）
+REGIONAL_POKEMON: list[tuple[str, str]] = [
+    ("vulpix",       "北海道を応援するポケモン"),
+    ("vulpix-alola", "北海道を応援するポケモン"),
+    ("slowpoke",     "香川県を応援するポケモン"),
+    ("lapras",       "宮城県を応援するポケモン"),
+    ("geodude",      "岩手県を応援するポケモン"),
+    ("chansey",      "福島県を応援するポケモン"),
+]
 
 
 def _get_display_name(slug: str, meta: dict) -> tuple[str, str]:
-    """Return (name_ja, name_en) with regional form prefix applied."""
     names = meta.get("names", {})
     form = meta.get("form") or ""
     prefix = _FORM_PREFIX.get(form, "")
@@ -44,30 +53,59 @@ def _get_display_name(slug: str, meta: dict) -> tuple[str, str]:
     return name_ja, name_en
 
 
-def generate_html(pokemon_index: dict[str, tuple[dict, list[dict]]]) -> str:
-    count = len(pokemon_index)
+def _region_summary(manholes: list[dict], count: int) -> str:
+    prefs = sorted({m.get("prefecture", "") for m in manholes if m.get("prefecture")})
+    region_text = prefs[0] if len(prefs) == 1 else f"{len(prefs)}都道府県"
+    return f"{count}枚 / {region_text}"
 
-    sorted_slugs = sorted(
-        pokemon_index.keys(),
-        key=lambda s: (
-            int(pokemon_index[s][0].get("no") or 9999),
-            pokemon_index[s][0].get("form") or "",
-        ),
+
+def _card_html(slug: str, meta: dict, manholes: list[dict], css_class: str = "poke-item") -> str:
+    name_ja, name_en = _get_display_name(slug, meta)
+    count = len(manholes)
+    summary = _region_summary(manholes, count)
+    en_html = f"<span class='poke-en'>{escape(name_en)}</span>" if name_en else ""
+    return (
+        f"<li class='{css_class}'>"
+        f"<a href='/pokemon/{quote(slug)}/'>"
+        f"<span class='poke-name'>{escape(name_ja)}</span>"
+        f"{en_html}"
+        f"<span class='poke-summary'>{escape(summary)}</span>"
+        f"</a></li>\n"
     )
 
+
+def generate_html(pokemon_index: dict[str, tuple[dict, list[dict]]]) -> str:
+    total_count = len(pokemon_index)
+
+    # 地域連携セクション
+    regional_items_html = ""
+    for slug, tagline in REGIONAL_POKEMON:
+        if slug not in pokemon_index:
+            continue
+        meta, manholes = pokemon_index[slug]
+        name_ja, name_en = _get_display_name(slug, meta)
+        count = len(manholes)
+        summary = _region_summary(manholes, count)
+        en_html = f"<span class='poke-en'>{escape(name_en)}</span>" if name_en else ""
+        regional_items_html += (
+            f"<li class='regional-item'>"
+            f"<a href='/pokemon/{quote(slug)}/'>"
+            f"<span class='poke-name'>{escape(name_ja)}</span>"
+            f"{en_html}"
+            f"<span class='poke-tagline'>{escape(tagline)}</span>"
+            f"<span class='poke-summary'>{escape(summary)}</span>"
+            f"</a></li>\n"
+        )
+
+    # 全ポケモン一覧（登場マンホール数の多い順）
+    sorted_slugs = sorted(
+        pokemon_index.keys(),
+        key=lambda s: -len(pokemon_index[s][1]),
+    )
     items_html = ""
     for slug in sorted_slugs:
         meta, manholes = pokemon_index[slug]
-        name_ja, name_en = _get_display_name(slug, meta)
-        manhole_count = len(manholes)
-        sub = f"（{name_en}）" if name_en else ""
-        items_html += (
-            f"<li class='poke-item'>"
-            f"<a href='/pokemon/{quote(slug)}/'>"
-            f"<span class='poke-name'>{escape(name_ja)}{escape(sub)}</span>"
-            f"<span class='poke-count'>{manhole_count}枚</span>"
-            f"</a></li>\n"
-        )
+        items_html += _card_html(slug, meta, manholes)
 
     jsonld_collection = json.dumps({
         "@context": "https://schema.org",
@@ -123,7 +161,7 @@ def generate_html(pokemon_index: dict[str, tuple[dict, list[dict]]]) -> str:
     function gtag(){{dataLayer.push(arguments);}}
     gtag('js', new Date());
     gtag('config', '{GA_MEASUREMENT_ID}', {{'page_path': '/pokemon/'}});
-    gtag('event', 'view_pokemon_index', {{'pokemon_count': {count}}});
+    gtag('event', 'view_pokemon_index', {{'pokemon_count': {total_count}}});
   </script>
 
   <style>
@@ -154,21 +192,35 @@ def generate_html(pokemon_index: dict[str, tuple[dict, list[dict]]]) -> str:
       color: #1a1a1a;
       margin-bottom: 8px;
     }}
+    h2 {{
+      font-size: 17px;
+      font-weight: bold;
+      color: #1a1a1a;
+      margin: 24px 0 10px;
+      padding-bottom: 6px;
+      border-bottom: 2px solid #e0e0e0;
+    }}
     .lead {{
       font-size: 14px;
       color: #555;
-      margin-bottom: 20px;
+      line-height: 1.75;
+      margin-bottom: 4px;
     }}
-    .poke-list {{
+    /* 共通カードリスト */
+    .poke-list, .regional-list {{
       list-style: none;
       display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
       gap: 6px;
     }}
-    .poke-item a {{
+    .regional-list {{
+      grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    }}
+    .poke-list {{
+      grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    }}
+    .poke-item a, .regional-item a {{
       display: flex;
-      justify-content: space-between;
-      align-items: center;
+      flex-direction: column;
       padding: 8px 12px;
       background: #fafafa;
       border: 1px solid #e8e8e8;
@@ -176,13 +228,38 @@ def generate_html(pokemon_index: dict[str, tuple[dict, list[dict]]]) -> str:
       text-decoration: none;
       color: #333;
       transition: border-color 0.15s, box-shadow 0.15s;
+      height: 100%;
     }}
-    .poke-item a:hover {{
+    .poke-item a:hover, .regional-item a:hover {{
       border-color: #6F55A3;
       box-shadow: 0 2px 8px rgba(111,85,163,0.12);
     }}
-    .poke-name {{ font-size: 14px; font-weight: bold; }}
-    .poke-count {{ font-size: 12px; color: #888; white-space: nowrap; margin-left: 8px; }}
+    .regional-item a {{
+      background: #f5f0ff;
+      border-color: #d8ccf0;
+    }}
+    .poke-name {{
+      font-size: 15px;
+      font-weight: bold;
+      color: #1a1a1a;
+    }}
+    .poke-en {{
+      font-size: 12px;
+      color: #888;
+      margin-top: 1px;
+    }}
+    .poke-tagline {{
+      font-size: 12px;
+      color: #6F55A3;
+      margin-top: 4px;
+      font-weight: bold;
+    }}
+    .poke-summary {{
+      font-size: 12px;
+      color: #666;
+      margin-top: auto;
+      padding-top: 4px;
+    }}
     .cta-map {{
       display: block;
       background: #6F55A3;
@@ -216,8 +293,17 @@ def generate_html(pokemon_index: dict[str, tuple[dict, list[dict]]]) -> str:
   </nav>
 
   <h1>ポケふたに登場するポケモン一覧</h1>
-  <p class="lead">全国 <strong>{count}</strong> 体のポケモンが描かれたポケふたを地図で探せます。</p>
+  <p class="lead">
+    全国各地に設置された「ポケふた（ポケモンマンホール）」に登場するポケモン一覧です。
+    北海道のロコンや香川県のヤドン、宮城県のラプラスなど、地域を応援するポケモンとして描かれたポケふたも人気があります。
+    気になるポケモンから、全国のポケふたや設置自治体を探せます。
+  </p>
 
+  <h2>地域を応援するポケモン</h2>
+  <ul class="regional-list">
+{regional_items_html}  </ul>
+
+  <h2>全ポケモン一覧（{total_count}体）</h2>
   <ul class="poke-list">
 {items_html}  </ul>
 

--- a/apps/scraper/generate_pokemon_index_page.py
+++ b/apps/scraper/generate_pokemon_index_page.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Generate /pokemon/index.html — a hub page listing all Pokemon with pokefuta."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+from urllib.parse import quote
+from xml.sax.saxutils import escape
+
+sys.path.insert(0, str(Path(__file__).parent))
+from generate_pokemon_pages import (
+    BASE_URL,
+    DEFAULT_OGP_IMAGE,
+    GA_MEASUREMENT_ID,
+    _FORM_PREFIX,
+    _normalize_katakana,
+    build_pokemon_index,
+    load_pokemon_metadata,
+    read_manholes,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+logger = logging.getLogger(__name__)
+
+CANONICAL_URL = f"{BASE_URL}pokemon/"
+TITLE = "ポケふたに登場するポケモン一覧 | 全国のポケモンマンホールマップ"
+DESCRIPTION = (
+    "全国のポケふた（ポケモンマンホール）に登場するポケモンの一覧です。"
+    "気になるポケモンをタップすると、そのポケモンが描かれたポケふたを地図で探せます。"
+)
+
+
+def _get_display_name(slug: str, meta: dict) -> tuple[str, str]:
+    """Return (name_ja, name_en) with regional form prefix applied."""
+    names = meta.get("names", {})
+    form = meta.get("form") or ""
+    prefix = _FORM_PREFIX.get(form, "")
+    name_ja = prefix + names.get("ja", slug)
+    name_en = names.get("en", "")
+    return name_ja, name_en
+
+
+def generate_html(pokemon_index: dict[str, tuple[dict, list[dict]]]) -> str:
+    count = len(pokemon_index)
+
+    sorted_slugs = sorted(
+        pokemon_index.keys(),
+        key=lambda s: (
+            int(pokemon_index[s][0].get("no") or 9999),
+            pokemon_index[s][0].get("form") or "",
+        ),
+    )
+
+    items_html = ""
+    for slug in sorted_slugs:
+        meta, manholes = pokemon_index[slug]
+        name_ja, name_en = _get_display_name(slug, meta)
+        manhole_count = len(manholes)
+        sub = f"（{name_en}）" if name_en else ""
+        items_html += (
+            f"<li class='poke-item'>"
+            f"<a href='/pokemon/{quote(slug)}/'>"
+            f"<span class='poke-name'>{escape(name_ja)}{escape(sub)}</span>"
+            f"<span class='poke-count'>{manhole_count}枚</span>"
+            f"</a></li>\n"
+        )
+
+    jsonld_collection = json.dumps({
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "ポケふたに登場するポケモン一覧",
+        "description": DESCRIPTION,
+        "url": CANONICAL_URL,
+        "inLanguage": "ja",
+    }, ensure_ascii=False, indent=2)
+
+    jsonld_breadcrumb = json.dumps({
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+            {"@type": "ListItem", "position": 1, "name": "全国マップ", "item": BASE_URL},
+            {"@type": "ListItem", "position": 2, "name": "ポケモン一覧"},
+        ],
+    }, ensure_ascii=False, indent=2)
+
+    return f"""<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{escape(TITLE)}</title>
+  <meta name="description" content="{escape(DESCRIPTION)}">
+  <meta name="robots" content="index,follow">
+  <link rel="canonical" href="{escape(CANONICAL_URL)}">
+
+  <meta property="og:type" content="website">
+  <meta property="og:locale" content="ja_JP">
+  <meta property="og:title" content="ポケふたに登場するポケモン一覧">
+  <meta property="og:description" content="{escape(DESCRIPTION)}">
+  <meta property="og:url" content="{escape(CANONICAL_URL)}">
+  <meta property="og:image" content="{escape(DEFAULT_OGP_IMAGE)}">
+
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="ポケふたに登場するポケモン一覧">
+  <meta name="twitter:description" content="{escape(DESCRIPTION)}">
+  <meta name="twitter:image" content="{escape(DEFAULT_OGP_IMAGE)}">
+
+  <script type="application/ld+json">
+{jsonld_collection}
+  </script>
+  <script type="application/ld+json">
+{jsonld_breadcrumb}
+  </script>
+
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id={GA_MEASUREMENT_ID}"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){{dataLayer.push(arguments);}}
+    gtag('js', new Date());
+    gtag('config', '{GA_MEASUREMENT_ID}', {{'page_path': '/pokemon/'}});
+    gtag('event', 'view_pokemon_index', {{'pokemon_count': {count}}});
+  </script>
+
+  <style>
+    * {{ box-sizing: border-box; margin: 0; padding: 0; }}
+    body {{
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+      line-height: 1.6;
+      color: #333;
+      background: #fff8ec;
+      padding: 16px;
+    }}
+    .container {{
+      max-width: 800px;
+      margin: 0 auto;
+      background: white;
+      border-radius: 12px;
+      padding: 20px;
+      box-shadow: 0 4px 16px rgba(0,0,0,0.08);
+    }}
+    .breadcrumb {{ font-size: 13px; color: #888; margin-bottom: 16px; }}
+    .breadcrumb ol {{ list-style: none; display: flex; flex-wrap: wrap; gap: 4px; align-items: center; }}
+    .breadcrumb li + li::before {{ content: "›"; margin-right: 4px; color: #ccc; }}
+    .breadcrumb a {{ color: #6F55A3; text-decoration: none; }}
+    .breadcrumb a:hover {{ text-decoration: underline; }}
+    h1 {{
+      font-size: 24px;
+      font-weight: bold;
+      color: #1a1a1a;
+      margin-bottom: 8px;
+    }}
+    .lead {{
+      font-size: 14px;
+      color: #555;
+      margin-bottom: 20px;
+    }}
+    .poke-list {{
+      list-style: none;
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+      gap: 6px;
+    }}
+    .poke-item a {{
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 8px 12px;
+      background: #fafafa;
+      border: 1px solid #e8e8e8;
+      border-radius: 8px;
+      text-decoration: none;
+      color: #333;
+      transition: border-color 0.15s, box-shadow 0.15s;
+    }}
+    .poke-item a:hover {{
+      border-color: #6F55A3;
+      box-shadow: 0 2px 8px rgba(111,85,163,0.12);
+    }}
+    .poke-name {{ font-size: 14px; font-weight: bold; }}
+    .poke-count {{ font-size: 12px; color: #888; white-space: nowrap; margin-left: 8px; }}
+    .cta-map {{
+      display: block;
+      background: #6F55A3;
+      color: white;
+      text-align: center;
+      padding: 14px 24px;
+      border-radius: 8px;
+      text-decoration: none;
+      font-size: 16px;
+      font-weight: bold;
+      margin-top: 24px;
+      transition: background 0.2s;
+    }}
+    .cta-map:hover {{ background: #5a4480; }}
+    footer {{
+      margin-top: 32px;
+      text-align: center;
+      font-size: 13px;
+      color: #aaa;
+    }}
+    footer a {{ color: #6F55A3; text-decoration: none; }}
+  </style>
+</head>
+<body>
+<div class="container">
+  <nav aria-label="パンくずリスト" class="breadcrumb">
+    <ol>
+      <li><a href="/">全国マップ</a></li>
+      <li aria-current="page">ポケモン一覧</li>
+    </ol>
+  </nav>
+
+  <h1>ポケふたに登場するポケモン一覧</h1>
+  <p class="lead">全国 <strong>{count}</strong> 体のポケモンが描かれたポケふたを地図で探せます。</p>
+
+  <ul class="poke-list">
+{items_html}  </ul>
+
+  <a href="{escape(BASE_URL)}" class="cta-map">地図で全国のポケふたを探す →</a>
+
+  <footer>
+    <p><a href="{escape(BASE_URL)}">data.pokefuta.com</a> &mdash; ポケモンマンホール全国マップ</p>
+  </footer>
+</div>
+</body>
+</html>"""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manholes", default="docs/pokefuta.ndjson")
+    parser.add_argument("--pokemon", default="docs/pokemon_metadata.json")
+    parser.add_argument("--output", default="dist/pokemon")
+    args = parser.parse_args()
+
+    metadata = load_pokemon_metadata(Path(args.pokemon))
+    if not metadata:
+        logger.error("No pokemon metadata loaded")
+        return 1
+
+    manholes = read_manholes(Path(args.manholes))
+    if not manholes:
+        logger.error("No manholes loaded")
+        return 1
+
+    pokemon_index = build_pokemon_index(manholes, metadata)
+    logger.info(f"Pokemon with active pokefuta: {len(pokemon_index)}")
+
+    output_dir = Path(args.output)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    html = generate_html(pokemon_index)
+    (output_dir / "index.html").write_text(html, encoding="utf-8")
+    logger.info(f"Written: {output_dir}/index.html")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/scraper/generate_pokemon_pages.py
+++ b/apps/scraper/generate_pokemon_pages.py
@@ -338,6 +338,16 @@ def generate_html(
     }
     jsonld_str = json.dumps(jsonld, ensure_ascii=False, indent=2)
 
+    jsonld_breadcrumb_str = json.dumps({
+        "@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+            {"@type": "ListItem", "position": 1, "name": "全国マップ", "item": BASE_URL},
+            {"@type": "ListItem", "position": 2, "name": "ポケモン一覧", "item": f"{BASE_URL}pokemon/"},
+            {"@type": "ListItem", "position": 3, "name": name_ja, "item": canonical_url},
+        ],
+    }, ensure_ascii=False, indent=2)
+
     # Manhole sections grouped by prefecture (empty prefecture sorted last)
     sorted_manholes = sorted(
         manholes,
@@ -425,15 +435,7 @@ def generate_html(
 {jsonld_str}
   </script>
   <script type="application/ld+json">
-{{
-  "@context": "https://schema.org",
-  "@type": "BreadcrumbList",
-  "itemListElement": [
-    {{"@type": "ListItem", "position": 1, "name": "全国マップ", "item": "{escape(BASE_URL)}"}},
-    {{"@type": "ListItem", "position": 2, "name": "ポケモン一覧", "item": "{escape(BASE_URL)}pokemon/"}},
-    {{"@type": "ListItem", "position": 3, "name": "{escape(name_ja)}", "item": "{escape(canonical_url)}"}}
-  ]
-}}
+{jsonld_breadcrumb_str}
   </script>
 
   <!-- Google Analytics -->

--- a/apps/scraper/generate_pokemon_pages.py
+++ b/apps/scraper/generate_pokemon_pages.py
@@ -424,6 +424,17 @@ def generate_html(
   <script type="application/ld+json">
 {jsonld_str}
   </script>
+  <script type="application/ld+json">
+{{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {{"@type": "ListItem", "position": 1, "name": "全国マップ", "item": "{escape(BASE_URL)}"}},
+    {{"@type": "ListItem", "position": 2, "name": "ポケモン一覧", "item": "{escape(BASE_URL)}pokemon/"}},
+    {{"@type": "ListItem", "position": 3, "name": "{escape(name_ja)}"}}
+  ]
+}}
+  </script>
 
   <!-- Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id={GA_MEASUREMENT_ID}"></script>
@@ -619,12 +630,22 @@ def generate_html(
       color: #aaa;
     }}
     footer a {{ color: #6F55A3; text-decoration: none; }}
+    .breadcrumb {{ font-size: 13px; color: #888; margin-bottom: 14px; }}
+    .breadcrumb ol {{ list-style: none; display: flex; flex-wrap: wrap; gap: 4px; align-items: center; }}
+    .breadcrumb li + li::before {{ content: "›"; margin-right: 4px; color: #ccc; }}
+    .breadcrumb a {{ color: #6F55A3; text-decoration: none; }}
+    .breadcrumb a:hover {{ text-decoration: underline; }}
   </style>
 </head>
 <body>
 <div class="container">
-  <a href="{escape(map_url)}" class="back-link"
-     onclick="trackEvent('click_back_to_map', {{pokemon_slug: {slug_js}}})">← 全国マップへ戻る</a>
+  <nav aria-label="パンくずリスト" class="breadcrumb">
+    <ol>
+      <li><a href="/">全国マップ</a></li>
+      <li><a href="/pokemon/">ポケモン一覧</a></li>
+      <li aria-current="page">{escape(name_ja)}</li>
+    </ol>
+  </nav>
 
   <div class="poke-hero">
     <h1>{escape(name_ja)}のポケふた一覧</h1>

--- a/apps/scraper/generate_pokemon_pages.py
+++ b/apps/scraper/generate_pokemon_pages.py
@@ -431,7 +431,7 @@ def generate_html(
   "itemListElement": [
     {{"@type": "ListItem", "position": 1, "name": "全国マップ", "item": "{escape(BASE_URL)}"}},
     {{"@type": "ListItem", "position": 2, "name": "ポケモン一覧", "item": "{escape(BASE_URL)}pokemon/"}},
-    {{"@type": "ListItem", "position": 3, "name": "{escape(name_ja)}"}}
+    {{"@type": "ListItem", "position": 3, "name": "{escape(name_ja)}", "item": "{escape(canonical_url)}"}}
   ]
 }}
   </script>
@@ -471,14 +471,6 @@ def generate_html(
       padding: 20px;
       box-shadow: 0 4px 16px rgba(0,0,0,0.08);
     }}
-    .back-link {{
-      display: inline-block;
-      color: #6F55A3;
-      text-decoration: none;
-      font-size: 14px;
-      margin-bottom: 16px;
-    }}
-    .back-link:hover {{ text-decoration: underline; }}
     .poke-hero {{
       margin-bottom: 24px;
     }}

--- a/apps/scraper/generate_sitemap.py
+++ b/apps/scraper/generate_sitemap.py
@@ -183,6 +183,7 @@ def build_sitemap(manhole_ids: list[str], pokemon_slugs: list[str] | None = None
     entries = [
         url_entry(BASE_URL, "daily", "1.0"),
         url_entry(f"{BASE_URL}summary", "weekly", "0.8"),
+        url_entry(f"{BASE_URL}pokemon/", "weekly", "0.8"),
         url_entry(f"{BASE_URL}nearby.html", "weekly", "0.6"),
         url_entry(f"{BASE_URL}gmanhole_map.html", "weekly", "0.6"),
     ]

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -383,7 +383,8 @@
     </div>
   </div>
   <nav aria-label="人気のポケモン" style="margin:16px auto 0; max-width:960px; padding:12px 16px; background:#fff8ec; border-radius:8px; border:1px solid #e8e0d0;">
-    <p style="font-size:0.85rem; font-weight:bold; color:#6F55A3; margin:0 0 8px;">人気のポケモン</p>
+    <p style="font-size:0.85rem; font-weight:bold; color:#6F55A3; margin:0 0 4px;">人気のポケモン</p>
+    <p style="margin:0 0 8px;"><a href="/pokemon/" style="font-size:0.85rem; color:#6F55A3; font-weight:bold;">→ ポケモン一覧を見る</a></p>
     <ul style="list-style:none; display:flex; flex-wrap:wrap; gap:8px; margin:0; padding:0;">
       <li><a href="/pokemon/chansey/" style="font-size:0.85rem; color:#6F55A3; text-decoration:none;">ラッキー</a></li>
       <li><a href="/pokemon/lapras/" style="font-size:0.85rem; color:#6F55A3; text-decoration:none;">ラプラス</a></li>

--- a/apps/web/sitemap.xml
+++ b/apps/web/sitemap.xml
@@ -11,6 +11,11 @@
     <priority>0.8</priority>
   </url>
   <url>
+    <loc>https://data.pokefuta.com/pokemon/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
     <loc>https://data.pokefuta.com/nearby.html</loc>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>


### PR DESCRIPTION
## Summary

- `/pokemon/index.html` ハブページを新規生成（534体、図鑑番号順リスト、breadcrumb付き）
- マンホール詳細ページの「登場ポケモン」名を `/pokemon/{slug}/` へのリンクに変更（地域フォーム対応slug解決含む）
- ポケモン個別LPにパンくずリスト追加（`全国マップ › ポケモン一覧 › {名前}`、BreadcrumbList JSON-LD含む）
- sitemapに `/pokemon/` インデックスURLを追加（priority 0.8）
- トップページの「人気のポケモン」ナビに「→ ポケモン一覧を見る」リンクを追加
- ワークフロー（`pages-deploy.yml`）に `generate_pokemon_index_page.py` を追加

## Test plan

- [ ] `dist/pokemon/index.html` が生成され、534体のポケモンリンクを含む
- [ ] `dist/manholes/{id}/index.html` のポケモン名が `<a href="/pokemon/{slug}/">` になっている
- [ ] `dist/pokemon/pikachu/index.html` にパンくずリストが含まれ、`/pokemon/` へのリンクがある
- [ ] `apps/web/sitemap.xml` に `https://data.pokefuta.com/pokemon/` が含まれる（priority 0.8）
- [ ] 既存の `/pokemon/{slug}/` URLは変更されていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)