### PR TITLE
fix: address パーサーを共通モジュールに統一し先祖返りを防止

### DIFF
--- a/apps/scraper/address_parser.py
+++ b/apps/scraper/address_parser.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Shared address extraction logic for pokefuta scrapers.
+
+Used by:
+  - update_pokefuta.py  (daily CI crawler)
+  - update_address_only.py  (manual address fill tool)
+"""
+import re
+
+from bs4 import BeautifulSoup
+
+
+def extract_address_from_html(html: str) -> str:
+    """Extract Japanese address from manhole detail page HTML.
+
+    Uses a 5-tier pattern cascade with noise filtering:
+      1. Specific detail (numbers, stations, parks)
+      2. Town + number suffix
+      3. Prefecture + city + place name
+      4. Broad range (up to 100 chars after city)
+      5. Fallback: prefecture + city only
+    """
+    soup = BeautifulSoup(html, "html.parser")
+    text_content = soup.get_text()
+
+    noise = ['｜', 'ポケモン', 'マンホール', 'ポケふた']
+
+    specific_detail = (
+        r'([一-鿿]*.{0,3}?(?:県|府|道|都).{0,20}?(?:市|区|町|村).{0,80}?'
+        r'(?:[一-鿿]+町[一-鿿]*\d*|大字[一-鿿]+\d+|字[一-鿿]+\d+'
+        r'|\d+[-−‐]\d+[-−‐]\d+|\d+[-−‐]\d+|\d+丁目|[一-鿿]+駅|[一-鿿]+センター'
+        r'|[一-鿿]+公園))'
+    )
+    town_num     = r'([一-鿿]*.{0,3}?(?:県|府|道|都).{0,20}?(?:市|区|町|村)[一-鿿]+\d+)'
+    place_name   = r'((?:県|府|道|都)[^\n。]*?(?:市|区|町|村)[一-鿿]{2,3}(?=[^\n。\s]|$))'
+    broad        = r'([一-鿿]*.{0,3}?(?:県|府|道|都).{0,20}?(?:市|区|町|村).{0,100}?[^\n。\s](?:\s|$))'
+    fallback     = r'((?:県|府|道|都)[^\n。]*?(?:市|区|町|村))'
+
+    lines = text_content.split('\n')
+
+    for pattern, min_len in [
+        (specific_detail, 0),
+        (town_num,        0),
+        (place_name,      0),
+        (broad,          10),
+        (fallback,        0),
+    ]:
+        for line in lines:
+            for candidate in re.findall(pattern, line):
+                candidate = candidate.strip()
+                if len(candidate) > min_len and not any(kw in candidate for kw in noise):
+                    return candidate
+
+    return ""

--- a/apps/scraper/update_address_only.py
+++ b/apps/scraper/update_address_only.py
@@ -20,6 +20,8 @@ from typing import Dict, List, Optional
 import requests
 from bs4 import BeautifulSoup
 
+from address_parser import extract_address_from_html as extract_address
+
 # Constants
 DEFAULT_BASE = "https://local.pokemon.jp/manhole/"
 HEADERS = {"User-Agent": "pokefuta-address-updater (+https://github.com/nishiokya/pokefuta-tracker)"}
@@ -51,79 +53,7 @@ def fetch(url: str, logger: logging.Logger, headers: Dict[str, str]) -> Optional
     return None
 
 
-def extract_address(html: str) -> str:
-    """Extract address from HTML using improved patterns"""
-    soup = BeautifulSoup(html, "html.parser")
-    text_content = soup.get_text()
-    
-    # ノイズ削除用キーワード
-    critical_noise = ['｜', 'ポケモン', 'マンホール', 'ポケふた']
-    
-    # パターン2（特定パターン）：駅・公園・センター・丁目・番地・数字などを含む
-    specific_detail_pattern = r'([\u4e00-\u9fff]*.{0,3}?(?:県|府|道|都).{0,20}?(?:市|区|町|村).{0,80}?(?:[\u4e00-\u9fff]+町[\u4e00-\u9fff]*\d*|大字[\u4e00-\u9fff]+\d+|字[\u4e00-\u9fff]+\d+|\d+[-−‐]\d+[-−‐]\d+|\d+[-−‐]\d+|\d+丁目|[\u4e00-\u9fff]+駅|[\u4e00-\u9fff]+センター|[\u4e00-\u9fff]+公園))'
-    
-    # パターン1a（町村+数字）：市町村の直後に漢字+数字
-    detailed_pattern_townnum = r'([\u4e00-\u9fff]*.{0,3}?(?:県|府|道|都).{0,20}?(?:市|区|町|村)[\u4e00-\u9fff]+\d+)'
-    
-    # パターン1b（県+市町村+漢字地名）：市町村の直後に2-3文字の漢字地名
-    detailed_pattern_placename = r'((?:県|府|道|都)[^\n。]*?(?:市|区|町|村)[\u4e00-\u9fff]{2,3}(?=[^\n。\s]|$))'
-    
-    # パターン1（より広い範囲）：県+市町村+その後の100文字以内
-    detailed_pattern = r'([\u4e00-\u9fff]*.{0,3}?(?:県|府|道|都).{0,20}?(?:市|区|町|村).{0,100}?[^\n。\s](?:\s|$))'
-    
-    # フォールバック：県名 + 市区町村のみ
-    fallback_pattern = r'((?:県|府|道|都)[^\n。]*?(?:市|区|町|村))'
-    
-    # 行ごとに処理
-    lines = text_content.split('\n')
-    
-    # パターン2（特定パターン）を優先
-    for line in lines:
-        matches = re.findall(specific_detail_pattern, line)
-        if matches:
-            for candidate in matches:
-                candidate = candidate.strip()
-                if not any(keyword in candidate for keyword in critical_noise):
-                    return candidate
-    
-    # パターン1a（町村+数字）：市町村の直後に漢字+数字
-    for line in lines:
-        matches = re.findall(detailed_pattern_townnum, line)
-        if matches:
-            for candidate in matches:
-                candidate = candidate.strip()
-                if not any(keyword in candidate for keyword in critical_noise):
-                    return candidate
-    
-    # パターン1b（県+市町村+漢字地名）
-    for line in lines:
-        matches = re.findall(detailed_pattern_placename, line)
-        if matches:
-            for candidate in matches:
-                candidate = candidate.strip()
-                if not any(keyword in candidate for keyword in critical_noise):
-                    return candidate
-    
-    # パターン1（より広い範囲）を試す
-    for line in lines:
-        matches = re.findall(detailed_pattern, line)
-        if matches:
-            for candidate in matches:
-                candidate = candidate.strip()
-                if len(candidate) > 10 and not any(keyword in candidate for keyword in critical_noise):
-                    return candidate
-    
-    # フォールバック
-    for line in lines:
-        matches = re.findall(fallback_pattern, line)
-        if matches:
-            for candidate in matches:
-                candidate = candidate.strip()
-                if not any(keyword in candidate for keyword in critical_noise):
-                    return candidate
-    
-    return ""
-
+# extract_address は address_parser からインポート済み (ファイル先頭参照)
 
 def update_address_only(input_path: str, output_path: str, logger: logging.Logger) -> tuple:
     """Update address field for existing records"""

--- a/apps/scraper/update_pokefuta.py
+++ b/apps/scraper/update_pokefuta.py
@@ -37,6 +37,8 @@ from typing import Any, Dict, List, Optional, Tuple
 from bs4 import BeautifulSoup
 import requests
 
+from address_parser import extract_address_from_html
+
 # Constants (unified with scrape_pokefuta.py)
 DEFAULT_BASE = "https://local.pokemon.jp/manhole/"
 HEADERS = {"User-Agent": "pokefuta-tracker-updater (+https://github.com/nishiokya/pokefuta-tracker)"}
@@ -320,20 +322,8 @@ def parse_detail(detail_url: str, html: str, logger: logging.Logger, title_data:
                 prefecture = pf
                 city = ct.rstrip("市町村区") if ct else ""
 
-    # 住所の取得 - HTML から可能な限り抽出 (不足分は後段の title.tsv で補完)
-    address = ""
-    # まずWebページから住所らしき文字列を抽出
-    text_content = soup.get_text()
-    address_patterns = [
-        r'([^。\n]*(?:県|府|道|都)[^。\n]*(?:市|区|町|村)[^。\n]*(?:\d+[-−‐]\d+[-−‐]\d+|\d+丁目|\d+番地)[^。\n]*)',
-        r'([^。\n]*(?:市|区|町|村)[^。\n]*(?:\d+[-−‐]\d+[-−‐]\d+|\d+丁目|\d+番地)[^。\n]*)',
-    ]
-    for pattern in address_patterns:
-        matches = re.findall(pattern, text_content)
-        if matches:
-            # 最も長い住所らしきものを選択
-            address = max(matches, key=len).strip()
-            break
+    # 住所の取得 - address_parser の共通ロジックを使用
+    address = extract_address_from_html(html)
     
     # Detect prefecture_site_url from link text
     prefecture_site_url = ""
@@ -489,6 +479,7 @@ def main():
             r.pop('source_last_checked', None)
         for _f in ('parking', 'nearby_spots', 'source_urls', 'address_raw', 'address_norm'):
             r.pop(_f, None)
+        r.setdefault('is_prefecture_site', False)
         if apply_title_metadata(r, title_data):
             changed.setdefault(r['id'], {})['title_metadata'] = True
         # Always sync city_url from city_links (source of truth, no last_updated bump)


### PR DESCRIPTION
## 問題の根本原因

`update_pokefuta.py`（デイリー CI）の住所抽出が簡易パーサー（2パターン）のため、
PR#115 で補完した 299件の住所を毎回 `""` で上書きし続けていた。

### 検証済み：同じ HTML への両パーサーの結果

| id | 旧パーサー（daily CI） | 新パーサー（PR#115 で使用） |
|---|---|---|
| 3 | `""` | `"鹿児島県指宿市東方9300−1"` |
| 7 | `""` | `"鹿児島県指宿市東方11915-5"` |
| 12 | `""` | `"岩手県野田村大字野田第5"` |
| 22 | `""` | `"岩手県住田町上有住字土倉298"` |
| 23 | `""` | `"神奈川県横浜市中区桜木町1"` |

## 変更内容

### 1. `apps/scraper/address_parser.py`（新規）
`extract_address_from_html()` を共通モジュールとして切り出し。
5段階パターン＋ノイズフィルタ付き。

### 2. `update_pokefuta.py`
- `parse_detail()` の住所抽出を `address_parser.extract_address_from_html(html)` に差し替え
- 既存レコード前処理に `r.setdefault('is_prefecture_site', False)` を追加
  → 新スキーマフィールド追加時に全件 CHANGED になるフォールスポジティブを防止（bbaa72 再発防止）

### 3. `update_address_only.py`
重複していた `extract_address()` を削除し `address_parser` からインポートに変更。

## 期待される効果

- デイリー CI が毎回同じ住所を返すようになりコンフリクトが解消
- 住所パーサーの改善が `address_parser.py` 1ファイルの変更で両スクリプトに反映される

## 対処が必要な既存 PR

`daily/update-pokefuta-dataset` PR は古いパーサーで生成されたコンフリクト状態。
この PR のマージ後に手動でクローズし、次回 daily 実行を待つこと。

🤖 Generated with [Claude Code](https://claude.com/claude-code)