### PR TITLE
Update manhole semantic metadata (20260520)

### DIFF
--- a/dataset/manhole_titles.json
+++ b/dataset/manhole_titles.json
@@ -610,6 +610,11 @@
         "seaside"
       ]
     },
+    "88": {
+      "tags": [
+        "near_station"
+      ]
+    },
     "89": {
       "tags": [
         "seaside"
@@ -653,6 +658,11 @@
     "117": {
       "tags": [
         "seaside"
+      ]
+    },
+    "124": {
+      "tags": [
+        "near_station"
       ]
     },
     "140": {
@@ -850,7 +860,8 @@
       "verified_at": "2025-12-27",
       "tags": [
         "seaside",
-        "tourism"
+        "tourism",
+        "near_station"
       ],
       "confidence": 3
     },
@@ -897,6 +908,11 @@
         "station_front"
       ],
       "confidence": 3
+    },
+    "265": {
+      "tags": [
+        "station_front"
+      ]
     },
     "271": {
       "building": "愛知県/豊橋市（バクフーン）",
@@ -1004,7 +1020,8 @@
       "tags": [
         "park",
         "family",
-        "tourism"
+        "tourism",
+        "near_station"
       ],
       "confidence": 3
     },
@@ -1018,7 +1035,8 @@
       "tags": [
         "culture",
         "museum",
-        "tourism"
+        "tourism",
+        "near_station"
       ],
       "confidence": 3
     },
@@ -1073,7 +1091,10 @@
     },
     "307": {
       "building": "美幌駅前",
-      "verified_at": "2023-06-05"
+      "verified_at": "2023-06-05",
+      "tags": [
+        "station_front"
+      ]
     },
     "308": {
       "building": "朝日公園",
@@ -1085,7 +1106,8 @@
       "verified_at": "2025-12-27",
       "tags": [
         "park",
-        "tourism"
+        "tourism",
+        "near_station"
       ],
       "confidence": 3
     },
@@ -1112,7 +1134,8 @@
       "tags": [
         "park",
         "family",
-        "tourism"
+        "tourism",
+        "near_station"
       ],
       "confidence": 3
     },
@@ -1175,7 +1198,8 @@
       "verified_at": "2025-12-27",
       "tags": [
         "station",
-        "town"
+        "town",
+        "station_front"
       ],
       "confidence": 3
     },
@@ -1391,7 +1415,8 @@
       "tags": [
         "roadside",
         "seaside",
-        "tourism"
+        "tourism",
+        "station_front"
       ],
       "confidence": 3
     },
@@ -1576,6 +1601,11 @@
     "450": {
       "tags": [
         "seaside"
+      ]
+    },
+    "465": {
+      "tags": [
+        "near_station"
       ]
     },
     "468": {


### PR DESCRIPTION
## Summary

semantic metadata をセマンティックエディタで更新しました。

## 変更内容

- assign_station_tags: 12件

対象マンホール数（ユニーク）: 12件

## Tasks

- assign_station_tags: 12件

## Guardrails

- docs/pokefuta.ndjson は変更されていません
- dataset/manhole_titles.json のみ変更されています

## Validation

- [x] JSON parse OK
- [x] schema OK
- [x] docs/*.ndjson 汚染なし
- [x] changes.ndjson で操作ログ確認済み

🤖 Generated with Semantic Manhole Metadata Editor