### PR TITLE
feat: SEO Phase 4 — AI Summary・発見カード・旅行文脈・sitemap優先度調整

### DIFF
--- a/apps/scraper/generate_pokemon_index_page.py
+++ b/apps/scraper/generate_pokemon_index_page.py
@@ -114,6 +114,19 @@ def generate_html(pokemon_index: dict[str, tuple[dict, list[dict]]]) -> str:
         items.append(_card_html(slug, meta, manholes))
     items_html = "".join(items)
 
+    # 「多く登場するポケモン」説明テキスト（動的生成）
+    top3_names = "・".join(
+        _get_display_name(s, pokemon_index[s][0])[0]
+        for s in sorted_slugs[:3]
+    )
+    top1_count = len(pokemon_index[sorted_slugs[0]][1]) if sorted_slugs else 0
+    popular_intro = escape(
+        f"登場回数が多いポケモンほど、全国各地で出会いやすいポケモンです。"
+        f"{top3_names}などは{top1_count}枚以上のポケふたに登場しており、"
+        f"初めてポケふた巡りをする方にも見つけやすいポケモンです。"
+        f"気になるポケモンをタップして、設置場所や旅のルートを確認しましょう。"
+    )
+
     jsonld_collection = json.dumps({
         "@context": "https://schema.org",
         "@type": "CollectionPage",
@@ -267,6 +280,24 @@ def generate_html(pokemon_index: dict[str, tuple[dict, list[dict]]]) -> str:
       margin-top: auto;
       padding-top: 4px;
     }}
