### PR TITLE
Update manhole semantic metadata (20260520)

### DIFF
--- a/dataset/manhole_titles.json
+++ b/dataset/manhole_titles.json
@@ -434,6 +434,11 @@
         "seaside"
       ]
     },
+    "6": {
+      "tags": [
+        "station_front"
+      ]
+    },
     "7": {
       "tags": [
         "seaside"


### PR DESCRIPTION
## Summary

semantic metadata をセマンティックエディタで更新しました。

## 変更内容

- assign_station_tags: 3件

対象マンホール数（ユニーク）: 3件

## Tasks

- assign_station_tags: 3件

## Guardrails

- docs/pokefuta.ndjson は変更されていません
- dataset/manhole_titles.json のみ変更されています

## Validation

- [x] JSON parse OK
- [x] schema OK
- [x] docs/*.ndjson 汚染なし
- [x] changes.ndjson で操作ログ確認済み

🤖 Generated with Semantic Manhole Metadata Editor