### PR TITLE
feat: 称号バッジ全件表示・マップポップアップシェアボタン追加

### DIFF
--- a/apps/scraper/generate_manhole_pages.py
+++ b/apps/scraper/generate_manhole_pages.py
@@ -391,16 +391,19 @@ def generate_html(
     )
 
     # og:/twitter: meta tags — inject top title when available
-    _titles_early: list[dict] = manhole.get("titles", []) or []
-    _top_title = _titles_early[0] if _titles_early else None
-    if _top_title:
-        _top_label = f"{_top_title.get('emoji', '')} {_top_title['label']}".strip()
+    titles: list[dict] = manhole.get("titles", []) or []
+    _top = titles[0] if titles else None
+    if _top:
+        _top_prefix = f"{_top['emoji']} " if _top.get('emoji') else ""
+        _top_label = f"{_top_prefix}{_top['label']}"
         _og_title = f"{_top_label}｜{city_label}のポケふた（{pokemon_label}）｜ポケふたマップ"
         _og_desc = f"{_top_label}！{prefecture}{city}に設置されている{pokemon_label}のポケふた。場所・写真・地図で確認できます。"
+        _tw_title = f"{_top_label}｜{city_label}のポケふた（{pokemon_label}）"
         _tw_desc = f"{_top_label}！{prefecture}{city}のポケふたを地図で確認できます。"
     else:
         _og_title = f"{city_label}のポケふた｜{pokemon_label}｜ポケふたマップ"
         _og_desc = f"{prefecture}{city}に設置されている{pokemon_label}のポケふた。場所・写真・地図で確認できます。"
+        _tw_title = f"{city_label}のポケふた｜{pokemon_label}"
         _tw_desc = f"{prefecture}{city}のポケふたを地図で確認できます。"
 
     h1 = f"{prefecture}{city}のポケふた"