+    .popular-intro {{
+      font-size: 13px;
+      color: #555;
+      line-height: 1.7;
+      margin: 0 0 10px;
+      padding: 10px 14px;
+      background: #f5f0ff;
+      border-left: 3px solid #6F55A3;
+      border-radius: 0 6px 6px 0;
+    }}
+    .map-nav-hint {{
+      font-size: 13px;
+      color: #666;
+      margin: 16px 0 4px;
+      text-align: center;
+    }}
+    .map-nav-hint a {{ color: #6F55A3; text-decoration: none; font-weight: bold; }}
+    .map-nav-hint a:hover {{ text-decoration: underline; }}
     .cta-map {{
       display: block;
       background: #6F55A3;
@@ -311,8 +342,11 @@ def generate_html(pokemon_index: dict[str, tuple[dict, list[dict]]]) -> str:
 {regional_items_html}  </ul>
 
   <h2>全ポケモン一覧（{total_count}体）</h2>
+  <p class="popular-intro">{popular_intro}</p>
   <ul class="poke-list">
 {items_html}  </ul>
+
+  <p class="map-nav-hint">都道府県ごとのポケふたは<a href="{escape(BASE_URL)}">全国マップ</a>から地域を選んで確認できます。</p>
 
   <a href="{escape(BASE_URL)}" class="cta-map">地図で全国のポケふたを探す →</a>
 

--- a/apps/scraper/generate_pokemon_index_page.py
+++ b/apps/scraper/generate_pokemon_index_page.py
@@ -119,10 +119,13 @@ def generate_html(pokemon_index: dict[str, tuple[dict, list[dict]]]) -> str:
         _get_display_name(s, pokemon_index[s][0])[0]
         for s in sorted_slugs[:3]
     )
-    top1_count = len(pokemon_index[sorted_slugs[0]][1]) if sorted_slugs else 0
+    top3_min_count = (
+        min(len(pokemon_index[s][1]) for s in sorted_slugs[:3])
+        if sorted_slugs else 0
+    )
     popular_intro = escape(
         f"登場回数が多いポケモンほど、全国各地で出会いやすいポケモンです。"
-        f"{top3_names}などは{top1_count}枚以上のポケふたに登場しており、"
+        f"{top3_names}などは{top3_min_count}枚以上のポケふたに登場しており、"
         f"初めてポケふた巡りをする方にも見つけやすいポケモンです。"
         f"気になるポケモンをタップして、設置場所や旅のルートを確認しましょう。"
     )

--- a/apps/scraper/generate_pokemon_pages.py
+++ b/apps/scraper/generate_pokemon_pages.py
@@ -71,6 +71,7 @@ POKEMON_SEO_DESCRIPTIONS: dict[str, str] = {
     ),
 }
 
+
 def generate_ai_summary(name_ja: str, manholes: list[dict]) -> str:
     """Return a natural-language summary describing where this Pokemon appears."""
     count = len(manholes)
@@ -81,11 +82,10 @@ def generate_ai_summary(name_ja: str, manholes: list[dict]) -> str:
         dist = f"{name_ja}のポケふたは現在{count}枚確認されています。"
     elif n == 1:
         dist = f"{name_ja}のポケふたは{prefs[0]}に{count}枚設置されています。"
-    elif n <= 3:
-        dist = (
-            f"{name_ja}のポケふたは{'・'.join(prefs)}など{n}都道府県、"
-            f"合計{count}枚設置されています。"
-        )
+    elif n == 2:
+        dist = f"{name_ja}のポケふたは{'・'.join(prefs)}の{n}都道府県、合計{count}枚設置されています。"
+    elif n == 3:
+        dist = f"{name_ja}のポケふたは{'・'.join(prefs)}の{n}都道府県、合計{count}枚設置されています。"
     else:
         dist = (
             f"{name_ja}のポケふたは全国{n}都道府県・{count}枚設置されています。"

--- a/apps/scraper/generate_pokemon_pages.py
+++ b/apps/scraper/generate_pokemon_pages.py
@@ -71,6 +71,35 @@ POKEMON_SEO_DESCRIPTIONS: dict[str, str] = {
     ),
 }
 
+def generate_ai_summary(name_ja: str, manholes: list[dict]) -> str:
+    """Return a natural-language summary describing where this Pokemon appears."""
+    count = len(manholes)
+    prefs = sorted({m.get("prefecture") for m in manholes if m.get("prefecture")})
+    n = len(prefs)
+
+    if n == 0:
+        dist = f"{name_ja}のポケふたは現在{count}枚確認されています。"
+    elif n == 1:
+        dist = f"{name_ja}のポケふたは{prefs[0]}に{count}枚設置されています。"
+    elif n <= 3:
+        dist = (
+            f"{name_ja}のポケふたは{'・'.join(prefs)}など{n}都道府県、"
+            f"合計{count}枚設置されています。"
+        )
+    else:
+        dist = (
+            f"{name_ja}のポケふたは全国{n}都道府県・{count}枚設置されています。"
+            f"{'・'.join(prefs[:2])}をはじめ、各地で出会えます。"
+        )
+
+    if n >= 3:
+        travel = "複数の都道府県を旅行しながら巡るのもおすすめです。"
+    else:
+        travel = "設置地域を訪れながら探してみてください。"
+
+    return dist + travel
+
+
 # Regional form prefix mapping (pokefuta data uses these prefixes)
 _FORM_PREFIX: dict[str, str] = {
     "alola": "アローラ",
@@ -327,6 +356,9 @@ def generate_html(
     gen_html = f"<p class='poke-gen'>第{generation}世代</p>" if generation else ""
     seo_desc_html = f"<p class='poke-seo-desc'>{escape(seo_desc)}</p>" if seo_desc else ""
 
+    ai_summary_text = generate_ai_summary(name_ja, manholes)
+    ai_summary_html = f"<div class='ai-summary-box'><p>{escape(ai_summary_text)}</p></div>"
+
     # JSON-LD
     jsonld = {
         "@context": "https://schema.org",
@@ -385,9 +417,17 @@ def generate_html(
                 + (f"<span class='manhole-poke'>{escape(sub)}</span>" if sub else "")
                 + f"</a></li>"
             )
+        pref_map_link = ""
+        if prefecture:
+            pref_encoded = quote(prefecture)
+            pref_map_link = (
+                f"<a class='pref-map-link' href='/?pref={pref_encoded}'>"
+                f"{escape(prefecture)}の地図で見る →</a>"
+            )
         sections_html += (
             f"<section class='pref-section'>"
             f"<h2>{escape(pref_h2)}</h2>"
+            f"{pref_map_link}"
             f"<ul class='manhole-list'>{cards_html}</ul>"
             f"</section>"
         )
@@ -486,6 +526,25 @@ def generate_html(
       border-left: 3px solid #6F55A3;
       border-radius: 0 6px 6px 0;
     }}
+    .ai-summary-box {{
+      margin-top: 12px;
+      padding: 12px 14px;
+      background: #f0faf9;
+      border-left: 3px solid #176f68;
+      border-radius: 0 6px 6px 0;
+      font-size: 14px;
+      color: #2d5c58;
+      line-height: 1.75;
+    }}
+    .pref-map-link {{
+      display: inline-block;
+      font-size: 12px;
+      color: #6F55A3;
+      text-decoration: none;
+      margin-bottom: 8px;
+      font-weight: bold;
+    }}
+    .pref-map-link:hover {{ text-decoration: underline; }}
     h1 {{
       font-size: 26px;
       font-weight: bold;
@@ -647,6 +706,7 @@ def generate_html(
     {type_html}
     {gen_html}
     {seo_desc_html}
+    {ai_summary_html}
   </div>
 
   <div class="section-card">

--- a/apps/scraper/generate_sitemap.py
+++ b/apps/scraper/generate_sitemap.py
@@ -182,8 +182,8 @@ def url_entry(loc: str, changefreq: str, priority: str) -> str:
 def build_sitemap(manhole_ids: list[str], pokemon_slugs: list[str] | None = None) -> str:
     entries = [
         url_entry(BASE_URL, "daily", "1.0"),
-        url_entry(f"{BASE_URL}summary", "weekly", "0.8"),
-        url_entry(f"{BASE_URL}pokemon/", "weekly", "0.8"),
+        url_entry(f"{BASE_URL}summary", "weekly", "0.9"),
+        url_entry(f"{BASE_URL}pokemon/", "weekly", "0.9"),
         url_entry(f"{BASE_URL}nearby.html", "weekly", "0.6"),
         url_entry(f"{BASE_URL}gmanhole_map.html", "weekly", "0.6"),
     ]
@@ -202,7 +202,7 @@ def build_sitemap(manhole_ids: list[str], pokemon_slugs: list[str] | None = None
     # Pokemon LP pages
     for slug in pokemon_slugs or []:
         entries.append(
-            url_entry(f"{BASE_URL}pokemon/{quote(slug)}/", "weekly", "0.7")
+            url_entry(f"{BASE_URL}pokemon/{quote(slug)}/", "weekly", "0.1")
         )
 
     return "\n".join(

--- a/apps/web/sitemap.xml
+++ b/apps/web/sitemap.xml
@@ -8,12 +8,12 @@
   <url>
     <loc>https://data.pokefuta.com/summary</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
+    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
+    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/nearby.html</loc>
@@ -2613,2671 +2613,2671 @@
   <url>
     <loc>https://data.pokefuta.com/pokemon/abomasnow/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/abra/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/absol/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/accelgor/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/aegislash/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/aerodactyl/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/aggron/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/aipom/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/alakazam/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/alcremie/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/alomomola/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/altaria/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/amaura/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/ampharos/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/applin/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/arcanine/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/archen/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/aromatisse/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/aron/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/arrokuda/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/audino/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/axew/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/azelf/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/azumarill/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/azurill/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/bagon/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/baltoy/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/banette/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/barboach/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/bayleef/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/beartic/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/beautifly/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/bellibolt/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/bellossom/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/bellsprout/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/bergmite/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/bewear/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/bibarel/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/bisharp/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/blastoise/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/blipbug/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/blissey/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/bombirdier/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/bounsweet/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/braixen/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/braviary-hisui/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/bronzong/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/bronzor/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/buizel/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/bulbasaur/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/buneary/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/bunnelby/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/burmy/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/butterfree/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/cacturne/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/camerupt/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/capsakid/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/carkol/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/cascoon/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/castform/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/caterpie/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/celebi/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/cetoddle/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/chansey/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/charizard/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/charjabug/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/charmander/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/cherrim/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/cherubi/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/chespin/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/chikorita/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/chimchar/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/chimecho/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/chinchou/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/chingling/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/clamperl/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/clauncher/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/claydol/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/clefable/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/clefairy/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/cleffa/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/clodsire/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/cloyster/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/combusken/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/comfey/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/corsola/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/corviknight/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/corvisquire/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/cosmog/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/crabrawler/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/cramorant/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/cranidos/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/cresselia/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/croagunk/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/crustle/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/cubchoo/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/cubone/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/cutiefly/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/cyclizar/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/cyndaquil/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/dachsbun/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/darmanitan/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/darmanitan-galar/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/dartrix/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/darumaka/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/decidueye/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/dedenne/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/deerling/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/deino/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/delcatty/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/delphox/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/dewgong/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/dewott/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/dewpider/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/dialga/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/diglett/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/dipplin/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/ditto/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/dodrio/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/doduo/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/dragonair/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/dragonite/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/dratini/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/drednaw/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/ducklett/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/dugtrio/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/dugtrio-alola/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/duosion/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/duraludon/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/eelektrik/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/eelektross/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/eevee/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/eiscue/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/ekans/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/eldegoss/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/electabuzz/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/electrike/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/elekid/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/elgyem/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/emolga/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/empoleon/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/entei/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/escavalier/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/espeon/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/espurr/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/exeggcute/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/exeggutor/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/exeggutor-alola/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/falinks/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/farfetchd/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/farfetchd-galar/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/feebas/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/ferrothorn/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/fidough/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/finizen/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/finneon/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/flabebe/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/flareon/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/fletchinder/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/fletchling/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/flittle/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/floatzel/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/floette/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/florges/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/foongus/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/frillish/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/froakie/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/frogadier/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/froslass/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/gallade/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/garchomp/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/gardevoir/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/gastrodon/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/geodude/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/geodude-alola/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/gible/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/glaceon/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/glalie/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/glameow/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/gogoat/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/goldeen/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/golem/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/golurk/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/gorebyss/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/gossifleur/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/gothorita/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/granbull/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/graveler/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/greninja/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/grookey/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/grotle/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/growlithe/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/growlithe-hisui/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/grubbin/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/gulpin/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/gyarados/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/hakamo-o/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/happiny/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/hatenna/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/hatterene/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/hawlucha/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/heracross/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/herdier/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/ho-oh/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/honedge/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/hoothoot/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/hoppip/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/horsea/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/houndoom/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/huntail/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/hydreigon/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/igglybuff/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/illumise/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/indeedee/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/inkay/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/ivysaur/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/jangmo-o/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/jellicent/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/jigglypuff/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/jirachi/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/jolteon/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/joltik/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/jumpluff/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/kabuto/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/kingambit/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/kingdra/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/kirlia/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/klang/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/klink/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/koffing/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/komala/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/kommo-o/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/krabby/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/kubfu/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/kyogre/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/lampent/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/lapras/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/larvitar/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/latias/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/latios/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/leafeon/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/lechonk/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/ledyba/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/lickilicky/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/lileep/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/lilligant/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/litten/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/litwick/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/lombre/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/lopunny/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/lotad/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/loudred/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/lucario/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/ludicolo/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/lugia/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/lunatone/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/lurantis/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/luvdisc/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/luxray/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/lycanroc/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/mabosstiff/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/machamp/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/machoke/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/machop/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/magby/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/magikarp/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/magmar/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/magnemite/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/magneton/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/magnezone/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/makuhita/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/mantine/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/mantyke/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/maractus/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/mareanie/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/mareep/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/marill/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/marshtomp/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/masquerain/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/mawile/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/meloetta/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/meltan/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/meowstic/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/meowth/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/meowth-alola/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/meowth-galar/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/mesprit/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/mew/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/milcery/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/milotic/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/miltank/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/mime-jr/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/minior/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/minun/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/moltres/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/morpeko/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/mr-mime/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/mr-rime/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/mudbray/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/mudsdale/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/munchlax/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/nacli/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/nickit/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/ninetales/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/ninetales-alola/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/nosepass/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/octillery/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/oddish/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/ogerpon/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/omanyte/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/omastar/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/onix/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/oranguru/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/oricorio/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/oshawott/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/pachirisu/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/palafin/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/palkia/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/palpitoad/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/pancham/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/pangoro/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/panpour/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/pansage/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/pansear/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/passimian/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/pawniard/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/pelipper/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/perrserker/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/petilil/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/phanpy/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/phione/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/pichu/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/pidgeot/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/pidgeotto/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/pidgey/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/pidove/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/pikachu/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/pikipek/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/pincurchin/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/piplup/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/plusle/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/politoed/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/poliwag/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/poliwhirl/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/poltchageist/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/polteageist/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/ponyta/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/ponyta-galar/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/poochyena/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/primarina/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/probopass/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/psyduck/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/pyukumuku/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/quagsire/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/quaxly/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/qwilfish/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/raboot/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/raichu/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/raichu-alola/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/raikou/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/ralts/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/rapidash/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/rattata/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/rayquaza/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/regice/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/regigigas/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/regirock/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/registeel/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/relicanth/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/remoraid/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/reuniclus/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/rhyhorn/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/rhyperior/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/ribombee/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/rillaboom/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/riolu/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/rockruff/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/roggenrola/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/rookidee/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/roselia/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/roserade/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/rowlet/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/rufflet/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/sableye/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/salamence/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/salandit/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/samurott/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/sandshrew/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/sandshrew-alola/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/sandslash/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/sandslash-alola/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/sandygast/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/sawsbuck/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/sceptile/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/scorbunny/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/scovillain/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/seadra/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/sealeo/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/seedot/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/seismitoad/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/sentret/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/serperior/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/seviper/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/sewaddle/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/sharpedo/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/shellder/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/shellos/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/shieldon/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/shiftry/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/shiinotic/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/shuckle/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/sigilyph/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/silcoon/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/simisear/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/sinistcha/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/sinistea/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/sirfetchd/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/sizzlipede/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/skarmory/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/skiddo/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/skiploom/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/skitty/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/skwovet/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/slaking/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/slakoth/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/slowbro/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/slowking/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/slowpoke/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/slowpoke-galar/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/slurpuff/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/smoochum/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/snom/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/snorlax/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/snorunt/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/snover/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/snubbull/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/sobble/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/solrock/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/spearow/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/spheal/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/spinda/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/spoink/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/squawkabilly/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/squirtle/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/stantler/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/staraptor/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/staravia/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/starly/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/starmie/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/staryu/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/steenee/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/stufful/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/stunfisk/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/sudowoodo/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/suicune/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/sunflora/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/sunkern/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/surskit/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/swablu/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/swadloon/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/swanna/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/swinub/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/swirlix/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/sylveon/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/taillow/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/talonflame/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/tandemaus/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/tatsugiri/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/tauros/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/teddiursa/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/tentacool/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/tentacruel/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/thundurus/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/thwackey/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/timburr/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/tirtouga/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/togedemaru/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/togekiss/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/togepi/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/togetic/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/torkoal/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/torracat/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/torterra/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/totodile/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/toxel/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/trapinch/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/treecko/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/tropius/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/tsareena/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/turtwig/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/tympole/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/tynamo/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/typhlosion/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/tyrantrum/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/tyrunt/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/umbreon/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/unfezant/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/urshifu/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/uxie/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/vanillish/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/vanillite/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/vaporeon/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/varoom/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/venusaur/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/victini/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/vikavolt/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/vileplume/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/virizion/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/volbeat/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/vulpix/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/vulpix-alola/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/wailmer/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/wailord/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/wartortle/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/wattrel/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/weavile/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/weedle/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/whimsicott/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/whiscash/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/wigglytuff/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/wiglett/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/wingull/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/wishiwashi/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/woobat/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/wooloo/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/wooper/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/wormadam/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/wynaut/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/xatu/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/yamask-galar/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/yamper/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/yanma/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/zangoose/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
   <url>
     <loc>https://data.pokefuta.com/pokemon/zigzagoon/</loc>
     <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
+    <priority>0.1</priority>
   </url>
 </urlset>

--- a/apps/web/summary.html
+++ b/apps/web/summary.html
@@ -220,6 +220,12 @@
       line-height: 1.75;
     }
 
+    .summary-section:empty,
+    #ai-summary-section:empty,
+    #discovery-section:empty {
+      display: none;
+    }
+
     .summary-list li a.summary-link {
       font-size: .78rem;
       margin-left: 6px;
@@ -395,7 +401,6 @@
       if (!ranking.length) return '';
       const top1 = ranking[0];
       const top3 = ranking.slice(0, 3).map(r => r.prefecture).join('・');
-      const avgActive = Math.round(total / (summary.length - empty.length));
       const emptyCount = empty.length;
       let text = `全国には${total}枚のポケふたが設置されています。`;
       text += `最も多いのは${top1.prefecture}（${top1.count}枚）で、${top3}などに多く分布しています。`;
@@ -407,6 +412,7 @@
     }
 
     function generateDiscoveryCards(summary, ranking, total, empty) {
+      if (!ranking.length || !total) return '';
       const installed = summary.filter(item => item.count > 0);
       const top1 = ranking[0];
       const avg = installed.length ? Math.round(total / installed.length) : 0;
@@ -437,7 +443,8 @@
       const top = sorted[0];
       const second = sorted[1];
       if (!top) return '';
-      let text = `地方別では${top[0]}（${top[1]}枚）が最も多く、${second ? `次いで${second[0]}（${second[1]}枚）` : ''}となっています。`;
+      let text = `地方別では${top[0]}（${top[1]}枚）が最も多く`;
+      text += second ? `、次いで${second[0]}（${second[1]}枚）となっています。` : `となっています。`;
       text += `ポケふたは地方自治体・観光協会との連携で設置されることが多く、観光地や駅周辺に置かれているケースが目立ちます。`;
       text += `地域を旅しながら複数のポケふたを巡るルートを作るのも人気の楽しみ方です。`;
       return `<p>${escapeHtml(text)}</p>`;

--- a/apps/web/summary.html
+++ b/apps/web/summary.html
@@ -161,6 +161,70 @@
       text-decoration: none;
     }
 
+    .ai-summary-box {
+      margin: 0 0 20px;
+      padding: 16px 18px;
+      background: #f0faf9;
+      border-left: 4px solid #176f68;
+      border-radius: 0 8px 8px 0;
+      font-size: 1rem;
+      color: #2d5c58;
+      line-height: 1.8;
+    }
+
+    .discovery-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 10px;
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .discovery-card {
+      padding: 14px;
+      border: 1px solid rgba(93, 67, 35, .14);
+      border-radius: 8px;
+      background: #fffdf7;
+    }
+
+    .discovery-card strong {
+      display: block;
+      font-size: 1.25rem;
+      line-height: 1.2;
+      margin-bottom: 4px;
+      color: #176f68;
+    }
+
+    .discovery-card span {
+      display: block;
+      font-size: .84rem;
+      color: #5a4f47;
+      font-weight: 750;
+    }
+
+    .regional-trend-box {
+      padding: 14px 16px;
+      border: 1px solid rgba(93, 67, 35, .14);
+      border-radius: 8px;
+      background: #fffaf0;
+      font-size: .95rem;
+      color: #574b41;
+      line-height: 1.8;
+    }
+
+    .empty-note {
+      margin-top: 10px;
+      font-size: .9rem;
+      color: #716154;
+      line-height: 1.75;
+    }
+
+    .summary-list li a.summary-link {
+      font-size: .78rem;
+      margin-left: 6px;
+    }
+
     @media (max-width: 700px) {
       .summary-stats {
         grid-template-columns: 1fr;
@@ -168,6 +232,10 @@
 
       .summary-hero h1 {
         font-size: 2rem;
+      }
+
+      .discovery-grid {
+        grid-template-columns: repeat(2, 1fr);
       }
     }
   </style>
@@ -179,6 +247,8 @@
       <h1>ポケふたは全国に何個ある？</h1>
       <p>全国のポケふた・ポケモンマンホールを、既存データから都道府県別に集計しています。</p>
     </nav>
+
+    <div id="ai-summary-section"></div>
 
     <section class="summary-stats" aria-label="全国集計">
       <div class="summary-stat">
@@ -194,6 +264,8 @@
         <strong id="empty-prefecture-count">-</strong>
       </div>
     </section>
+
+    <section id="discovery-section" class="summary-section" aria-label="発見"></section>
 
     <section class="summary-section" aria-labelledby="prefecture-count-heading">
       <h2 id="prefecture-count-heading">都道府県別の設置数一覧</h2>
@@ -216,17 +288,24 @@
     <section class="summary-section" aria-labelledby="ranking-heading">
       <h2 id="ranking-heading">ポケふたが多い県ランキング</h2>
       <ol id="ranking-list" class="summary-list"></ol>
+      <p style="margin-top:10px;font-size:.875rem;color:#574b41;">各都道府県の地図は、<a class="summary-link" href="/">全国マップ</a>から地域を選んで確認できます。</p>
+    </section>
+
+    <section id="regional-trend-section" class="summary-section" aria-labelledby="regional-trend-heading">
+      <h2 id="regional-trend-heading">地域の分布傾向</h2>
+      <div id="regional-trend-box" class="regional-trend-box"></div>
     </section>
 
     <section class="summary-section" aria-labelledby="empty-prefecture-heading">
       <h2 id="empty-prefecture-heading">ポケふたがない県</h2>
-      <ul id="empty-prefecture-list" class="summary-list"></ul>
+      <p class="empty-note">まだポケふたが設置されていない県もあります。今後新しい地域へ広がる可能性があり、"次はどこに設置されるか"を予想する楽しみもあります。</p>
+      <ul id="empty-prefecture-list" class="summary-list" style="margin-top:10px;"></ul>
     </section>
 
     <section class="summary-section" aria-labelledby="map-link-heading">
       <h2 id="map-link-heading">全国マップで探す</h2>
-      <p>設置場所や近くのポケふたは、地図上で確認できます。</p>
-      <a class="summary-cta" href="/">地図で全国のポケふたを探す</a>
+      <p>設置場所や近くのポケふたは、地図上で確認できます。都道府県フィルターで絞り込んで巡るルートを考えてみましょう。</p>
+      <a class="summary-cta" href="/">地図で全国のポケふたを探す →</a>
     </section>
   </main>
 
@@ -300,11 +379,79 @@
         .sort((a, b) => a.code.localeCompare(b.code));
     }
 
+    const REGION_MAP = {
+      '北海道': '北海道',
+      '青森県': '東北', '岩手県': '東北', '宮城県': '東北', '秋田県': '東北', '山形県': '東北', '福島県': '東北',
+      '茨城県': '関東', '栃木県': '関東', '群馬県': '関東', '埼玉県': '関東', '千葉県': '関東', '東京都': '関東', '神奈川県': '関東',
+      '新潟県': '中部', '富山県': '中部', '石川県': '中部', '福井県': '中部', '山梨県': '中部', '長野県': '中部',
+      '岐阜県': '中部', '静岡県': '中部', '愛知県': '中部',
+      '三重県': '近畿', '滋賀県': '近畿', '京都府': '近畿', '大阪府': '近畿', '兵庫県': '近畿', '奈良県': '近畿', '和歌山県': '近畿',
+      '鳥取県': '中国', '島根県': '中国', '岡山県': '中国', '広島県': '中国', '山口県': '中国',
+      '徳島県': '四国', '香川県': '四国', '愛媛県': '四国', '高知県': '四国',
+      '福岡県': '九州', '佐賀県': '九州', '長崎県': '九州', '熊本県': '九州', '大分県': '九州', '宮崎県': '九州', '鹿児島県': '九州', '沖縄県': '九州'
+    };
+
+    function generateAISummary(summary, ranking, total, empty) {
+      if (!ranking.length) return '';
+      const top1 = ranking[0];
+      const top3 = ranking.slice(0, 3).map(r => r.prefecture).join('・');
+      const avgActive = Math.round(total / (summary.length - empty.length));
+      const emptyCount = empty.length;
+      let text = `全国には${total}枚のポケふたが設置されています。`;
+      text += `最も多いのは${top1.prefecture}（${top1.count}枚）で、${top3}などに多く分布しています。`;
+      if (emptyCount > 0) {
+        text += `まだ${emptyCount}県では設置されていませんが、今後の広がりも期待されます。`;
+      }
+      text += `ポケふたは地方観光や地域振興との結びつきが強く、旅行しながら巡る楽しみ方が特徴です。`;
+      return `<div class="ai-summary-box"><p>${escapeHtml(text)}</p></div>`;
+    }
+
+    function generateDiscoveryCards(summary, ranking, total, empty) {
+      const installed = summary.filter(item => item.count > 0);
+      const top1 = ranking[0];
+      const avg = installed.length ? Math.round(total / installed.length) : 0;
+      const maxConc = Math.round((top1.count / total) * 100);
+
+      const cards = [
+        { stat: `${top1.count}枚`, desc: `${top1.prefecture}だけで全国${maxConc}%` },
+        { stat: `${installed.length}都道府県`, desc: 'ポケふた設置済み' },
+        { stat: `${avg}枚`, desc: '設置済み県の平均枚数' },
+      ];
+      if (empty.length > 0) {
+        cards.push({ stat: `${empty.length}県`, desc: 'まだ未設置の県がある' });
+      }
+
+      const items = cards.map(c =>
+        `<li class="discovery-card"><strong>${escapeHtml(c.stat)}</strong><span>${escapeHtml(c.desc)}</span></li>`
+      ).join('');
+      return `<ul class="discovery-grid">${items}</ul>`;
+    }
+
+    function generateRegionalTrend(summary, ranking) {
+      const regionCounts = {};
+      summary.forEach(item => {
+        const region = REGION_MAP[item.prefecture] || 'その他';
+        regionCounts[region] = (regionCounts[region] || 0) + item.count;
+      });
+      const sorted = Object.entries(regionCounts).sort((a, b) => b[1] - a[1]);
+      const top = sorted[0];
+      const second = sorted[1];
+      if (!top) return '';
+      let text = `地方別では${top[0]}（${top[1]}枚）が最も多く、${second ? `次いで${second[0]}（${second[1]}枚）` : ''}となっています。`;
+      text += `ポケふたは地方自治体・観光協会との連携で設置されることが多く、観光地や駅周辺に置かれているケースが目立ちます。`;
+      text += `地域を旅しながら複数のポケふたを巡るルートを作るのも人気の楽しみ方です。`;
+      return `<p>${escapeHtml(text)}</p>`;
+    }
+
     function render(summary) {
       const total = summary.reduce((sum, item) => sum + item.count, 0);
       const installed = summary.filter(item => item.count > 0);
       const empty = summary.filter(item => item.count === 0);
       const ranking = [...installed].sort((a, b) => b.count - a.count || a.code.localeCompare(b.code)).slice(0, 10);
+
+      document.getElementById('ai-summary-section').innerHTML = generateAISummary(summary, ranking, total, empty);
+      document.getElementById('discovery-section').innerHTML = generateDiscoveryCards(summary, ranking, total, empty);
+      document.getElementById('regional-trend-box').innerHTML = generateRegionalTrend(summary, ranking);
 
       document.getElementById('total-count').textContent = `${total}枚`;
       document.getElementById('installed-prefecture-count').textContent = `${installed.length}都道府県`;
@@ -322,12 +469,16 @@
         `;
       }).join('');
 
-      document.getElementById('ranking-list').innerHTML = ranking.map(item => `
-        <li>
-          ${escapeHtml(item.prefecture)}
-          <small>${item.count}枚</small>
-        </li>
-      `).join('');
+      document.getElementById('ranking-list').innerHTML = ranking.map(item => {
+        const href = `/?pref=${encodeURIComponent(item.prefecture)}`;
+        return `
+          <li>
+            ${escapeHtml(item.prefecture)}
+            <small>${item.count}枚</small>
+            <a class="summary-link" href="${href}">地図で見る</a>
+          </li>
+        `;
+      }).join('');
 
       document.getElementById('empty-prefecture-list').innerHTML = empty.length
         ? empty.map(item => `<li>${escapeHtml(item.prefecture)}</li>`).join('')


### PR DESCRIPTION
## Summary

- **summary ページ**: AI Summaryセクション（自然文の集計サマリー）・発見カードグリッド・地域傾向セクション・ランキングへの地図リンクを追加。空白県セクションに「今後の広がり」補足テキストを追加
- **pokemon LP** (`/pokemon/{slug}/`): 全534ポケモンに `generate_ai_summary()` で「N都道府県・N枚・旅行文脈」の自然文サマリーを自動生成。都道府県 h2 ごとに「○○の地図で見る →」リンクを追加
- **pokemon index** (`/pokemon/`): 「多く登場するポケモン」説明テキストと地図誘導リンクを追加
- **sitemap**: `/summary` → 0.9、`/pokemon/` → 0.9、`/pokemon/{slug}/` → 0.1 に調整

## Test plan

- [ ] summary ページをローカルサーバーで開き、AI Summary・発見カード・地域傾向が表示されることを確認
- [ ] ランキング各 li に「地図で見る」リンクが表示されることを確認
- [ ] 空白県セクションに補足テキストが表示されることを確認
- [ ] `dist/pokemon/pikachu/index.html` で AI Summary ブロック（緑ボーダー）と都道府県リンクが確認できること
- [ ] `dist/pokemon/index.html` で「多く登場するポケモン」説明テキストが表示されること
- [ ] `apps/web/sitemap.xml` の priority 値が正しいこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)