### PR TITLE
Update manhole semantic metadata (20260520)

### DIFF
--- a/dataset/manhole_titles.json
+++ b/dataset/manhole_titles.json
@@ -421,6 +421,11 @@
       "prefecture": "三重県",
       "city": "菰野町",
       "url": "https://www2.town.komono.mie.jp/www/contents/1742359133701/index.html"
+    },
+    {
+      "prefecture": "茨城県",
+      "city": "つくば市",
+      "url": "https://www.city.tsukuba.lg.jp/soshikikarasagasu/toshikeikakubugakuenchikushigaichishinkoka/gyomuannai/1/25531.html"
     }
   ],
   "manholes": {


### PR DESCRIPTION
## Summary

semantic metadata をセマンティックエディタで更新しました。

## 変更内容

- add_municipality_url: 1件

対象マンホール数（ユニーク）: 0件

## Tasks

- add_municipality_url: 1件

## Guardrails

- docs/pokefuta.ndjson は変更されていません
- dataset/manhole_titles.json のみ変更されています

## Validation

- [x] JSON parse OK
- [x] schema OK
- [x] docs/*.ndjson 汚染なし
- [x] changes.ndjson で操作ログ確認済み

🤖 Generated with Semantic Manhole Metadata Editor