### PR TITLE
feat: i18n multilingual map pages (EN / zh-TW / zh-CN / KO)

### DIFF
--- a/apps/web/index.template.html
+++ b/apps/web/index.template.html
@@ -1022,7 +1022,7 @@
         });
         await loadLatestPhotoMeta();
         // Load Pokemon metadata asynchronously (non-blocking)
-        loadPokemonMetadata().catch(err => console.warn('Pokemon metadata loading failed', err));
+        await loadPokemonMetadata().catch(err => console.warn('Pokemon metadata loading failed', err));
         initMarkerLayer();
         // Build markers
         allMarkers = [];

--- a/apps/web/index.template.html
+++ b/apps/web/index.template.html
@@ -1021,7 +1021,7 @@
           d._addedDate = normalizeDateString(raw);
         });
         await loadLatestPhotoMeta();
-        // Load Pokemon metadata asynchronously (non-blocking)
+        // Await Pokemon metadata so popup HTML and page meta use translated names
         await loadPokemonMetadata().catch(err => console.warn('Pokemon metadata loading failed', err));
         initMarkerLayer();
         // Build markers


### PR DESCRIPTION
## Summary

- Add multilingual support for English, Traditional Chinese, Simplified Chinese, and Korean via a build pipeline (`tools/build_i18n.py`) that generates language-specific `index.html` from `index.template.html` + per-language JSON string files
- Wire Pokémon name translations (`getPokemonDisplayName`) and prefecture name translations (`translatePref`) into map popups, page meta tags, and OG tags
- Translate popup badge labels (`translateTitle`) with 16 title keys across all 4 languages
- Fix async timing bug: `await` pokemon metadata fetch before building marker popups so translated names are used (not Japanese fallbacks)
- Add language pages to `sitemap.xml` and fix Pokémon URLs in sitemap
- Fix regional-form Pokémon lookup (Alolan / Galarian / Hisuian / Paldean) and hiragana→katakana normalization edge case

## Key files

| File | Purpose |
|------|---------|
| `apps/web/index.template.html` | Template with i18n helpers and `%%PLACEHOLDER%%` variables |
| `tools/build_i18n.py` | Build script generating `dist/{lang}/index.html` per language |
| `apps/web/i18n/strings.{en,ko,zh-CN,zh-TW}.json` | UI strings per language |
| `apps/web/i18n/prefectures.json` | Prefecture name translations |
| `apps/scraper/generate_sitemap.py` | Sitemap with i18n language entries |

## Test plan

- [ ] Run `tools/build_i18n.py` and verify `dist/en/`, `dist/zh-TW/`, `dist/zh-CN/`, `dist/ko/` are generated
- [ ] Open `/en/?manhole=368` — confirm page title and popup show "Dragonite / Dragonair / Dratini" (not Japanese)
- [ ] Open `/en/?pref=福井県` — confirm prefecture name renders as "Fukui"
- [ ] Verify popup badge "Only Pokéfuta in {city}" renders in English
- [ ] Check `sitemap.xml` includes language-specific URLs
- [ ] Block `pokemon_metadata.json` in DevTools — confirm graceful fallback to Japanese names

🤖 Generated with [Claude Code](https://claude.com/claude-code)