@@ -545,7 +548,6 @@ def generate_html(
         pokemon_tags_html = f"<div class='hero-pokemon-tags'>{tags}</div>"
 
     # HERO card: stats badges
-    titles: list[dict] = manhole.get("titles", []) or []
     title_keys: set[str] = {t["key"] for t in titles}
     badges: list[str] = []
     added_at = manhole.get("added_at", "") or ""
@@ -597,8 +599,7 @@ def generate_html(
     # Web Share API (used by shareManhole in links_grid)
     _share_title = f"{city}のポケふた（{pokemon_text}）"
     _top_title_line = (
-        f"{titles[0].get('emoji', '')} {titles[0]['label']}のポケふた！\n".lstrip()
-        if titles else ""
+        f"{_top_prefix}{_top['label']}のポケふた！\n" if _top else ""
     )
     _share_text = (
         f"{_top_title_line}"
@@ -877,7 +878,7 @@ def generate_html(
   <meta property="og:image" content="{escape(og_image)}">
 
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="{escape(_og_title)}">
+  <meta name="twitter:title" content="{escape(_tw_title)}">
   <meta name="twitter:description" content="{escape(_tw_desc)}">
   <meta name="twitter:image" content="{escape(og_image)}">
 

--- a/apps/scraper/generate_manhole_pages.py
+++ b/apps/scraper/generate_manhole_pages.py
@@ -390,6 +390,19 @@ def generate_html(
         f"場所・写真・地図・周辺のポケふた情報を掲載。"
     )
 
+    # og:/twitter: meta tags — inject top title when available
+    _titles_early: list[dict] = manhole.get("titles", []) or []
+    _top_title = _titles_early[0] if _titles_early else None
+    if _top_title:
+        _top_label = f"{_top_title.get('emoji', '')} {_top_title['label']}".strip()
+        _og_title = f"{_top_label}｜{city_label}のポケふた（{pokemon_label}）｜ポケふたマップ"
+        _og_desc = f"{_top_label}！{prefecture}{city}に設置されている{pokemon_label}のポケふた。場所・写真・地図で確認できます。"
+        _tw_desc = f"{_top_label}！{prefecture}{city}のポケふたを地図で確認できます。"
+    else:
+        _og_title = f"{city_label}のポケふた｜{pokemon_label}｜ポケふたマップ"
+        _og_desc = f"{prefecture}{city}に設置されている{pokemon_label}のポケふた。場所・写真・地図で確認できます。"
+        _tw_desc = f"{prefecture}{city}のポケふたを地図で確認できます。"
+
     h1 = f"{prefecture}{city}のポケふた"
     if pokemons:
         h1 += f"（{pokemon_text}）"
@@ -542,8 +555,8 @@ def generate_html(
             badges.append(f"<span class='hero-badge hero-badge-new'>NEW {added_year}年設置</span>")
     except (ValueError, TypeError):
         pass
-    # Title badges (top 3, from pokefuta.ndjson) — prepended before stats badges
-    for t in titles[:3]:
+    # Title badges (all, from pokefuta.ndjson) — prepended before stats badges
+    for t in titles:
         label = f"{escape(t['emoji'])} {escape(t['label'])}" if t.get("emoji") else escape(t["label"])
         badges.append(f"<span class='hero-badge hero-badge-title'>{label}</span>")
     # Stats badges with suppression rules (§2.3)
@@ -560,7 +573,7 @@ def generate_html(
     stats_html = f"<div class='hero-stats'>{''.join(badges)}</div>" if badges else ""
 
     # HERO card: share JS data (Python-serialized to avoid injection)
-    _title_hashtags = " ".join(t["hashtag"] for t in titles[:2] if t.get("hashtag"))
+    _title_hashtags = " ".join(t["hashtag"] for t in titles if t.get("hashtag"))
     _base_hashtags = f"{_title_hashtags} #ポケふた #ポケモンマンホール".strip()
     if has_photo_bool and pokemons:
         _x_text = (
@@ -583,7 +596,12 @@ def generate_html(
     share_url_json = _js_json(canonical_url)
     # Web Share API (used by shareManhole in links_grid)
     _share_title = f"{city}のポケふた（{pokemon_text}）"
+    _top_title_line = (
+        f"{titles[0].get('emoji', '')} {titles[0]['label']}のポケふた！\n".lstrip()
+        if titles else ""
+    )
     _share_text = (
+        f"{_top_title_line}"
         f"{prefecture}{city}のポケふた（{pokemon_text}）を見つけました。\n"
         f"{prefecture}には{pref_total}枚のポケふたがあります。"
     ) if prefecture else f"{h1}を見つけました。"
@@ -853,14 +871,14 @@ def generate_html(
   <meta property="og:type" content="article">
   <meta property="og:locale" content="ja_JP">
   <meta property="og:site_name" content="ポケふたマップ">
-  <meta property="og:title" content="{escape(f'{city_label}のポケふた｜{pokemon_label}｜ポケふたマップ')}">
-  <meta property="og:description" content="{escape(f'{prefecture}{city}に設置されている{pokemon_label}のポケふた。場所・写真・地図で確認できます。')}">
+  <meta property="og:title" content="{escape(_og_title)}">
+  <meta property="og:description" content="{escape(_og_desc)}">
   <meta property="og:url" content="{escape(canonical_url)}">
   <meta property="og:image" content="{escape(og_image)}">
 
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="{escape(f'{city_label}のポケふた｜{pokemon_label}')}">
-  <meta name="twitter:description" content="{escape(f'{prefecture}{city}のポケふたを地図で確認できます。')}">
+  <meta name="twitter:title" content="{escape(_og_title)}">
+  <meta name="twitter:description" content="{escape(_tw_desc)}">
   <meta name="twitter:image" content="{escape(og_image)}">
 
   <script type="application/ld+json">

--- a/apps/web/assets/pokefuta-map.css
+++ b/apps/web/assets/pokefuta-map.css
@@ -879,6 +879,31 @@ body.pokefuta-map-page {
   color: #168074;
 }
 
+.pokefuta-map-page .travel-popup-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin: 4px 0 6px;
+}
+
+.pokefuta-map-page .travel-popup-badge {
+  background: #f0edff;
+  border: 1px solid #b8a8f0;
+  border-radius: 20px;
+  padding: 2px 10px;
+  font-size: 11px;
+  font-weight: 600;
+  color: #5040a0;
+  white-space: nowrap;
+}
+
+.pokefuta-map-page .travel-popup-action--share {
+  grid-column: 1 / -1;
+  background: #fff;
+  box-shadow: inset 0 0 0 1.5px #b8c0f0;
+  color: #3a4fc7;
+}
+
 /* Pokemon Info Card */
 .pokefuta-map-page .pokemon-info-card {
   margin: 14px 0 0;

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -621,6 +621,7 @@
       const url = button?.dataset.shareUrl;
       if (!url) return;
       const title = button.dataset.shareTitle || 'ポケふた';
+      const text = button.dataset.shareText || '';
 
       // Track share event
       if (window.trackEvent) {
@@ -632,7 +633,7 @@
 
       if (navigator.share) {
         try {
-          await navigator.share({ title, url });
+          await navigator.share({ title, text: text || undefined, url });
           return;
         } catch (error) {
           if (error?.name === 'AbortError') return;
@@ -710,6 +711,22 @@
       ].filter(Boolean).join('');
       const shareUrl = getAbsoluteManholePageUrl(d.id);
       const shareTitle = `${d.title || 'ポケふた'} | ポケふたマップ`;
+      const titles = Array.isArray(d.titles) ? d.titles : [];
+      const titleBadgesHtml = titles.length
+        ? '<div class="travel-popup-badges">'
+          + titles.map(t => '<span class="travel-popup-badge">'
+            + escapeHtml((t.emoji ? t.emoji + ' ' : '') + t.label)
+            + '</span>').join('')
+          + '</div>'
+        : '';
+      const _titleHashtags = titles.map(t => t.hashtag || '').filter(Boolean).join(' ');
+      const _shareHashtags = (_titleHashtags + ' #ポケふた #ポケモンマンホール').trim();
+      const _shareText = titles.length
+        ? (titles[0].emoji ? titles[0].emoji + ' ' : '') + titles[0].label + 'のポケふた！\n' + _shareHashtags
+        : _shareHashtags;
+      const safeShareUrl = escapeHtml(shareUrl);
+      const safeShareTitle = escapeHtml(shareTitle);
+      const safeShareText = escapeHtml(_shareText);
       const photoBlock = imageUrl ? `
         <div class="popup-photo travel-popup-photo" aria-label="マンホール写真">
           <img src="${imageUrl}" alt="${escapeHtml(photoAlt)}" loading="lazy" decoding="async" onerror="handlePopupImageError(this)">
@@ -743,9 +760,13 @@
               ${d.city ? `<b>${escapeHtml(d.city)}</b>` : ''}
             </div>
             <h3 class="travel-popup-title">${escapeHtml(d.title || 'ポケふた')}</h3>
+            ${titleBadgesHtml}
             ${photoComment ? `<p class="travel-popup-comment">${escapeHtml(photoComment)}</p>` : ''}
             <div class="travel-popup-pokemon-list" aria-label="登場ポケモン">${pokemonsHtml}</div>
-            <div class="popup-actions travel-popup-actions travel-popup-actions--single">${officialDetailLink}</div>
+            <div class="popup-actions travel-popup-actions">
+              ${officialDetailLink}
+              <button class="travel-popup-action travel-popup-action--share" data-share-url="${safeShareUrl}" data-share-title="${safeShareTitle}" data-share-text="${safeShareText}" aria-label="シェア">シェア</button>
+            </div>
           </div>
         </div>
       `;

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -726,7 +726,7 @@
         : _shareHashtags;
       const safeShareUrl = escapeHtml(shareUrl);
       const safeShareTitle = escapeHtml(shareTitle);
-      const safeShareText = escapeHtml(_shareText);
+      const safeShareText = escapeHtml(_shareText).replace(/\n/g, '&#10;');
       const photoBlock = imageUrl ? `
         <div class="popup-photo travel-popup-photo" aria-label="マンホール写真">
           <img src="${imageUrl}" alt="${escapeHtml(photoAlt)}" loading="lazy" decoding="async" onerror="handlePopupImageError(this)">


### PR DESCRIPTION
## Summary

- **詳細ページ ヒーローバッジ**: 称号を全件表示（従来は top-3 に制限）
- **OGP / Twitter Card メタタグ**: `og:title`, `og:description`, `twitter:title`, `twitter:description` に称号 top-1 を反映し SNS シェア時のプレビューを個性化
- **X シェアハッシュタグ**: 称号ハッシュタグを全件付与（従来は top-2）
- **Web Share API テキスト**: 共有テキスト冒頭に称号ラベルを追記
- **マップポップアップ**: 称号バッジ全件表示と「シェア」ボタン追加（`data-share-text` 対応）

## Test plan

- [ ] `http://localhost:8000/manholes/67/` を開き、ヒーローバッジに称号 6 件（🧭🌲⭐🏘🏆🌊）が全件表示されることを確認
- [ ] og:title が `🧭 日本最北のポケふた｜稚内のポケふた（...）` 形式になっていることを確認（ブラウザ devtools → Elements → `<head>`）
- [ ] `index.html` マップで称号ありマンホールのポップアップを開き、バッジとシェアボタンが表示されることを確認
- [ ] シェアボタンをクリックし Web Share API または URL コピーが動作することを確認
- [ ] 称号なしのマンホールではバッジが非表示・シェアボタンのみ表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)