### PR TITLE
feat: map-based tag editor with shared MapTagsTask component

### DIFF
--- a/tools/manhole-semantic-editor/package-lock.json
+++ b/tools/manhole-semantic-editor/package-lock.json
@@ -8,6 +8,8 @@
       "name": "manhole-semantic-editor",
       "version": "0.1.0",
       "dependencies": {
+        "@types/leaflet": "^1.9.21",
+        "leaflet": "^1.9.4",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
@@ -1152,6 +1154,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.21",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.21.tgz",
+      "integrity": "sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.19.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
@@ -1423,6 +1440,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",

--- a/tools/manhole-semantic-editor/package.json
+++ b/tools/manhole-semantic-editor/package.json
@@ -12,6 +12,8 @@
     "lint-titles:check": "node scripts/lint-titles.js --check"
   },
   "dependencies": {
+    "@types/leaflet": "^1.9.21",
+    "leaflet": "^1.9.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/tools/manhole-semantic-editor/scripts/create-pr.js
+++ b/tools/manhole-semantic-editor/scripts/create-pr.js
@@ -16,9 +16,8 @@ function run(cmd, opts = {}) {
 function getJSTTimestamp() {
   const now = new Date()
   const jst = new Date(now.getTime() + 9 * 60 * 60 * 1000)
-  const date = jst.toISOString().slice(0, 10).replace(/-/g, '')
-  const time = jst.toISOString().slice(11, 16).replace(':', '')
-  return `${date}-${time}`
+  const iso = jst.toISOString()
+  return iso.slice(0, 10).replace(/-/g, '') + iso.slice(11, 19).replace(/:/g, '')
 }
 
 function buildPRBody(patches) {

--- a/tools/manhole-semantic-editor/src/App.tsx
+++ b/tools/manhole-semantic-editor/src/App.tsx
@@ -8,6 +8,7 @@ import { AddMunicipalityUrlTask } from './tasks/addMunicipalityUrl/AddMunicipali
 import { VerifyOfficialUrlTask } from './tasks/verifyOfficialUrl/VerifyOfficialUrlTask'
 import { VerifyTitleTask } from './tasks/verifyTitle/VerifyTitleTask'
 import { AssignStationTagsTask } from './tasks/assignStationTags/AssignStationTagsTask'
+import { AssignTourismTagsTask } from './tasks/assignTourismTags/AssignTourismTagsTask'
 import { AdminBulkEditTask } from './tasks/adminBulkEdit/AdminBulkEditTask'
 
 type ActiveTask = 'home' | TaskType
@@ -104,7 +105,7 @@ export default function App() {
     if (!titles) return null
     switch (activeTask) {
       case 'assign_location_tags':
-        return <AssignLocationTagsTask {...commonProps} titles={titles} onSave={handleSavePatch} />
+        return <AssignLocationTagsTask {...commonProps} titles={titles} onSaveMany={handleSavePatches} />
       case 'add_municipality_url':
         return <AddMunicipalityUrlTask {...commonProps} titles={titles} onSave={handleSavePatch} />
       case 'verify_official_url':
@@ -112,9 +113,9 @@ export default function App() {
       case 'verify_title':
         return <VerifyTitleTask {...commonProps} titles={titles} onSave={handleSavePatch} />
       case 'assign_station_tags':
-        return <AssignStationTagsTask {...commonProps} titles={titles} onSave={handleSavePatch} />
+        return <AssignStationTagsTask {...commonProps} titles={titles} onSaveMany={handleSavePatches} />
       case 'assign_tourism_tags':
-        return <AssignLocationTagsTask {...commonProps} titles={titles} onSave={handleSavePatch} />
+        return <AssignTourismTagsTask {...commonProps} titles={titles} onSaveMany={handleSavePatches} />
       case 'admin_edit_manhole':
         return <AdminSingleEdit records={records} titles={titles} onSave={handleSavePatch} saving={saving} />
       case 'admin_bulk_edit':

--- a/tools/manhole-semantic-editor/src/tasks/assignLocationTags/AssignLocationTagsTask.tsx
+++ b/tools/manhole-semantic-editor/src/tasks/assignLocationTags/AssignLocationTagsTask.tsx
@@ -1,12 +1,9 @@
-import { useState, useMemo } from 'react'
 import type { PokefutaRecord, ManholeTitlesJson, SemanticPatch } from '../../semantic/semanticPatch'
-import { validatePatch } from '../../semantic/semanticPatchValidator'
-import { newPatchId } from '../../util'
+import { MapTagsTask } from '../shared/MapTagsTask'
 
 const LOCATION_TAGS = ['seaside', 'beach', 'lakeside', 'river', 'remote_island'] as const
-type LocationTag = (typeof LOCATION_TAGS)[number]
 
-const TAG_LABEL: Record<LocationTag, string> = {
+const TAG_LABEL: Record<(typeof LOCATION_TAGS)[number], string> = {
   seaside: '🌊 海沿い',
   beach: '🏖 ビーチ',
   lakeside: '🏞 湖畔',
@@ -17,188 +14,18 @@ const TAG_LABEL: Record<LocationTag, string> = {
 type Props = {
   records: PokefutaRecord[]
   titles: ManholeTitlesJson
-  onSave: (patch: SemanticPatch) => Promise<void>
+  onSaveMany: (patches: SemanticPatch[]) => Promise<void>
   saving: boolean
 }
 
-export function AssignLocationTagsTask({ records, titles, onSave, saving }: Props) {
-  const [search, setSearch] = useState('')
-  const [prefFilter, setPrefFilter] = useState('')
-  const [showFilter, setShowFilter] = useState<'all' | 'has_tag' | 'no_tag'>('all')
-  const [pending, setPending] = useState<Map<string, Set<string>>>(new Map())
-  const [saveError, setSaveError] = useState<string | null>(null)
-
-  const prefectures = useMemo(
-    () => [...new Set(records.map(r => r.prefecture))].sort(),
-    [records]
-  )
-
-  const filtered = useMemo(() => {
-    return records.filter(r => {
-      if (r.status !== 'active') return false
-      if (prefFilter && r.prefecture !== prefFilter) return false
-      if (search && !`${r.id} ${r.prefecture} ${r.city} ${r.address}`.includes(search)) return false
-      const currentTags = titles.manholes[r.id]?.tags ?? []
-      const hasLocationTag = LOCATION_TAGS.some(t => currentTags.includes(t))
-      if (showFilter === 'has_tag' && !hasLocationTag) return false
-      if (showFilter === 'no_tag' && hasLocationTag) return false
-      return true
-    })
-  }, [records, titles, prefFilter, search, showFilter])
-
-  function getEffectiveTags(id: string): Set<string> {
-    if (pending.has(id)) return new Set(pending.get(id))
-    return new Set(titles.manholes[id]?.tags ?? [])
-  }
-
-  function toggleTag(id: string, tag: string) {
-    setPending(prev => {
-      const next = new Map(prev)
-      const base = new Set(titles.manholes[id]?.tags ?? [])
-      const current = next.has(id) ? new Set(next.get(id)) : new Set(base)
-      if (current.has(tag)) current.delete(tag)
-      else current.add(tag)
-      // If same as base, remove from pending
-      if ([...current].sort().join() === [...base].sort().join()) {
-        next.delete(id)
-      } else {
-        next.set(id, current)
-      }
-      return next
-    })
-  }
-
-  const pendingCount = pending.size
-
-  async function handleSaveAll() {
-    setSaveError(null)
-    for (const [id, tags] of pending.entries()) {
-      const base = new Set(titles.manholes[id]?.tags ?? [])
-      const added = [...tags].filter(t => !base.has(t))
-      const removed = [...base].filter(t => !tags.has(t))
-
-      if (added.length > 0) {
-        const patch: SemanticPatch = {
-          id: newPatchId(),
-          createdAt: new Date().toISOString(),
-          taskType: 'assign_location_tags',
-          operation: 'add_tags',
-          target: 'manholes',
-          manholeIds: [parseInt(id, 10)],
-          payload: { tags: added },
-        }
-        const v = validatePatch(patch, titles)
-        if (!v.valid) { setSaveError(v.errors.join('\n')); return }
-        await onSave(patch)
-      }
-      if (removed.length > 0) {
-        const patch: SemanticPatch = {
-          id: newPatchId(),
-          createdAt: new Date().toISOString(),
-          taskType: 'assign_location_tags',
-          operation: 'remove_tags',
-          target: 'manholes',
-          manholeIds: [parseInt(id, 10)],
-          payload: { tags: removed },
-        }
-        await onSave(patch)
-      }
-    }
-    setPending(new Map())
-  }
-
+export function AssignLocationTagsTask(props: Props) {
   return (
-    <div>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
-        <h2 style={{ margin: 0 }}>海・湖・離島タグを付ける</h2>
-        {pendingCount > 0 && (
-          <button
-            className="btn btn-primary"
-            onClick={handleSaveAll}
-            disabled={saving}
-          >
-            {saving ? '保存中…' : `${pendingCount}件を保存`}
-          </button>
-        )}
-      </div>
-
-      {saveError && (
-        <div style={{ background: '#fef2f2', border: '1px solid #fca5a5', borderRadius: 6, padding: 12, marginBottom: 12, color: '#dc2626' }}>
-          {saveError}
-        </div>
-      )}
-
-      <div className="filter-bar">
-        <input
-          placeholder="ID / 住所 / 市区町村で絞り込み"
-          value={search}
-          onChange={e => setSearch(e.target.value)}
-          style={{ width: 260 }}
-        />
-        <select value={prefFilter} onChange={e => setPrefFilter(e.target.value)}>
-          <option value="">全都道府県</option>
-          {prefectures.map(p => <option key={p} value={p}>{p}</option>)}
-        </select>
-        <select value={showFilter} onChange={e => setShowFilter(e.target.value as typeof showFilter)}>
-          <option value="all">全件</option>
-          <option value="has_tag">タグあり</option>
-          <option value="no_tag">タグなし</option>
-        </select>
-        <span style={{ color: '#6b7280', fontSize: 13 }}>{filtered.length}件</span>
-      </div>
-
-      <table className="table">
-        <thead>
-          <tr>
-            <th style={{ width: 60 }}>ID</th>
-            <th>場所</th>
-            <th>住所</th>
-            <th>地図</th>
-            <th>タグ</th>
-          </tr>
-        </thead>
-        <tbody>
-          {filtered.slice(0, 200).map(r => {
-            const effectiveTags = getEffectiveTags(r.id)
-            const isDirty = pending.has(r.id)
-            return (
-              <tr key={r.id} style={isDirty ? { background: '#fefce8' } : undefined}>
-                <td style={{ fontFamily: 'monospace' }}>{r.id}</td>
-                <td>
-                  <div>{r.prefecture} {r.city}</div>
-                  {titles.manholes[r.id]?.building && (
-                    <div style={{ fontSize: 11, color: '#6b7280' }}>{titles.manholes[r.id].building}</div>
-                  )}
-                </td>
-                <td style={{ fontSize: 12, maxWidth: 200, wordBreak: 'break-all' }}>{r.address}</td>
-                <td style={{ whiteSpace: 'nowrap' }}>
-                  <a href={`https://maps.google.com/?q=${r.lat},${r.lng}`} target="_blank" rel="noreferrer" style={{ fontSize: 12, marginRight: 6 }}>GM</a>
-                  <a href={`https://www.openstreetmap.org/?mlat=${r.lat}&mlon=${r.lng}&zoom=17`} target="_blank" rel="noreferrer" style={{ fontSize: 12 }}>OSM</a>
-                </td>
-                <td>
-                  <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
-                    {LOCATION_TAGS.map(tag => (
-                      <button
-                        key={tag}
-                        className={`tag ${effectiveTags.has(tag) ? 'tag-active' : 'tag-inactive'}`}
-                        onClick={() => toggleTag(r.id, tag)}
-                        title={tag}
-                      >
-                        {TAG_LABEL[tag]}
-                      </button>
-                    ))}
-                  </div>
-                </td>
-              </tr>
-            )
-          })}
-        </tbody>
-      </table>
-      {filtered.length > 200 && (
-        <p style={{ color: '#6b7280', fontSize: 13, marginTop: 8 }}>
-          先頭200件を表示。絞り込みで件数を減らしてください。
-        </p>
-      )}
-    </div>
+    <MapTagsTask
+      {...props}
+      title="海・湖・離島タグを付ける"
+      taskType="assign_location_tags"
+      tags={LOCATION_TAGS}
+      tagLabels={TAG_LABEL}
+    />
   )
 }

--- a/tools/manhole-semantic-editor/src/tasks/assignStationTags/AssignStationTagsTask.tsx
+++ b/tools/manhole-semantic-editor/src/tasks/assignStationTags/AssignStationTagsTask.tsx
@@ -1,35 +1,39 @@
-import type { PokefutaRecord, ManholeTitlesJson, SemanticPatch } from '../../semantic/semanticPatch'
+import type { PokefutaRecord, ManholeTitlesJson, SemanticPatch, ManholeEntry } from '../../semantic/semanticPatch'
+import { MapTagsTask } from '../shared/MapTagsTask'
+
+const STATION_TAGS = ['in_station', 'station_front', 'near_station', 'rail_access_good'] as const
+
+const TAG_LABEL: Record<(typeof STATION_TAGS)[number], string> = {
+  in_station: '🚉 駅構内',
+  station_front: '🏢 駅前',
+  near_station: '🚶 駅近',
+  rail_access_good: '🚆 アクセス良',
+}
+
+function stationHint(r: PokefutaRecord, entry: ManholeEntry | undefined): boolean {
+  return (
+    r.address.includes('駅') ||
+    (entry?.building ?? '').includes('駅') ||
+    (entry?.place_detail ?? '').includes('駅')
+  )
+}
 
 type Props = {
   records: PokefutaRecord[]
   titles: ManholeTitlesJson
-  onSave: (patch: SemanticPatch) => Promise<void>
+  onSaveMany: (patches: SemanticPatch[]) => Promise<void>
   saving: boolean
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export function AssignStationTagsTask(_props: Props) {
+export function AssignStationTagsTask(props: Props) {
   return (
-    <div>
-      <h2 style={{ marginBottom: 16 }}>駅近・駅構内タグを付ける</h2>
-      <div style={{
-        border: '2px dashed #d1d5db',
-        borderRadius: 8,
-        padding: 40,
-        textAlign: 'center',
-        color: '#6b7280',
-      }}>
-        <p style={{ fontSize: 18, marginBottom: 8 }}>🚉 実装予定</p>
-        <p style={{ fontSize: 14 }}>
-          駅近マンホールを検索・タグ付けする機能は将来実装予定です。
-        </p>
-        <p style={{ fontSize: 13, marginTop: 12 }}>
-          対象タグ: <code>in_station</code> / <code>station_front</code> / <code>near_station</code> / <code>rail_access_good</code>
-        </p>
-        <p style={{ fontSize: 13, marginTop: 8, color: '#9ca3af' }}>
-          将来的に Station Proximity Agent からの提案をレビューするUIをここに統合します。
-        </p>
-      </div>
-    </div>
+    <MapTagsTask
+      {...props}
+      title="駅近・駅構内タグを付ける"
+      taskType="assign_station_tags"
+      tags={STATION_TAGS}
+      tagLabels={TAG_LABEL}
+      hintFilter={{ label: '駅キーワードのみ', fn: stationHint, defaultOn: true }}
+    />
   )
 }

--- a/tools/manhole-semantic-editor/src/tasks/assignTourismTags/AssignTourismTagsTask.tsx
+++ b/tools/manhole-semantic-editor/src/tasks/assignTourismTags/AssignTourismTagsTask.tsx
@@ -1,0 +1,31 @@
+import type { PokefutaRecord, ManholeTitlesJson, SemanticPatch } from '../../semantic/semanticPatch'
+import { MapTagsTask } from '../shared/MapTagsTask'
+
+const TOURISM_TAGS = ['tourism', 'park', 'museum', 'history', 'food'] as const
+
+const TAG_LABEL: Record<(typeof TOURISM_TAGS)[number], string> = {
+  tourism: '🗺 観光',
+  park: '🌳 公園',
+  museum: '🏛 博物館',
+  history: '🏯 歴史',
+  food: '🍜 グルメ',
+}
+
+type Props = {
+  records: PokefutaRecord[]
+  titles: ManholeTitlesJson
+  onSaveMany: (patches: SemanticPatch[]) => Promise<void>
+  saving: boolean
+}
+
+export function AssignTourismTagsTask(props: Props) {
+  return (
+    <MapTagsTask
+      {...props}
+      title="観光地タグを付ける"
+      taskType="assign_tourism_tags"
+      tags={TOURISM_TAGS}
+      tagLabels={TAG_LABEL}
+    />
+  )
+}

--- a/tools/manhole-semantic-editor/src/tasks/shared/MapTagsTask.tsx
+++ b/tools/manhole-semantic-editor/src/tasks/shared/MapTagsTask.tsx
@@ -1,0 +1,343 @@
+import { useState, useMemo, useRef, useEffect } from 'react'
+import L from 'leaflet'
+import 'leaflet/dist/leaflet.css'
+import type { PokefutaRecord, ManholeTitlesJson, SemanticPatch, ManholeEntry, TaskType } from '../../semantic/semanticPatch'
+import { validatePatch } from '../../semantic/semanticPatchValidator'
+import { newPatchId } from '../../util'
+
+const PAGE_SIZE = 10
+
+function makeIcon(color: string) {
+  return L.divIcon({
+    className: '',
+    html: `<div style="width:14px;height:14px;border-radius:50%;background:${color};border:2px solid white;box-shadow:0 1px 4px rgba(0,0,0,0.5)"></div>`,
+    iconSize: [14, 14],
+    iconAnchor: [7, 7],
+    popupAnchor: [0, -10],
+  })
+}
+
+export type HintFilter = {
+  label: string
+  fn: (r: PokefutaRecord, entry: ManholeEntry | undefined) => boolean
+  defaultOn?: boolean
+}
+
+export type MapTagsTaskProps = {
+  title: string
+  taskType: TaskType
+  tags: readonly string[]
+  tagLabels: Record<string, string>
+  hintFilter?: HintFilter
+  records: PokefutaRecord[]
+  titles: ManholeTitlesJson
+  onSaveMany: (patches: SemanticPatch[]) => Promise<void>
+  saving: boolean
+}
+
+export function MapTagsTask({
+  title,
+  taskType,
+  tags,
+  tagLabels,
+  hintFilter,
+  records,
+  titles,
+  onSaveMany,
+  saving,
+}: MapTagsTaskProps) {
+  const [search, setSearch] = useState('')
+  const [prefFilter, setPrefFilter] = useState('')
+  const [showFilter, setShowFilter] = useState<'all' | 'has_tag' | 'no_tag'>('all')
+  const [hintOn, setHintOn] = useState(hintFilter?.defaultOn ?? false)
+  const [pending, setPending] = useState<Map<string, Set<string>>>(new Map())
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const [page, setPage] = useState(0)
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+
+  const mapDivRef = useRef<HTMLDivElement>(null)
+  const mapRef = useRef<L.Map | null>(null)
+  const markersRef = useRef<Map<string, L.Marker>>(new Map())
+
+  const prefectures = useMemo(
+    () => [...new Set(records.map(r => r.prefecture))].sort(),
+    [records]
+  )
+
+  const filtered = useMemo(() => {
+    return records.filter(r => {
+      if (r.status !== 'active') return false
+      if (prefFilter && r.prefecture !== prefFilter) return false
+      if (search && !`${r.id} ${r.prefecture} ${r.city} ${r.address}`.includes(search)) return false
+      if (hintFilter && hintOn && !hintFilter.fn(r, titles.manholes[r.id])) return false
+      const currentTags = titles.manholes[r.id]?.tags ?? []
+      const hasAnyTag = tags.some(t => currentTags.includes(t))
+      if (showFilter === 'has_tag' && !hasAnyTag) return false
+      if (showFilter === 'no_tag' && hasAnyTag) return false
+      return true
+    })
+  }, [records, titles, prefFilter, search, showFilter, hintFilter, hintOn, tags])
+
+  useEffect(() => { setPage(0); setSelectedId(null) }, [filtered])
+
+  const totalPages = Math.ceil(filtered.length / PAGE_SIZE) || 1
+  const pageItems = useMemo(
+    () => filtered.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE),
+    [filtered, page]
+  )
+
+  // Initialize map
+  useEffect(() => {
+    if (!mapDivRef.current) return
+    const map = L.map(mapDivRef.current).setView([36.5, 136.0], 5)
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+    }).addTo(map)
+    mapRef.current = map
+    return () => {
+      map.remove()
+      mapRef.current = null
+    }
+  }, [])
+
+  // Rebuild markers on page change
+  useEffect(() => {
+    const map = mapRef.current
+    if (!map) return
+
+    markersRef.current.forEach(m => m.remove())
+    markersRef.current.clear()
+
+    if (pageItems.length === 0) return
+
+    pageItems.forEach(r => {
+      const marker = L.marker([r.lat, r.lng], { icon: makeIcon('#3b82f6') })
+        .addTo(map)
+        .bindPopup(`<b>#${r.id}</b> ${r.prefecture} ${r.city}<br><span style="font-size:11px">${r.address}</span>`)
+        .on('click', () => setSelectedId(id => id === r.id ? null : r.id))
+      markersRef.current.set(r.id, marker)
+    })
+
+    map.setView([pageItems[0].lat, pageItems[0].lng], 18)
+
+    return () => {
+      markersRef.current.forEach(m => m.remove())
+      markersRef.current.clear()
+    }
+  }, [pageItems])
+
+  // Sync marker icons when selection or pending changes
+  useEffect(() => {
+    markersRef.current.forEach((marker, id) => {
+      const base = titles.manholes[id]?.tags ?? []
+      const currentTags = pending.has(id) ? pending.get(id)! : new Set(base)
+      const hasTag = tags.some(t => currentTags.has(t))
+      const isSelected = id === selectedId
+      marker.setIcon(makeIcon(isSelected ? '#ef4444' : hasTag ? '#22c55e' : '#3b82f6'))
+      if (isSelected) marker.openPopup()
+    })
+
+    if (selectedId) {
+      const sel = pageItems.find(r => r.id === selectedId)
+      if (sel) mapRef.current?.panTo([sel.lat, sel.lng])
+    }
+  }, [selectedId, pending, pageItems, titles, tags])
+
+  function getEffectiveTags(id: string): Set<string> {
+    if (pending.has(id)) return new Set(pending.get(id))
+    return new Set(titles.manholes[id]?.tags ?? [])
+  }
+
+  function toggleTag(id: string, tag: string) {
+    setPending(prev => {
+      const next = new Map(prev)
+      const base = new Set(titles.manholes[id]?.tags ?? [])
+      const current = next.has(id) ? new Set(next.get(id)) : new Set(base)
+      if (current.has(tag)) current.delete(tag)
+      else current.add(tag)
+      if ([...current].sort().join() === [...base].sort().join()) {
+        next.delete(id)
+      } else {
+        next.set(id, current)
+      }
+      return next
+    })
+  }
+
+  async function handleSaveAll() {
+    setSaveError(null)
+    const patches: SemanticPatch[] = []
+
+    for (const [id, tags_] of pending.entries()) {
+      const base = new Set(titles.manholes[id]?.tags ?? [])
+      const added = [...tags_].filter(t => !base.has(t))
+      const removed = [...base].filter(t => !tags_.has(t))
+
+      if (added.length > 0) {
+        const patch: SemanticPatch = {
+          id: newPatchId(),
+          createdAt: new Date().toISOString(),
+          taskType,
+          operation: 'add_tags',
+          target: 'manholes',
+          manholeIds: [parseInt(id, 10)],
+          payload: { tags: added },
+        }
+        const v = validatePatch(patch, titles)
+        if (!v.valid) { setSaveError(v.errors.join('\n')); return }
+        patches.push(patch)
+      }
+      if (removed.length > 0) {
+        patches.push({
+          id: newPatchId(),
+          createdAt: new Date().toISOString(),
+          taskType,
+          operation: 'remove_tags',
+          target: 'manholes',
+          manholeIds: [parseInt(id, 10)],
+          payload: { tags: removed },
+        })
+      }
+    }
+
+    if (patches.length > 0) await onSaveMany(patches)
+    setPending(new Map())
+  }
+
+  const pendingCount = pending.size
+
+  return (
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
+        <h2 style={{ margin: 0 }}>{title}</h2>
+        {pendingCount > 0 && (
+          <button className="btn btn-primary" onClick={handleSaveAll} disabled={saving}>
+            {saving ? '保存中…' : `${pendingCount}件を保存`}
+          </button>
+        )}
+      </div>
+
+      {saveError && (
+        <div style={{ background: '#fef2f2', border: '1px solid #fca5a5', borderRadius: 6, padding: 12, marginBottom: 12, color: '#dc2626' }}>
+          {saveError}
+        </div>
+      )}
+
+      <div className="filter-bar">
+        <input
+          placeholder="ID / 住所 / 市区町村で絞り込み"
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+          style={{ width: 240 }}
+        />
+        <select value={prefFilter} onChange={e => setPrefFilter(e.target.value)}>
+          <option value="">全都道府県</option>
+          {prefectures.map(p => <option key={p} value={p}>{p}</option>)}
+        </select>
+        <select value={showFilter} onChange={e => setShowFilter(e.target.value as typeof showFilter)}>
+          <option value="all">全件</option>
+          <option value="has_tag">タグあり</option>
+          <option value="no_tag">タグなし</option>
+        </select>
+        {hintFilter && (
+          <label style={{ display: 'flex', alignItems: 'center', gap: 4, fontSize: 13, cursor: 'pointer' }}>
+            <input type="checkbox" checked={hintOn} onChange={e => setHintOn(e.target.checked)} />
+            {hintFilter.label}
+          </label>
+        )}
+        <span style={{ color: '#6b7280', fontSize: 13 }}>{filtered.length}件</span>
+      </div>
+
+      <div style={{ display: 'flex', gap: 16, marginBottom: 8, fontSize: 12, color: '#6b7280', alignItems: 'center' }}>
+        <span>凡例:</span>
+        {[['#3b82f6', 'タグなし'], ['#22c55e', 'タグあり'], ['#ef4444', '選択中']].map(([color, label]) => (
+          <span key={label} style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+            <span style={{ width: 10, height: 10, borderRadius: '50%', background: color, display: 'inline-block', border: '1px solid white', boxShadow: '0 0 2px rgba(0,0,0,0.4)' }} />
+            {label}
+          </span>
+        ))}
+        <span style={{ marginLeft: 'auto' }}>マーカーをクリックで詳細</span>
+      </div>
+
+      <div ref={mapDivRef} style={{ height: 340, borderRadius: 8, border: '1px solid #e5e7eb', marginBottom: 12, overflow: 'hidden' }} />
+
+      <table className="table">
+        <thead>
+          <tr>
+            <th style={{ width: 50 }}>ID</th>
+            <th>場所</th>
+            <th>住所</th>
+            <th>タグ</th>
+          </tr>
+        </thead>
+        <tbody>
+          {pageItems.map(r => {
+            const effectiveTags = getEffectiveTags(r.id)
+            const isDirty = pending.has(r.id)
+            const isSelected = r.id === selectedId
+            return (
+              <tr
+                key={r.id}
+                onClick={() => setSelectedId(id => id === r.id ? null : r.id)}
+                style={{
+                  background: isSelected ? '#eff6ff' : isDirty ? '#fefce8' : undefined,
+                  cursor: 'pointer',
+                  outline: isSelected ? '2px solid #3b82f6' : undefined,
+                  outlineOffset: '-1px',
+                }}
+              >
+                <td style={{ fontFamily: 'monospace' }}>{r.id}</td>
+                <td>
+                  <div>{r.prefecture} {r.city}</div>
+                  {titles.manholes[r.id]?.building && (
+                    <div style={{ fontSize: 11, color: '#6b7280' }}>{titles.manholes[r.id].building}</div>
+                  )}
+                </td>
+                <td style={{ fontSize: 12, maxWidth: 200, wordBreak: 'break-all' }}>{r.address}</td>
+                <td onClick={e => e.stopPropagation()}>
+                  <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+                    {tags.map(tag => (
+                      <button
+                        key={tag}
+                        className={`tag ${effectiveTags.has(tag) ? 'tag-active' : 'tag-inactive'}`}
+                        onClick={() => toggleTag(r.id, tag)}
+                        title={tag}
+                      >
+                        {tagLabels[tag] ?? tag}
+                      </button>
+                    ))}
+                  </div>
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 16, marginTop: 12 }}>
+        <button
+          className="btn"
+          style={{ padding: '6px 14px', background: '#f3f4f6', fontSize: 13 }}
+          onClick={() => { setPage(p => p - 1); setSelectedId(null) }}
+          disabled={page === 0}
+        >
+          ← 前へ
+        </button>
+        <span style={{ fontSize: 13, color: '#6b7280' }}>
+          {page + 1} / {totalPages}
+          <span style={{ marginLeft: 8, color: '#9ca3af' }}>
+            （{filtered.length}件中 {page * PAGE_SIZE + 1}〜{Math.min((page + 1) * PAGE_SIZE, filtered.length)}件）
+          </span>
+        </span>
+        <button
+          className="btn"
+          style={{ padding: '6px 14px', background: '#f3f4f6', fontSize: 13 }}
+          onClick={() => { setPage(p => p + 1); setSelectedId(null) }}
+          disabled={page >= totalPages - 1}
+        >
+          次へ →
+        </button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- 海・湖・離島 / 駅近・駅構内 / 観光地タグの3タスクを共通の `MapTagsTask` コンポーネントに統合
- Leaflet地図（zoom 18 ≒ 100m圏）＋10件ページネーション表のUIに刷新
- **複数件保存バグを修正**: `onSave` を1件ずつ呼ぶと stale closure で後の書き込みが前を上書きしていた → `onSaveMany` でパッチをまとめて1回書き込みに変更
- `AssignTourismTagsTask` を新規作成（旧: 海タグUIを誤流用していた）
- `create-pr.js` ブランチ名フォーマットを `yyyymmddhhmmss` に変更
- `leaflet@1.9.4` を追加

## Changes

| File | Change |
|---|---|
| `src/tasks/shared/MapTagsTask.tsx` | 新規: 地図＋表の共通実装 |
| `src/tasks/assignLocationTags/` | ラッパーに縮小 |
| `src/tasks/assignStationTags/` | ラッパーに縮小 |
| `src/tasks/assignTourismTags/` | 新規ラッパー |
| `src/App.tsx` | `onSaveMany` に切り替え、tourism を正しいコンポーネントへ |
| `scripts/create-pr.js` | タイムスタンプ形式変更 |

## Bug fix detail

PR #130 で3件追加したはずが1件しか入らなかった原因:
`handleSaveAll` が `await onSave(patch)` を順番に呼ぶとき、`onSave` の中の `titles` は初回レンダー時のものが固定されており、2件目以降は同じベース状態に適用されて前の書き込みを上書きしていた。`onSaveMany` に変更し、全パッチをまとめて `savePatches` に渡すことで解決。

🤖 Generated with [Claude Code](https://claude.com/claude-code)