### PR TITLE
feat: ポケモンLPページ・一覧ページのi18n対応（5言語）

### DIFF
--- a/apps/scraper/generate_pokemon_index_page.py
+++ b/apps/scraper/generate_pokemon_index_page.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
-"""Generate /pokemon/index.html — SEO hub listing all Pokemon with pokefuta."""
+"""Generate /pokemon/index.html — SEO hub listing all Pokemon with pokefuta.
+
+Generates language-specific versions under dist/{lang}/pokemon/index.html
+(Japanese goes to dist/pokemon/index.html).
+"""
 
 from __future__ import annotations
 
@@ -7,6 +11,7 @@ import argparse
 import json
 import logging
 import sys
+from collections.abc import Callable
 from pathlib import Path
 from urllib.parse import quote
 from xml.sax.saxutils import escape
@@ -16,86 +21,291 @@ from generate_pokemon_pages import (
     BASE_URL,
     DEFAULT_OGP_IMAGE,
     GA_MEASUREMENT_ID,
-    _FORM_PREFIX,
+    LANG_CONFIGS,
+    _get_display_name,
     build_pokemon_index,
     load_pokemon_metadata,
+    load_prefectures,
     read_manholes,
 )
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")
 logger = logging.getLogger(__name__)
 
-CANONICAL_URL = f"{BASE_URL}pokemon/"
-TITLE = "ポケふたに登場するポケモン一覧 | 全国のポケモンマンホールマップ"
-DESCRIPTION = (
-    "全国各地に設置された「ポケふた（ポケモンマンホール）」に登場するポケモン一覧です。"
-    "北海道のロコンや香川県のヤドン、宮城県のラプラスなど、地域を応援するポケモンとして"
-    "描かれたポケふたも人気があります。気になるポケモンから、全国のポケふたや設置自治体を探せます。"
-)
+# UI strings per language for the Pokemon index page.
+LP_INDEX_STRINGS: dict[str, dict] = {
+    "ja": {
+        "title": "ポケふたに登場するポケモン一覧 | 全国のポケモンマンホールマップ",
+        "description": (
+            "全国各地に設置された「ポケふた（ポケモンマンホール）」に登場するポケモン一覧です。"
+            "北海道のロコンや香川県のヤドン、宮城県のラプラスなど、地域を応援するポケモンとして"
+            "描かれたポケふたも人気があります。気になるポケモンから、全国のポケふたや設置自治体を探せます。"
+        ),
+        "og_title": "ポケふたに登場するポケモン一覧",
+        "h1": "ポケふたに登場するポケモン一覧",
+        "lead": (
+            "全国各地に設置された「ポケふた（ポケモンマンホール）」に登場するポケモン一覧です。"
+            "北海道のロコンや香川県のヤドン、宮城県のラプラスなど、地域を応援するポケモンとして描かれたポケふたも人気があります。"
+            "気になるポケモンから、全国のポケふたや設置自治体を探せます。"
+        ),
+        "regional_heading": "地域を応援するポケモン",
+        "all_heading": "全ポケモン一覧（{total}体）",
+        "map_nav_hint": "都道府県ごとのポケふたは<a href='{map_href}'>全国マップ</a>から地域を選んで確認できます。",
+        "cta": "地図で全国のポケふたを探す →",
+        "breadcrumb_aria": "パンくずリスト",
+        "breadcrumb_home": "全国マップ",
+        "footer": "ポケモンマンホール全国マップ",
+        "region_summary_unknown": "所在地不明",
+        "region_summary_fmt": "{count}枚 / {region}",
+        "region_summary_pref_count": "{n}都道府県",
+        "popular_intro": (
+            "登場回数が多いポケモンほど、全国各地で出会いやすいポケモンです。"
+            "{top3}などは{min_count}枚以上のポケふたに登場しており、"
+            "初めてポケふた巡りをする方にも見つけやすいポケモンです。"
+            "気になるポケモンをタップして、設置場所や旅のルートを確認しましょう。"
+        ),
+        "jsonld_name": "ポケふたに登場するポケモン一覧",
+    },
+    "en": {
+        "title": "Pokémon on Pokéfuta — Full List | Pokémon Manhole Map of Japan",
+        "description": (
+            "Complete list of Pokémon featured on Pokéfuta (Pokémon manhole covers) installed across Japan. "
+            "Includes regional favorites such as Vulpix in Hokkaido, Slowpoke in Kagawa, and Lapras in Miyagi. "
+            "Find Pokéfuta locations and municipalities for any Pokémon you love."
+        ),
+        "og_title": "Pokémon on Pokéfuta — Full List",
+        "h1": "Pokémon on Pokéfuta — Full List",
+        "lead": (
+            "Complete list of Pokémon featured on Pokéfuta (Pokémon manhole covers) installed across Japan. "
+            "Includes regional favorites such as Vulpix in Hokkaido, Slowpoke in Kagawa, and Lapras in Miyagi. "
+            "Tap any Pokémon to see installation locations and plan your trip."
+        ),
+        "regional_heading": "Regional Pokémon",
+        "all_heading": "All Pokémon ({total})",
+        "map_nav_hint": "Browse Pokéfuta by prefecture on the <a href='{map_href}'>Japan Map</a>.",
+        "cta": "Explore all Pokéfuta on the map →",
+        "breadcrumb_aria": "Breadcrumb",
+        "breadcrumb_home": "Japan Map",
+        "footer": "Pokémon Manhole Map of Japan",
+        "region_summary_unknown": "Location unknown",
+        "region_summary_fmt": "{count} / {region}",
+        "region_summary_pref_count": "{n} prefectures",
+        "popular_intro": (
+            "Pokémon that appear on more Pokéfuta are easier to find across Japan. "
+            "{top3} and others appear on {min_count}+ Pokéfuta, "
+            "making them great starting points for first-time Pokéfuta hunters. "
+            "Tap any Pokémon to check locations and plan your route."
+        ),
+        "jsonld_name": "Pokémon on Pokéfuta — Full List",
+    },
+    "zh-CN": {
+        "title": "宝可夢井盖上的宝可梦一览 | 日本宝可梦井盖地图",
+        "description": (
+            "日本各地设置的「宝可梦井盖（Pokéfuta）」上登场的宝可梦一览。"
+            "包括北海道的六尾、香川县的呆呆兽、宫城县的拉普拉斯等代表各地区的宝可梦。"
+            "从喜欢的宝可梦查找全国各地的宝可梦井盖和设置市区町村。"
+        ),
+        "og_title": "宝可梦井盖上的宝可梦一览",
+        "h1": "宝可梦井盖上的宝可梦一览",
+        "lead": (
+            "日本各地设置的「宝可梦井盖（Pokéfuta）」上登场的宝可梦一览。"
+            "包括北海道的六尾、香川县的呆呆兽、宫城县的拉普拉斯等代表各地区的宝可梦。"
+            "点击感兴趣的宝可梦，查看设置地点并规划行程。"
+        ),
+        "regional_heading": "代表各地区的宝可梦",
+        "all_heading": "全部宝可梦（{total}只）",
+        "map_nav_hint": "可从<a href='{map_href}'>全国地图</a>按都道府县查看宝可梦井盖分布。",
+        "cta": "在地图上查找全国宝可梦井盖 →",
+        "breadcrumb_aria": "面包屑导航",
+        "breadcrumb_home": "全国地图",
+        "footer": "日本宝可梦井盖全国地图",
+        "region_summary_unknown": "位置不明",
+        "region_summary_fmt": "{count}个 / {region}",
+        "region_summary_pref_count": "{n}个都道府县",
+        "popular_intro": (
+            "登场次数越多的宝可梦，越容易在全国各地相遇。"
+            "{top3}等宝可梦登场的宝可梦井盖达{min_count}个以上，"
+            "非常适合初次挑战宝可梦井盖打卡的玩家。"
+            "点击感兴趣的宝可梦，确认设置地点和旅行路线。"
+        ),
+        "jsonld_name": "宝可梦井盖上的宝可梦一览",
+    },
+    "zh-TW": {
+        "title": "寶可夢人孔蓋上的寶可夢一覽 | 日本寶可夢人孔蓋地圖",
+        "description": (
+            "日本各地設置的「寶可夢人孔蓋（Pokéfuta）」上登場的寶可夢一覽。"
+            "包括北海道的六尾、香川縣的呆呆獸、宮城縣的拉普拉斯等代表各地區的寶可夢。"
+            "從喜歡的寶可夢查找全國各地的寶可夢人孔蓋和設置市區町村。"
+        ),
+        "og_title": "寶可夢人孔蓋上的寶可夢一覽",
+        "h1": "寶可夢人孔蓋上的寶可夢一覽",
+        "lead": (
+            "日本各地設置的「寶可夢人孔蓋（Pokéfuta）」上登場的寶可夢一覽。"
+            "包括北海道的六尾、香川縣的呆呆獸、宮城縣的拉普拉斯等代表各地區的寶可夢。"
+            "點擊感興趣的寶可夢，查看設置地點並規劃行程。"
+        ),
+        "regional_heading": "代表各地區的寶可夢",
+        "all_heading": "全部寶可夢（{total}隻）",
+        "map_nav_hint": "可從<a href='{map_href}'>全國地圖</a>按都道府縣查看寶可夢人孔蓋分布。",
+        "cta": "在地圖上查找全國寶可夢人孔蓋 →",
+        "breadcrumb_aria": "麵包屑導覽",
+        "breadcrumb_home": "全國地圖",
+        "footer": "日本寶可夢人孔蓋全國地圖",
+        "region_summary_unknown": "位置不明",
+        "region_summary_fmt": "{count}個 / {region}",
+        "region_summary_pref_count": "{n}個都道府縣",
+        "popular_intro": (
+            "登場次數越多的寶可夢，越容易在全國各地相遇。"
+            "{top3}等寶可夢登場的寶可夢人孔蓋達{min_count}個以上，"
+            "非常適合初次挑戰寶可夢人孔蓋打卡的玩家。"
+            "點擊感興趣的寶可夢，確認設置地點和旅行路線。"
+        ),
+        "jsonld_name": "寶可夢人孔蓋上的寶可夢一覽",
+    },
+    "ko": {
+        "title": "포케후타에 등장하는 포켓몬 목록 | 일본 포켓몬 맨홀 지도",
+        "description": (
+            "일본 전국에 설치된 「포케후타（포켓몬 맨홀）」에 등장하는 포켓몬 목록입니다. "
+            "홋카이도의 식스테일, 카가와현의 야돈, 미야기현의 라프라스 등 지역을 응원하는 포켓몬도 인기입니다. "
+            "좋아하는 포켓몬으로 전국의 포케후타와 설치 지자체를 찾아보세요."
+        ),
+        "og_title": "포케후타에 등장하는 포켓몬 목록",
+        "h1": "포케후타에 등장하는 포켓몬 목록",
+        "lead": (
+            "일본 전국에 설치된 「포케후타（포켓몬 맨홀）」에 등장하는 포켓몬 목록입니다. "
+            "홋카이도의 식스테일, 카가와현의 야돈, 미야기현의 라프라스 등 지역을 응원하는 포켓몬도 인기입니다. "
+            "좋아하는 포켓몬을 탭해서 설치 장소와 여행 루트를 확인해 보세요."
+        ),
+        "regional_heading": "지역을 응원하는 포켓몬",
+        "all_heading": "모든 포켓몬（{total}마리）",
+        "map_nav_hint": "<a href='{map_href}'>전국 지도</a>에서 현별로 포케후타를 확인할 수 있습니다.",
+        "cta": "지도에서 전국의 포케후타 찾기 →",
+        "breadcrumb_aria": "이동 경로",
+        "breadcrumb_home": "전국 지도",
+        "footer": "일본 포켓몬 맨홀 전국 지도",
+        "region_summary_unknown": "위치 불명",
+        "region_summary_fmt": "{count}개 / {region}",
+        "region_summary_pref_count": "{n}개 현",
+        "popular_intro": (
+            "등장 횟수가 많은 포켓몬일수록 전국 각지에서 만나기 쉽습니다. "
+            "{top3} 등은 {min_count}개 이상의 포케후타에 등장하여 "
+            "처음 포케후타를 찾는 분들에게도 발견하기 쉬운 포켓몬입니다. "
+            "좋아하는 포켓몬을 탭해서 설치 장소와 여행 루트를 확인해 보세요."
+        ),
+        "jsonld_name": "포케후타에 등장하는 포켓몬 목록",
+    },
+}
 
-# 地域連携ポケモン（slug → 紹介文）
-REGIONAL_POKEMON: list[tuple[str, str]] = [
-    ("vulpix",       "北海道を応援するポケモン"),
-    ("vulpix-alola", "北海道を応援するポケモン"),
-    ("slowpoke",     "香川県を応援するポケモン"),
-    ("lapras",       "宮城県を応援するポケモン"),
-    ("geodude",      "岩手県を応援するポケモン"),
-    ("chansey",      "福島県を応援するポケモン"),
+# Regional Pokémon taglines per language: slug → {lang: tagline}
+REGIONAL_TAGLINES: dict[str, dict[str, str]] = {
+    "vulpix": {
+        "ja": "北海道を応援するポケモン",
+        "en": "Pokémon representing Hokkaido",
+        "zh-CN": "代表北海道的宝可梦",
+        "zh-TW": "代表北海道的寶可夢",
+        "ko": "홋카이도를 응원하는 포켓몬",
+    },
+    "vulpix-alola": {
+        "ja": "北海道を応援するポケモン",
+        "en": "Pokémon representing Hokkaido",
+        "zh-CN": "代表北海道的宝可梦",
+        "zh-TW": "代表北海道的寶可夢",
+        "ko": "홋카이도를 응원하는 포켓몬",
+    },
+    "slowpoke": {
+        "ja": "香川県を応援するポケモン",
+        "en": "Pokémon representing Kagawa",
+        "zh-CN": "代表香川县的宝可梦",
+        "zh-TW": "代表香川縣的寶可夢",
+        "ko": "카가와현을 응원하는 포켓몬",
+    },
+    "lapras": {
+        "ja": "宮城県を応援するポケモン",
+        "en": "Pokémon representing Miyagi",
+        "zh-CN": "代表宫城县的宝可梦",
+        "zh-TW": "代表宮城縣的寶可夢",
+        "ko": "미야기현을 응원하는 포켓몬",
+    },
+    "geodude": {
+        "ja": "岩手県を応援するポケモン",
+        "en": "Pokémon representing Iwate",
+        "zh-CN": "代表岩手县的宝可梦",
+        "zh-TW": "代表岩手縣的寶可夢",
+        "ko": "이와테현을 응원하는 포켓몬",
+    },
+    "chansey": {
+        "ja": "福島県を応援するポケモン",
+        "en": "Pokémon representing Fukushima",
+        "zh-CN": "代表福岛县的宝可梦",
+        "zh-TW": "代表福島縣的寶可夢",
+        "ko": "후쿠시마현을 응원하는 포켓몬",
+    },
+}
+
+REGIONAL_POKEMON_SLUGS: list[str] = [
+    "vulpix", "vulpix-alola", "slowpoke", "lapras", "geodude", "chansey",
 ]
 
 
-def _get_display_name(slug: str, meta: dict) -> tuple[str, str]:
-    names = meta.get("names", {})
-    form = meta.get("form") or ""
-    prefix = _FORM_PREFIX.get(form, "")
-    name_ja = prefix + names.get("ja", slug)
-    name_en = names.get("en", "")
-    return name_ja, name_en
-
-
-def _region_summary(manholes: list[dict], count: int) -> str:
-    prefs = sorted({m.get("prefecture", "") for m in manholes if m.get("prefecture")})
-    if not prefs:
-        region_text = "所在地不明"
-    elif len(prefs) == 1:
-        region_text = prefs[0]
+def _region_summary(
+    manholes: list[dict],
+    count: int,
+    strings: dict,
+    translate_pref: Callable[[str], str],
+) -> str:
+    prefs_ja = sorted({m.get("prefecture", "") for m in manholes if m.get("prefecture")})
+    if not prefs_ja:
+        region_text = strings["region_summary_unknown"]
+    elif len(prefs_ja) == 1:
+        region_text = translate_pref(prefs_ja[0])
     else:
-        region_text = f"{len(prefs)}都道府県"
-    return f"{count}枚 / {region_text}"
+        n = len(prefs_ja)
+        region_text = strings["region_summary_pref_count"].format(n=n)
+    return strings["region_summary_fmt"].format(count=count, region=region_text)
 
 
-def _card_html(slug: str, meta: dict, manholes: list[dict], css_class: str = "poke-item") -> str:
-    name_ja, name_en = _get_display_name(slug, meta)
-    count = len(manholes)
-    summary = _region_summary(manholes, count)
-    en_html = f"<span class='poke-en'>{escape(name_en)}</span>" if name_en else ""
-    return (
-        f"<li class='{css_class}'>"
-        f"<a href='/pokemon/{quote(slug)}/'>"
-        f"<span class='poke-name'>{escape(name_ja)}</span>"
-        f"{en_html}"
-        f"<span class='poke-summary'>{escape(summary)}</span>"
-        f"</a></li>"
-    )
+def _hreflang_links_index() -> str:
+    """Generate hreflang <link> tags for all language variants of the Pokemon index."""
+    lines = []
+    for lang, lc in LANG_CONFIGS.items():
+        url = f"{BASE_URL}{lc['url_prefix']}pokemon/"
+        lines.append(f'  <link rel="alternate" hreflang="{lc["hreflang"]}" href="{escape(url)}">')
+    lines.append(f'  <link rel="alternate" hreflang="x-default" href="{escape(BASE_URL)}pokemon/">')
+    return "\n".join(lines)
 
 
-def generate_html(pokemon_index: dict[str, tuple[dict, list[dict]]]) -> str:
+def generate_html(
+    pokemon_index: dict[str, tuple[dict, list[dict]]],
+    lang: str,
+    lang_config: dict,
+    strings: dict,
+    translate_pref: Callable[[str], str],
+) -> str:
     total_count = len(pokemon_index)
+    url_prefix = lang_config["url_prefix"]
+    map_href = f"/{url_prefix}" if url_prefix else "/"
+    pokemon_list_url = f"/{url_prefix}pokemon/" if url_prefix else "/pokemon/"
+    canonical_url = f"{BASE_URL}{url_prefix}pokemon/"
+    map_url = f"{BASE_URL}{url_prefix}"
 
-    # 地域連携セクション
+    hreflang_html = _hreflang_links_index()
+
+    # Regional Pokémon section
     regional_items: list[str] = []
-    for slug, tagline in REGIONAL_POKEMON:
+    for slug in REGIONAL_POKEMON_SLUGS:
         if slug not in pokemon_index:
             continue
         meta, manholes = pokemon_index[slug]
-        name_ja, name_en = _get_display_name(slug, meta)
+        display_name = _get_display_name(meta, lang_config)
+        name_en = meta.get("names", {}).get("en", "")
         count = len(manholes)
-        summary = _region_summary(manholes, count)
-        en_html = f"<span class='poke-en'>{escape(name_en)}</span>" if name_en else ""
+        summary = _region_summary(manholes, count, strings, translate_pref)
+        tagline = REGIONAL_TAGLINES.get(slug, {}).get(lang, REGIONAL_TAGLINES.get(slug, {}).get("en", ""))
+        en_html = f"<span class='poke-en'>{escape(name_en)}</span>" if name_en and lang != "en" else ""
         regional_items.append(
             f"<li class='regional-item'>"
-            f"<a href='/pokemon/{quote(slug)}/'>"
-            f"<span class='poke-name'>{escape(name_ja)}</span>"
+            f"<a href='/{url_prefix}pokemon/{quote(slug)}/'>"
+            f"<span class='poke-name'>{escape(display_name)}</span>"
             f"{en_html}"
             f"<span class='poke-tagline'>{escape(tagline)}</span>"
             f"<span class='poke-summary'>{escape(summary)}</span>"
@@ -103,7 +313,7 @@ def generate_html(pokemon_index: dict[str, tuple[dict, list[dict]]]) -> str:
         )
     regional_items_html = "\n".join(regional_items) + "\n" if regional_items else ""
 
-    # 全ポケモン一覧（登場マンホール数の多い順）
+    # All Pokémon list sorted by manhole count (descending)
     sorted_slugs = sorted(
         pokemon_index.keys(),
         key=lambda s: -len(pokemon_index[s][1]),
@@ -111,12 +321,24 @@ def generate_html(pokemon_index: dict[str, tuple[dict, list[dict]]]) -> str:
     items: list[str] = []
     for slug in sorted_slugs:
         meta, manholes = pokemon_index[slug]
-        items.append(_card_html(slug, meta, manholes))
+        display_name = _get_display_name(meta, lang_config)
+        name_en = meta.get("names", {}).get("en", "")
+        count = len(manholes)
+        summary = _region_summary(manholes, count, strings, translate_pref)
+        en_html = f"<span class='poke-en'>{escape(name_en)}</span>" if name_en and lang != "en" else ""
+        items.append(
+            f"<li class='poke-item'>"
+            f"<a href='/{url_prefix}pokemon/{quote(slug)}/'>"
+            f"<span class='poke-name'>{escape(display_name)}</span>"
+            f"{en_html}"
+            f"<span class='poke-summary'>{escape(summary)}</span>"
+            f"</a></li>"
+        )
     items_html = "".join(items)
 
-    # 「多く登場するポケモン」説明テキスト（動的生成）
+    # Popular intro text
     top3_names = "・".join(
-        _get_display_name(s, pokemon_index[s][0])[0]
+        _get_display_name(pokemon_index[s][0], lang_config)
         for s in sorted_slugs[:3]
     )
     top3_min_count = (
@@ -124,50 +346,58 @@ def generate_html(pokemon_index: dict[str, tuple[dict, list[dict]]]) -> str:
         if sorted_slugs else 0
     )
     popular_intro = escape(
-        f"登場回数が多いポケモンほど、全国各地で出会いやすいポケモンです。"
-        f"{top3_names}などは{top3_min_count}枚以上のポケふたに登場しており、"
-        f"初めてポケふた巡りをする方にも見つけやすいポケモンです。"
-        f"気になるポケモンをタップして、設置場所や旅のルートを確認しましょう。"
+        strings["popular_intro"].format(top3=top3_names, min_count=top3_min_count)
     )
+
+    all_heading = escape(strings["all_heading"].format(total=total_count))
+    regional_heading = escape(strings["regional_heading"])
+    h1 = escape(strings["h1"])
+    lead = escape(strings["lead"])
+    map_nav_hint = strings["map_nav_hint"].format(map_href=escape(map_href))
+    cta = escape(strings["cta"])
+    footer_text = escape(strings["footer"])
+    breadcrumb_aria = escape(strings["breadcrumb_aria"])
+    breadcrumb_home = escape(strings["breadcrumb_home"])
 
     jsonld_collection = json.dumps({
         "@context": "https://schema.org",
         "@type": "CollectionPage",
-        "name": "ポケふたに登場するポケモン一覧",
-        "description": DESCRIPTION,
-        "url": CANONICAL_URL,
-        "inLanguage": "ja",
+        "name": strings["jsonld_name"],
+        "description": strings["description"],
+        "url": canonical_url,
+        "inLanguage": lang_config["html_lang"],
     }, ensure_ascii=False, indent=2)
 
     jsonld_breadcrumb = json.dumps({
         "@context": "https://schema.org",
         "@type": "BreadcrumbList",
         "itemListElement": [
-            {"@type": "ListItem", "position": 1, "name": "全国マップ", "item": BASE_URL},
-            {"@type": "ListItem", "position": 2, "name": "ポケモン一覧", "item": CANONICAL_URL},
+            {"@type": "ListItem", "position": 1, "name": strings["breadcrumb_home"], "item": map_url},
+            {"@type": "ListItem", "position": 2, "name": strings["jsonld_name"], "item": canonical_url},
         ],
     }, ensure_ascii=False, indent=2)
 
     return f"""<!doctype html>
-<html lang="ja">
+<html lang="{lang_config['html_lang']}">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>{escape(TITLE)}</title>
-  <meta name="description" content="{escape(DESCRIPTION)}">
+  <title>{escape(strings['title'])}</title>
+  <meta name="description" content="{escape(strings['description'])}">
   <meta name="robots" content="index,follow">
-  <link rel="canonical" href="{escape(CANONICAL_URL)}">
+  <link rel="canonical" href="{escape(canonical_url)}">
+{hreflang_html}
 
   <meta property="og:type" content="website">
-  <meta property="og:locale" content="ja_JP">
-  <meta property="og:title" content="ポケふたに登場するポケモン一覧">
-  <meta property="og:description" content="{escape(DESCRIPTION)}">
-  <meta property="og:url" content="{escape(CANONICAL_URL)}">
+  <meta property="og:locale" content="{lang_config['og_locale']}">
+  <meta property="og:title" content="{escape(strings['og_title'])}">
+  <meta property="og:description" content="{escape(strings['description'])}">
+  <meta property="og:url" content="{escape(canonical_url)}">
   <meta property="og:image" content="{escape(DEFAULT_OGP_IMAGE)}">
 
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="ポケふたに登場するポケモン一覧">
-  <meta name="twitter:description" content="{escape(DESCRIPTION)}">
+  <meta name="twitter:title" content="{escape(strings['og_title'])}">
+  <meta name="twitter:description" content="{escape(strings['description'])}">
   <meta name="twitter:image" content="{escape(DEFAULT_OGP_IMAGE)}">
 
   <script type="application/ld+json">
@@ -183,8 +413,8 @@ def generate_html(pokemon_index: dict[str, tuple[dict, list[dict]]]) -> str:
     window.dataLayer = window.dataLayer || [];
     function gtag(){{dataLayer.push(arguments);}}
     gtag('js', new Date());
-    gtag('config', '{GA_MEASUREMENT_ID}', {{'page_path': '/pokemon/'}});
-    gtag('event', 'view_pokemon_index', {{'pokemon_count': {total_count}}});
+    gtag('config', '{GA_MEASUREMENT_ID}', {{'page_path': '/{url_prefix}pokemon/'}});
+    gtag('event', 'view_pokemon_index', {{'pokemon_count': {total_count}, 'lang': '{lang}'}});
   </script>
 
   <style>
@@ -229,7 +459,6 @@ def generate_html(pokemon_index: dict[str, tuple[dict, list[dict]]]) -> str:
       line-height: 1.75;
       margin-bottom: 4px;
     }}
-    /* 共通カードリスト */
     .poke-list, .regional-list {{
       list-style: none;
       display: grid;
@@ -326,35 +555,31 @@ def generate_html(pokemon_index: dict[str, tuple[dict, list[dict]]]) -> str:
 </head>
 <body>
 <div class="container">
-  <nav aria-label="パンくずリスト" class="breadcrumb">
+  <nav aria-label="{breadcrumb_aria}" class="breadcrumb">
     <ol>
-      <li><a href="/">全国マップ</a></li>
-      <li aria-current="page">ポケモン一覧</li>
+      <li><a href="{escape(map_href)}">{breadcrumb_home}</a></li>
+      <li aria-current="page">{escape(strings['og_title'])}</li>
     </ol>
   </nav>
 
-  <h1>ポケふたに登場するポケモン一覧</h1>
-  <p class="lead">
-    全国各地に設置された「ポケふた（ポケモンマンホール）」に登場するポケモン一覧です。
-    北海道のロコンや香川県のヤドン、宮城県のラプラスなど、地域を応援するポケモンとして描かれたポケふたも人気があります。
-    気になるポケモンから、全国のポケふたや設置自治体を探せます。
-  </p>
+  <h1>{h1}</h1>
+  <p class="lead">{lead}</p>
 
-  <h2>地域を応援するポケモン</h2>
+  <h2>{regional_heading}</h2>
   <ul class="regional-list">
 {regional_items_html}  </ul>
 
-  <h2>全ポケモン一覧（{total_count}体）</h2>
+  <h2>{all_heading}</h2>
   <p class="popular-intro">{popular_intro}</p>
   <ul class="poke-list">
 {items_html}  </ul>
 
-  <p class="map-nav-hint">都道府県ごとのポケふたは<a href="{escape(BASE_URL)}">全国マップ</a>から地域を選んで確認できます。</p>
+  <p class="map-nav-hint">{map_nav_hint}</p>
 
-  <a href="{escape(BASE_URL)}" class="cta-map">地図で全国のポケふたを探す →</a>
+  <a href="{escape(map_url)}" class="cta-map">{cta}</a>
 
   <footer>
-    <p><a href="{escape(BASE_URL)}">data.pokefuta.com</a> &mdash; ポケモンマンホール全国マップ</p>
+    <p><a href="{escape(BASE_URL)}">data.pokefuta.com</a> &mdash; {footer_text}</p>
   </footer>
 </div>
 </body>
@@ -365,7 +590,18 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--manholes", default="docs/pokefuta.ndjson")
     parser.add_argument("--pokemon", default="docs/pokemon_metadata.json")
-    parser.add_argument("--output", default="dist/pokemon")
+    parser.add_argument(
+        "--output-root", default="dist",
+        help="Root output directory (default: dist). Index goes to {output-root}/pokemon/ for ja.",
+    )
+    parser.add_argument(
+        "--langs", nargs="*", default=list(LANG_CONFIGS.keys()),
+        help="Languages to generate (default: all).",
+    )
+    parser.add_argument(
+        "--prefectures", default="apps/web/i18n/prefectures.json",
+        help="Path to prefectures.json",
+    )
     args = parser.parse_args()
 
     metadata = load_pokemon_metadata(Path(args.pokemon))
@@ -378,15 +614,38 @@ def main() -> int:
         logger.error("No manholes loaded")
         return 1
 
+    pref_data = load_prefectures(Path(args.prefectures))
     pokemon_index = build_pokemon_index(manholes, metadata)
     logger.info(f"Pokemon with active pokefuta: {len(pokemon_index)}")
 
-    output_dir = Path(args.output)
-    output_dir.mkdir(parents=True, exist_ok=True)
+    output_root = Path(args.output_root)
+    langs_to_build = [la for la in args.langs if la in LANG_CONFIGS]
+    if not langs_to_build:
+        logger.error(f"No valid languages specified. Choose from: {list(LANG_CONFIGS.keys())}")
+        return 1
 
-    html = generate_html(pokemon_index)
-    (output_dir / "index.html").write_text(html, encoding="utf-8")
-    logger.info(f"Written: {output_dir}/index.html")
+    for lang in langs_to_build:
+        lc = LANG_CONFIGS[lang]
+        strings = LP_INDEX_STRINGS[lang]
+        pref_key = lc["pref_key"]
+
+        if pref_key is None:
+            def translate_pref(ja: str, _key: str = "") -> str:
+                return ja
+        else:
+            def translate_pref(ja: str, _key: str = pref_key) -> str:
+                return pref_data.get(ja, {}).get(_key, ja)
+
+        url_prefix = lc["url_prefix"]
+        if url_prefix:
+            output_dir = output_root / url_prefix.rstrip("/") / "pokemon"
+        else:
+            output_dir = output_root / "pokemon"
+
+        output_dir.mkdir(parents=True, exist_ok=True)
+        html = generate_html(pokemon_index, lang, lc, strings, translate_pref)
+        (output_dir / "index.html").write_text(html, encoding="utf-8")
+        logger.info(f"[{lang}] Written: {output_dir}/index.html")
 
     return 0
 

--- a/apps/scraper/generate_pokemon_index_page.py
+++ b/apps/scraper/generate_pokemon_index_page.py
@@ -284,7 +284,6 @@ def generate_html(
     total_count = len(pokemon_index)
     url_prefix = lang_config["url_prefix"]
     map_href = f"/{url_prefix}" if url_prefix else "/"
-    pokemon_list_url = f"/{url_prefix}pokemon/" if url_prefix else "/pokemon/"
     canonical_url = f"{BASE_URL}{url_prefix}pokemon/"
     map_url = f"{BASE_URL}{url_prefix}"
 
@@ -337,7 +336,8 @@ def generate_html(
     items_html = "".join(items)
 
     # Popular intro text
-    top3_names = "・".join(
+    name_joiner = lang_config.get("pref_joiner", "・")
+    top3_names = name_joiner.join(
         _get_display_name(pokemon_index[s][0], lang_config)
         for s in sorted_slugs[:3]
     )

--- a/apps/scraper/generate_pokemon_pages.py
+++ b/apps/scraper/generate_pokemon_pages.py
@@ -4,6 +4,8 @@
 Creates /pokemon/{slug}/index.html for each Pokemon that appears on at least
 one active pokefuta manhole.  Each page includes title, meta description,
 canonical URL, OGP tags, JSON-LD (CollectionPage), a manhole list, and CTAs.
+Supports 5 languages (ja/en/zh-CN/zh-TW/ko); generates language-specific pages
+under dist/{lang}/pokemon/{slug}/ (Japanese goes to dist/pokemon/{slug}/).
 """
 
 from __future__ import annotations
@@ -12,6 +14,7 @@ import argparse
 import json
 import logging
 from collections import defaultdict
+from collections.abc import Callable
 from itertools import groupby
 from pathlib import Path
 from urllib.parse import quote
@@ -26,6 +29,7 @@ DEFAULT_OGP_IMAGE = f"{BASE_URL}assets/ogp/pokefuta_map_ogp.png"
 
 # Short contextual descriptions explaining regional connections.
 # Keeps wording soft ("イメージ", "語感", "連想") — no unsourced assertions.
+# Only shown on Japanese pages (not yet translated).
 POKEMON_SEO_DESCRIPTIONS: dict[str, str] = {
     "vulpix": (
         "ロコンは北海道各地を応援するポケモンとして親しまれ、"
@@ -71,35 +75,6 @@ POKEMON_SEO_DESCRIPTIONS: dict[str, str] = {
     ),
 }
 
-
-def generate_ai_summary(name_ja: str, manholes: list[dict]) -> str:
-    """Return a natural-language summary describing where this Pokemon appears."""
-    count = len(manholes)
-    prefs = sorted({m.get("prefecture") for m in manholes if m.get("prefecture")})
-    n = len(prefs)
-
-    if n == 0:
-        dist = f"{name_ja}のポケふたは現在{count}枚確認されています。"
-    elif n == 1:
-        dist = f"{name_ja}のポケふたは{prefs[0]}に{count}枚設置されています。"
-    elif n == 2:
-        dist = f"{name_ja}のポケふたは{'・'.join(prefs)}の{n}都道府県、合計{count}枚設置されています。"
-    elif n == 3:
-        dist = f"{name_ja}のポケふたは{'・'.join(prefs)}の{n}都道府県、合計{count}枚設置されています。"
-    else:
-        dist = (
-            f"{name_ja}のポケふたは全国{n}都道府県・{count}枚設置されています。"
-            f"{'・'.join(prefs[:2])}をはじめ、各地で出会えます。"
-        )
-
-    if n >= 3:
-        travel = "複数の都道府県を旅行しながら巡るのもおすすめです。"
-    else:
-        travel = "設置地域を訪れながら探してみてください。"
-
-    return dist + travel
-
-
 # Regional form prefix mapping (pokefuta data uses these prefixes)
 _FORM_PREFIX: dict[str, str] = {
     "alola": "アローラ",
@@ -107,6 +82,224 @@ _FORM_PREFIX: dict[str, str] = {
     "hisui": "ヒスイ",
     "paldea": "パルデア",
 }
+
+# Per-language config: name_key maps to pokemon_metadata names keys.
+LANG_CONFIGS: dict[str, dict] = {
+    "ja": {
+        "name_key": "ja",
+        "pref_key": None,  # None = use Japanese prefecture name directly
+        "html_lang": "ja",
+        "og_locale": "ja_JP",
+        "hreflang": "ja",
+        "url_prefix": "",   # → dist/pokemon/
+        "form_prefixes": _FORM_PREFIX,
+        "pref_joiner": "・",
+    },
+    "en": {
+        "name_key": "en",
+        "pref_key": "en",
+        "html_lang": "en",
+        "og_locale": "en_US",
+        "hreflang": "en",
+        "url_prefix": "en/",
+        "form_prefixes": {"alola": "Alolan ", "galar": "Galarian ", "hisui": "Hisuian ", "paldea": "Paldean "},
+        "pref_joiner": ", ",
+    },
+    "zh-CN": {
+        "name_key": "zh-Hans",
+        "pref_key": "zh-Hans",
+        "html_lang": "zh-Hans",
+        "og_locale": "zh_CN",
+        "hreflang": "zh-Hans",
+        "url_prefix": "zh-CN/",
+        "form_prefixes": {"alola": "阿罗拉", "galar": "伽勒尔", "hisui": "洗翠", "paldea": "帕底亚"},
+        "pref_joiner": "、",
+    },
+    "zh-TW": {
+        "name_key": "zh-Hant",
+        "pref_key": "zh-Hant",
+        "html_lang": "zh-Hant",
+        "og_locale": "zh_TW",
+        "hreflang": "zh-TW",
+        "url_prefix": "zh-TW/",
+        "form_prefixes": {"alola": "阿羅拉", "galar": "伽勒爾", "hisui": "洗翠", "paldea": "帕底亞"},
+        "pref_joiner": "、",
+    },
+    "ko": {
+        "name_key": "ko",
+        "pref_key": "ko",
+        "html_lang": "ko",
+        "og_locale": "ko_KR",
+        "hreflang": "ko",
+        "url_prefix": "ko/",
+        "form_prefixes": {"alola": "알로라 ", "galar": "가라르 ", "hisui": "히스이 ", "paldea": "팔데아 "},
+        "pref_joiner": "・",
+    },
+}
+
+# UI strings per language for LP pages.
+LP_STRINGS: dict[str, dict[str, str]] = {
+    "ja": {
+        "title_suffix": "のポケふた一覧 | 全国のポケモンマンホールマップ",
+        "desc_template": "{name}が描かれた全国のポケふた（ポケモンマンホール）を地図で探せます。旅行先や現在地から近くのポケふたを見つけよう。",
+        "og_title_suffix": "のポケふた一覧",
+        "generation": "第{gen}世代",
+        "unknown_location": "所在地不明",
+        "pref_section_heading": "{pref}の{name}のポケふた",
+        "pref_map_link": "{pref}の地図で見る →",
+        "related_heading": "関連するポケモン",
+        "count_text": "全国に <strong>{count}</strong> 枚の{name}のポケふたがあります。",
+        "cta": "地図で全国のポケふたを探す →",
+        "breadcrumb_aria": "パンくずリスト",
+        "breadcrumb_home": "全国マップ",
+        "breadcrumb_pokemon": "ポケモン一覧",
+        "footer": "ポケモンマンホール全国マップ",
+        "summary_0pref": "{name}のポケふたは現在{count}枚確認されています。",
+        "summary_1pref": "{name}のポケふたは{pref}に{count}枚設置されています。",
+        "summary_few_pref": "{name}のポケふたは{prefs}の{n}都道府県、合計{count}枚設置されています。",
+        "summary_many_pref": "{name}のポケふたは全国{n}都道府県・{count}枚設置されています。{top_prefs}をはじめ、各地で出会えます。",
+        "summary_travel_many": "複数の都道府県を旅行しながら巡るのもおすすめです。",
+        "summary_travel_few": "設置地域を訪れながら探してみてください。",
+    },
+    "en": {
+        "title_suffix": " Pokéfuta | Pokémon Manhole Map of Japan",
+        "desc_template": "Find all Pokéfuta (Pokémon manholes) featuring {name} across Japan. Explore locations on the map from your destination or current position.",
+        "og_title_suffix": " Pokéfuta",
+        "generation": "Generation {gen}",
+        "unknown_location": "Location unknown",
+        "pref_section_heading": "{name} Pokéfuta in {pref}",
+        "pref_map_link": "View {pref} on map →",
+        "related_heading": "Related Pokémon",
+        "count_text": "There are <strong>{count}</strong> {name} Pokéfuta nationwide.",
+        "cta": "Explore all Pokéfuta on the map →",
+        "breadcrumb_aria": "Breadcrumb",
+        "breadcrumb_home": "Japan Map",
+        "breadcrumb_pokemon": "Pokémon List",
+        "footer": "Pokémon Manhole Map of Japan",
+        "summary_0pref": "There are currently {count} {name} Pokéfuta confirmed.",
+        "summary_1pref": "{count} {name} Pokéfuta installed in {pref}.",
+        "summary_few_pref": "{name} Pokéfuta found in {n} prefectures — {prefs} — totaling {count} locations.",
+        "summary_many_pref": "{name} Pokéfuta spread across {n} prefectures nationwide, {count} total. Including {top_prefs} and more.",
+        "summary_travel_many": "Consider visiting multiple prefectures to find them all.",
+        "summary_travel_few": "Visit the installation area to find it.",
+    },
+    "zh-CN": {
+        "title_suffix": " 宝可梦井盖 | 日本宝可梦井盖地图",
+        "desc_template": "在地图上查找日本各地绘有{name}的宝可梦井盖（Pokéfuta）。从旅游目的地或当前位置寻找附近的宝可梦井盖。",
+        "og_title_suffix": " 宝可梦井盖",
+        "generation": "第{gen}世代",
+        "unknown_location": "位置不明",
+        "pref_section_heading": "{pref}的{name}宝可梦井盖",
+        "pref_map_link": "在地图上查看{pref} →",
+        "related_heading": "相关宝可梦",
+        "count_text": "全国共有 <strong>{count}</strong> 个{name}宝可梦井盖。",
+        "cta": "在地图上查找全国宝可梦井盖 →",
+        "breadcrumb_aria": "面包屑导航",
+        "breadcrumb_home": "全国地图",
+        "breadcrumb_pokemon": "宝可梦列表",
+        "footer": "日本宝可梦井盖全国地图",
+        "summary_0pref": "目前已确认{count}个{name}宝可梦井盖。",
+        "summary_1pref": "{name}宝可梦井盖共{count}个，设置于{pref}。",
+        "summary_few_pref": "{name}宝可梦井盖遍布{prefs}等{n}个都道府县，合计{count}个。",
+        "summary_many_pref": "{name}宝可梦井盖遍布全国{n}个都道府县，共{count}个。包括{top_prefs}等地。",
+        "summary_travel_many": "推荐前往多个都道府县打卡。",
+        "summary_travel_few": "前往设置地点寻找吧。",
+    },
+    "zh-TW": {
+        "title_suffix": " 寶可夢人孔蓋 | 日本寶可夢人孔蓋地圖",
+        "desc_template": "在地圖上查找日本各地繪有{name}的寶可夢人孔蓋（Pokéfuta）。從旅遊目的地或所在位置尋找附近的寶可夢人孔蓋。",
+        "og_title_suffix": " 寶可夢人孔蓋",
+        "generation": "第{gen}世代",
+        "unknown_location": "位置不明",
+        "pref_section_heading": "{pref}的{name}寶可夢人孔蓋",
+        "pref_map_link": "在地圖上查看{pref} →",
+        "related_heading": "相關寶可夢",
+        "count_text": "全國共有 <strong>{count}</strong> 個{name}寶可夢人孔蓋。",
+        "cta": "在地圖上查找全國寶可夢人孔蓋 →",
+        "breadcrumb_aria": "麵包屑導覽",
+        "breadcrumb_home": "全國地圖",
+        "breadcrumb_pokemon": "寶可夢列表",
+        "footer": "日本寶可夢人孔蓋全國地圖",
+        "summary_0pref": "目前已確認{count}個{name}寶可夢人孔蓋。",
+        "summary_1pref": "{name}寶可夢人孔蓋共{count}個，設置於{pref}。",
+        "summary_few_pref": "{name}寶可夢人孔蓋遍布{prefs}等{n}個都道府縣，合計{count}個。",
+        "summary_many_pref": "{name}寶可夢人孔蓋遍布全國{n}個都道府縣，共{count}個。包括{top_prefs}等地。",
+        "summary_travel_many": "推薦前往多個都道府縣打卡。",
+        "summary_travel_few": "前往設置地點尋找吧。",
+    },
+    "ko": {
+        "title_suffix": " 포케후타 | 일본 포켓몬 맨홀 지도",
+        "desc_template": "일본 전국에 설치된 {name} 포케후타（포켓몬 맨홀）를 지도에서 찾아보세요. 여행지나 현재 위치에서 가까운 포케후타를 발견하세요.",
+        "og_title_suffix": " 포케후타",
+        "generation": "{gen}세대",
+        "unknown_location": "위치 불명",
+        "pref_section_heading": "{pref}의 {name} 포케후타",
+        "pref_map_link": "{pref} 지도로 보기 →",
+        "related_heading": "관련 포켓몬",
+        "count_text": "전국에 <strong>{count}</strong>개의 {name} 포케후타가 있습니다.",
+        "cta": "지도에서 전국의 포케후타 찾기 →",
+        "breadcrumb_aria": "이동 경로",
+        "breadcrumb_home": "전국 지도",
+        "breadcrumb_pokemon": "포켓몬 목록",
+        "footer": "일본 포켓몬 맨홀 전국 지도",
+        "summary_0pref": "현재 {name} 포케후타가 {count}개 확인되었습니다.",
+        "summary_1pref": "{name} 포케후타가 {pref}에 {count}개 설치되어 있습니다.",
+        "summary_few_pref": "{name} 포케후타는 {prefs} 등 {n}개 현에 합계 {count}개 설치되어 있습니다.",
+        "summary_many_pref": "{name} 포케후타는 전국 {n}개 현에 {count}개 설치되어 있습니다. {top_prefs} 등 각지에서 만날 수 있습니다.",
+        "summary_travel_many": "여러 현을 여행하며 방문해 보세요.",
+        "summary_travel_few": "설치 지역을 방문해 찾아보세요.",
+    },
+}
+
+
+def load_prefectures(path: Path) -> dict[str, dict[str, str]]:
+    """Load prefecture name translations from prefectures.json."""
+    if not path.exists():
+        logger.warning(f"Prefectures file not found: {path}")
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _get_display_name(pokemon: dict, lang_config: dict) -> str:
+    """Return the localized display name for a Pokémon, including form prefix."""
+    names = pokemon.get("names", {})
+    form = pokemon.get("form") or ""
+    name_key = lang_config["name_key"]
+    form_prefixes = lang_config.get("form_prefixes", {})
+    prefix = form_prefixes.get(form, "")
+    name = names.get(name_key) or names.get("ja", "")
+    return prefix + name
+
+
+def generate_ai_summary(
+    name: str,
+    manholes: list[dict],
+    strings: dict,
+    translate_pref: Callable[[str], str],
+    pref_joiner: str = "・",
+) -> str:
+    """Return a natural-language summary describing where this Pokemon appears."""
+    count = len(manholes)
+    prefs_ja = sorted({m.get("prefecture") for m in manholes if m.get("prefecture")})
+    prefs = [translate_pref(p) for p in prefs_ja]
+    n = len(prefs)
+
+    if n == 0:
+        dist = strings["summary_0pref"].format(count=count, name=name)
+    elif n == 1:
+        dist = strings["summary_1pref"].format(count=count, name=name, pref=prefs[0])
+    elif n <= 3:
+        dist = strings["summary_few_pref"].format(
+            n=n, count=count, name=name, prefs=pref_joiner.join(prefs)
+        )
+    else:
+        dist = strings["summary_many_pref"].format(
+            n=n, count=count, name=name,
+            top_prefs=pref_joiner.join(prefs[:2])
+        )
+
+    travel = strings["summary_travel_many"] if n >= 3 else strings["summary_travel_few"]
+    return dist + travel
 
 
 def _normalize_katakana(text: str) -> str:
@@ -256,19 +449,18 @@ RELATED_POKEMON_OVERRIDES: dict[str, list[str]] = {
 def build_related_map(
     index: dict[str, tuple[dict, list[dict]]],
     metadata: dict[str, dict],
-) -> dict[str, list[tuple[str, str]]]:
-    """Return {slug: [(related_slug, ja_name), ...]} sharing a base evolution family."""
+) -> dict[str, list[tuple[str, dict]]]:
+    """Return {slug: [(related_slug, pokemon_meta), ...]} sharing a base evolution family."""
     slug_to_family: dict[str, str] = {}
-    slug_to_ja: dict[str, str] = {}
+    slug_to_poke_meta: dict[str, dict] = {}
+
     for _ja_name, meta in metadata.items():
         slug = meta.get("slug", "")
         fam = (meta.get("evolution") or {}).get("family_id", "")
-        if slug and fam:
-            slug_to_family[slug] = fam
-            form = meta.get("form") or ""
-            ja_name = meta.get("names", {}).get("ja", slug)
-            prefix = _FORM_PREFIX.get(form, "")
-            slug_to_ja.setdefault(slug, prefix + ja_name if prefix else ja_name)
+        if slug:
+            slug_to_poke_meta[slug] = meta
+            if fam:
+                slug_to_family[slug] = fam
 
     base_to_slugs: dict[str, list[str]] = defaultdict(list)
     for slug in index:
@@ -277,14 +469,14 @@ def build_related_map(
         if base:
             base_to_slugs[base].append(slug)
 
-    result: dict[str, list[tuple[str, str]]] = {}
+    result: dict[str, list[tuple[str, dict]]] = {}
     for slug in index:
         fam = slug_to_family.get(slug, "")
         base = fam.split("-")[0] if fam else ""
         related = [
-            (s, slug_to_ja.get(s, s))
+            (s, slug_to_poke_meta[s])
             for s in sorted(base_to_slugs.get(base, []))
-            if s != slug
+            if s != slug and s in slug_to_poke_meta
         ]
         result[slug] = related
 
@@ -296,67 +488,103 @@ def build_related_map(
         for related_slug in override_slugs:
             if related_slug not in index or related_slug in existing:
                 continue
-            merged.append((related_slug, slug_to_ja.get(related_slug, related_slug)))
+            if related_slug not in slug_to_poke_meta:
+                continue
+            merged.append((related_slug, slug_to_poke_meta[related_slug]))
             existing.add(related_slug)
         result[slug] = merged
 
     return result
 
 
+def _hreflang_links(slug: str) -> str:
+    """Generate hreflang <link> tags for all language variants of a Pokemon page."""
+    lines = []
+    for lang, lc in LANG_CONFIGS.items():
+        url = f"{BASE_URL}{lc['url_prefix']}pokemon/{quote(slug)}/"
+        lines.append(f'  <link rel="alternate" hreflang="{lc["hreflang"]}" href="{escape(url)}">')
+    # x-default points to Japanese (root)
+    default_url = f"{BASE_URL}pokemon/{quote(slug)}/"
+    lines.append(f'  <link rel="alternate" hreflang="x-default" href="{escape(default_url)}">')
+    return "\n".join(lines)
+
+
 def generate_html(
     slug: str,
     pokemon: dict,
     manholes: list[dict],
-    related: list[tuple[str, str]],
+    related: list[tuple[str, dict]],
     image_dir: Path,
+    lang: str,
+    lang_config: dict,
+    strings: dict,
+    translate_pref: Callable[[str], str],
     seo_desc: str = "",
 ) -> str:
     """Return complete HTML for a Pokemon LP page."""
+    display_name = _get_display_name(pokemon, lang_config)
     names = pokemon.get("names", {})
-    form = pokemon.get("form") or ""
-    _prefix = _FORM_PREFIX.get(form, "")
-    name_ja = _prefix + names.get("ja", slug)
-    name_en = names.get("en", "")
-    name_ko = names.get("ko", "")
-    name_zh = names.get("zh-Hans", "")
     types_data = pokemon.get("types", [])
-    types_ja = [t.get("ja", "") for t in types_data if isinstance(t, dict)]
     generation = pokemon.get("generation")
 
-    canonical_url = f"{BASE_URL}pokemon/{quote(slug)}/"
-    map_url = BASE_URL
+    # Show type badges in the page language where available; fall back to Japanese.
+    lang_type_key = lang_config["name_key"] if lang_config["name_key"] != "ja" else None
+    types_display = []
+    for t in types_data:
+        if not isinstance(t, dict):
+            continue
+        label = (lang_type_key and t.get(lang_type_key)) or t.get("en") or t.get("ja", "")
+        if label:
+            types_display.append(label)
+
+    url_prefix = lang_config["url_prefix"]
+    canonical_url = f"{BASE_URL}{url_prefix}pokemon/{quote(slug)}/"
+    map_url = f"{BASE_URL}{url_prefix}"
+    pokemon_list_url = f"/{url_prefix}pokemon/" if url_prefix else "/pokemon/"
+    map_href = f"/{url_prefix}" if url_prefix else "/"
+
     count = len(manholes)
 
-    title = f"{name_ja}のポケふた一覧 | 全国のポケモンマンホールマップ"
-    description = (
-        f"{name_ja}が描かれた全国のポケふた（ポケモンマンホール）を地図で探せます。"
-        f"旅行先や現在地から近くのポケふたを見つけよう。"
-    )
+    title = display_name + strings["title_suffix"]
+    description = strings["desc_template"].format(name=display_name)
+    og_title = display_name + strings["og_title_suffix"]
 
-    # OGP title keeps it short
-    og_title = f"{name_ja}のポケふた一覧"
-    og_desc = description
-
-    # Multilingual names line
-    multilang_parts = [p for p in [name_en, name_ko, name_zh] if p]
+    # Multilingual names line (other languages than the current one)
+    other_lang_keys = ["en", "ja", "ko", "zh-Hans", "zh-Hant"]
+    current_key = lang_config["name_key"]
+    multilang_parts = [
+        names[k] for k in other_lang_keys
+        if k != current_key and names.get(k)
+    ]
+    # For non-ja pages, show Japanese name prominently
+    if lang != "ja" and names.get("ja"):
+        ja_display = _get_display_name(pokemon, LANG_CONFIGS["ja"])
+        if ja_display not in multilang_parts:
+            multilang_parts.insert(0, ja_display)
     multilang_html = ""
     if multilang_parts:
         multilang_html = (
-            f"<p class='poke-multilang'>{escape(' / '.join(multilang_parts))}</p>"
+            f"<p class='poke-multilang'>{escape(' / '.join(multilang_parts[:3]))}</p>"
         )
 
     # Type badges
     type_badges = "".join(
-        f"<span class='type-badge'>{escape(t)}</span>" for t in types_ja
+        f"<span class='type-badge'>{escape(t)}</span>" for t in types_display
     )
     type_html = (
         f"<div class='type-badges'>{type_badges}</div>" if type_badges else ""
     )
 
-    gen_html = f"<p class='poke-gen'>第{generation}世代</p>" if generation else ""
+    gen_html = ""
+    if generation:
+        gen_html = f"<p class='poke-gen'>{escape(strings['generation'].format(gen=generation))}</p>"
+
     seo_desc_html = f"<p class='poke-seo-desc'>{escape(seo_desc)}</p>" if seo_desc else ""
 
-    ai_summary_text = generate_ai_summary(name_ja, manholes)
+    pref_joiner = lang_config.get("pref_joiner", "・")
+    ai_summary_text = generate_ai_summary(
+        display_name, manholes, strings, translate_pref, pref_joiner
+    )
     ai_summary_html = f"<div class='ai-summary-box'><p>{escape(ai_summary_text)}</p></div>"
 
     # JSON-LD
@@ -366,36 +594,42 @@ def generate_html(
         "name": og_title,
         "description": description,
         "url": canonical_url,
-        "inLanguage": "ja",
+        "inLanguage": lang_config["html_lang"],
     }
     jsonld_str = json.dumps(jsonld, ensure_ascii=False, indent=2)
 
+    breadcrumb_home = strings["breadcrumb_home"]
+    breadcrumb_pokemon = strings["breadcrumb_pokemon"]
     jsonld_breadcrumb_str = json.dumps({
         "@context": "https://schema.org",
         "@type": "BreadcrumbList",
         "itemListElement": [
-            {"@type": "ListItem", "position": 1, "name": "全国マップ", "item": BASE_URL},
-            {"@type": "ListItem", "position": 2, "name": "ポケモン一覧", "item": f"{BASE_URL}pokemon/"},
-            {"@type": "ListItem", "position": 3, "name": name_ja, "item": canonical_url},
+            {"@type": "ListItem", "position": 1, "name": breadcrumb_home, "item": map_url},
+            {"@type": "ListItem", "position": 2, "name": breadcrumb_pokemon, "item": f"{BASE_URL}{url_prefix}pokemon/"},
+            {"@type": "ListItem", "position": 3, "name": display_name, "item": canonical_url},
         ],
     }, ensure_ascii=False, indent=2)
 
-    # Manhole sections grouped by prefecture (empty prefecture sorted last)
+    hreflang_html = _hreflang_links(slug)
+
+    # Manhole sections grouped by prefecture
+    unknown_location = strings["unknown_location"]
     sorted_manholes = sorted(
         manholes,
         key=lambda m: (0 if m.get("prefecture") else 1, m.get("prefecture", ""), m.get("city", "")),
     )
     sections_html = ""
-    for prefecture, group in groupby(sorted_manholes, key=lambda m: m.get("prefecture", "")):
-        display_pref = prefecture or "所在地不明"
-        pref_h2 = f"{display_pref}の{name_ja}のポケふた"
+    for prefecture_ja, group in groupby(sorted_manholes, key=lambda m: m.get("prefecture", "")):
+        prefecture_display = translate_pref(prefecture_ja) if prefecture_ja else unknown_location
+        pref_h2 = strings["pref_section_heading"].format(pref=prefecture_display, name=display_name)
         cards_html = ""
         for m in group:
             mid = str(m.get("id", "")).strip()
-            pref = m.get("prefecture", "")
+            pref_ja = m.get("prefecture", "")
             city = m.get("city", "")
-            location = (pref + city) or m.get("title", "所在地不明")
-            label = f"{location}のポケふた"
+            pref_display = translate_pref(pref_ja) if pref_ja else ""
+            location = (pref_display + city) or m.get("title", unknown_location)
+            label = f"{location}のポケふた" if lang == "ja" else f"{display_name} Pokéfuta in {location}" if lang == "en" else location
             pokes = filter_pokemons(m.get("pokemons", []))
             sub = "・".join(pokes) if pokes else ""
 
@@ -403,9 +637,8 @@ def generate_html(
             img_path = image_dir / f"{mid}_latest.jpeg"
             if img_path.exists():
                 img_url = escape(f"https://data.pokefuta.com/manhole/image/{mid}_latest.jpeg")
-                alt = f"{location}の{name_ja}のポケふた"
                 img_html = (
-                    f"<img src='{img_url}' alt='{escape(alt)}'"
+                    f"<img src='{img_url}' alt='{escape(display_name)}'"
                     f" loading='lazy' decoding='async' width='320' height='180'>"
                 )
 
@@ -413,16 +646,18 @@ def generate_html(
                 f"<li class='manhole-item'>"
                 f"<a href='/manholes/{quote(mid)}/'>"
                 + img_html
-                + f"<span class='manhole-location'>{escape(label)}</span>"
+                + f"<span class='manhole-location'>{escape(location)}</span>"
                 + (f"<span class='manhole-poke'>{escape(sub)}</span>" if sub else "")
                 + f"</a></li>"
             )
+
         pref_map_link = ""
-        if prefecture:
-            pref_encoded = quote(prefecture)
+        if prefecture_ja:
+            pref_encoded = quote(prefecture_ja)
+            link_text = strings["pref_map_link"].format(pref=prefecture_display)
             pref_map_link = (
-                f"<a class='pref-map-link' href='/?pref={pref_encoded}'>"
-                f"{escape(prefecture)}の地図で見る →</a>"
+                f"<a class='pref-map-link' href='{escape(map_href)}?pref={pref_encoded}'>"
+                f"{escape(link_text)}</a>"
             )
         sections_html += (
             f"<section class='pref-section'>"
@@ -436,21 +671,26 @@ def generate_html(
     related_html = ""
     if related:
         links = "".join(
-            f"<li><a href='/pokemon/{quote(s)}/'>{escape(ja)}</a></li>"
-            for s, ja in related
+            f"<li><a href='/{url_prefix}pokemon/{quote(s)}/'>"
+            f"{escape(_get_display_name(meta, lang_config))}</a></li>"
+            for s, meta in related
         )
         related_html = (
             f"<div class='section-card related-section'>"
-            f"<h2>関連するポケモン</h2>"
+            f"<h2>{escape(strings['related_heading'])}</h2>"
             f"<ul class='related-list'>{links}</ul>"
             f"</div>"
         )
 
-    # slug_js for GA4 page_path
+    count_text_html = strings["count_text"].format(count=count, name=escape(display_name))
+    cta_text = strings["cta"]
+    footer_text = strings["footer"]
+    breadcrumb_aria = strings["breadcrumb_aria"]
+
     slug_js = json.dumps(slug)
 
     return f"""<!doctype html>
-<html lang="ja">
+<html lang="{lang_config['html_lang']}">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -458,17 +698,18 @@ def generate_html(
   <meta name="description" content="{escape(description)}">
   <meta name="robots" content="index,follow">
   <link rel="canonical" href="{escape(canonical_url)}">
+{hreflang_html}
 
   <meta property="og:type" content="website">
-  <meta property="og:locale" content="ja_JP">
+  <meta property="og:locale" content="{lang_config['og_locale']}">
   <meta property="og:title" content="{escape(og_title)}">
-  <meta property="og:description" content="{escape(og_desc)}">
+  <meta property="og:description" content="{escape(description)}">
   <meta property="og:url" content="{escape(canonical_url)}">
   <meta property="og:image" content="{escape(DEFAULT_OGP_IMAGE)}">
 
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="{escape(og_title)}">
-  <meta name="twitter:description" content="{escape(og_desc)}">
+  <meta name="twitter:description" content="{escape(description)}">
   <meta name="twitter:image" content="{escape(DEFAULT_OGP_IMAGE)}">
 
   <script type="application/ld+json">
@@ -485,11 +726,12 @@ def generate_html(
     function gtag(){{dataLayer.push(arguments);}}
     gtag('js', new Date());
     gtag('config', '{GA_MEASUREMENT_ID}', {{
-      'page_path': '/pokemon/' + {slug_js} + '/'
+      'page_path': '/{url_prefix}pokemon/' + {slug_js} + '/'
     }});
     gtag('event', 'view_pokemon_lp', {{
       pokemon_slug: {slug_js},
-      manhole_count: {count}
+      manhole_count: {count},
+      lang: '{lang}'
     }});
     function trackEvent(action, params) {{
       gtag('event', action, params);
@@ -692,16 +934,16 @@ def generate_html(
 </head>
 <body>
 <div class="container">
-  <nav aria-label="パンくずリスト" class="breadcrumb">
+  <nav aria-label="{escape(breadcrumb_aria)}" class="breadcrumb">
     <ol>
-      <li><a href="/">全国マップ</a></li>
-      <li><a href="/pokemon/">ポケモン一覧</a></li>
-      <li aria-current="page">{escape(name_ja)}</li>
+      <li><a href="{escape(map_href)}">{escape(breadcrumb_home)}</a></li>
+      <li><a href="{escape(pokemon_list_url)}">{escape(breadcrumb_pokemon)}</a></li>
+      <li aria-current="page">{escape(display_name)}</li>
     </ol>
   </nav>
 
   <div class="poke-hero">
-    <h1>{escape(name_ja)}のポケふた一覧</h1>
+    <h1>{escape(display_name)}{escape(strings['og_title_suffix'])}</h1>
     {multilang_html}
     {type_html}
     {gen_html}
@@ -710,7 +952,7 @@ def generate_html(
   </div>
 
   <div class="section-card">
-    <p class="count-text">全国に <strong>{count}</strong> 枚の{escape(name_ja)}のポケふたがあります。</p>
+    <p class="count-text">{count_text_html}</p>
     {sections_html}
   </div>
 
@@ -718,11 +960,11 @@ def generate_html(
 
   <a href="{escape(map_url)}" class="cta-map"
      onclick="trackEvent('click_map_cta', {{pokemon_slug: {slug_js}}})">
-    地図で全国のポケふたを探す →
+    {escape(cta_text)}
   </a>
 
   <footer>
-    <p><a href="{escape(BASE_URL)}">data.pokefuta.com</a> &mdash; ポケモンマンホール全国マップ</p>
+    <p><a href="{escape(BASE_URL)}">data.pokefuta.com</a> &mdash; {escape(footer_text)}</p>
   </footer>
 </div>
 </body>
@@ -744,8 +986,16 @@ def main() -> int:
         help="Directory containing {id}_latest.jpeg files",
     )
     parser.add_argument(
-        "--output", default="dist/pokemon",
-        help="Output directory (dist/pokemon)",
+        "--output-root", default="dist",
+        help="Root output directory (default: dist). Pokemon pages go to {output-root}/pokemon/ for ja and {output-root}/{lang}/pokemon/ for other languages.",
+    )
+    parser.add_argument(
+        "--langs", nargs="*", default=list(LANG_CONFIGS.keys()),
+        help="Languages to generate (default: all). Example: --langs ja en ko",
+    )
+    parser.add_argument(
+        "--prefectures", default="apps/web/i18n/prefectures.json",
+        help="Path to prefectures.json for prefecture name translations",
     )
     args = parser.parse_args()
 
@@ -759,27 +1009,59 @@ def main() -> int:
         logger.error("No manhole records loaded — aborting")
         return 1
 
+    pref_data = load_prefectures(Path(args.prefectures))
+
     index = build_pokemon_index(manholes, metadata)
     logger.info(f"Pokemon with pokefuta: {len(index)}")
 
     related_map = build_related_map(index, metadata)
     image_dir = Path(args.images)
+    output_root = Path(args.output_root)
 
-    output_root = Path(args.output)
-    generated = 0
-    for slug, (pokemon, poke_manholes) in sorted(index.items()):
-        out_dir = output_root / slug
-        out_dir.mkdir(parents=True, exist_ok=True)
-        html = generate_html(
-            slug, pokemon, poke_manholes,
-            related=related_map.get(slug, []),
-            image_dir=image_dir,
-            seo_desc=POKEMON_SEO_DESCRIPTIONS.get(slug, ""),
-        )
-        (out_dir / "index.html").write_text(html, encoding="utf-8")
-        generated += 1
+    langs_to_build = [la for la in args.langs if la in LANG_CONFIGS]
+    if not langs_to_build:
+        logger.error(f"No valid languages specified. Choose from: {list(LANG_CONFIGS.keys())}")
+        return 1
 
-    logger.info(f"[generate_pokemon_pages] wrote {generated} pages to {output_root}/")
+    for lang in langs_to_build:
+        lc = LANG_CONFIGS[lang]
+        strings = LP_STRINGS[lang]
+        pref_key = lc["pref_key"]
+
+        if pref_key is None:
+            def translate_pref(ja: str, _key: str = "") -> str:
+                return ja
+        else:
+            def translate_pref(ja: str, _key: str = pref_key) -> str:
+                return pref_data.get(ja, {}).get(_key, ja)
+
+        url_prefix = lc["url_prefix"]
+        if url_prefix:
+            pokemon_dir = output_root / url_prefix.rstrip("/") / "pokemon"
+        else:
+            pokemon_dir = output_root / "pokemon"
+
+        generated = 0
+        for slug, (pokemon, poke_manholes) in sorted(index.items()):
+            out_dir = pokemon_dir / slug
+            out_dir.mkdir(parents=True, exist_ok=True)
+            html = generate_html(
+                slug=slug,
+                pokemon=pokemon,
+                manholes=poke_manholes,
+                related=related_map.get(slug, []),
+                image_dir=image_dir,
+                lang=lang,
+                lang_config=lc,
+                strings=strings,
+                translate_pref=translate_pref,
+                seo_desc=POKEMON_SEO_DESCRIPTIONS.get(slug, "") if lang == "ja" else "",
+            )
+            (out_dir / "index.html").write_text(html, encoding="utf-8")
+            generated += 1
+
+        logger.info(f"[{lang}] wrote {generated} pages to {pokemon_dir}/")
+
     return 0
 
 

--- a/apps/scraper/generate_pokemon_pages.py
+++ b/apps/scraper/generate_pokemon_pages.py
@@ -628,8 +628,10 @@ def generate_html(
             pref_ja = m.get("prefecture", "")
             city = m.get("city", "")
             pref_display = translate_pref(pref_ja) if pref_ja else ""
-            location = (pref_display + city) or m.get("title", unknown_location)
-            label = f"{location}のポケふた" if lang == "ja" else f"{display_name} Pokéfuta in {location}" if lang == "en" else location
+            if pref_display and city:
+                location = pref_display + city if lang == "ja" else f"{pref_display} {city}"
+            else:
+                location = pref_display or city or m.get("title", unknown_location)
             pokes = filter_pokemons(m.get("pokemons", []))
             sub = "・".join(pokes) if pokes else ""
 

--- a/apps/scraper/generate_sitemap.py
+++ b/apps/scraper/generate_sitemap.py
@@ -203,11 +203,19 @@ def build_sitemap(manhole_ids: list[str], pokemon_slugs: list[str] | None = None
             url_entry(f"{BASE_URL}manholes/{quote(manhole_id)}/", "weekly", "0.8")
         )
 
-    # Pokemon LP pages
+    # Pokemon LP pages (Japanese root)
     for slug in pokemon_slugs or []:
         entries.append(
             url_entry(f"{BASE_URL}pokemon/{quote(slug)}/", "weekly", "0.1")
         )
+
+    # Pokemon LP pages (multilingual)
+    for lang in I18N_LANGS:
+        entries.append(url_entry(f"{BASE_URL}{lang}/pokemon/", "weekly", "0.9"))
+        for slug in pokemon_slugs or []:
+            entries.append(
+                url_entry(f"{BASE_URL}{lang}/pokemon/{quote(slug)}/", "weekly", "0.1")
+            )
 
     return "\n".join(
         [


### PR DESCRIPTION
## Summary

- `generate_pokemon_pages.py` と `generate_pokemon_index_page.py` を多言語対応に改修
- ポケモン個別LPページ（534体）と一覧ページを ja/en/zh-CN/zh-TW/ko の5言語で生成
- サイトマップに多言語ポケモンURLを追加

## Changes

### generate_pokemon_pages.py
- `LANG_CONFIGS` — 言語ごとのURL prefix / 名前キー / フォームプレフィックス / hreflang を管理
- `LP_STRINGS` — UI文字列を5言語分定義（title, description, breadcrumb, CTA, summary テンプレート等）
- `load_prefectures()` — `apps/web/i18n/prefectures.json` を使い都道府県名を翻訳
- `generate_ai_summary()` — テンプレートベースに変更し、言語・都道府県名翻訳に対応
- `_get_display_name()` — アローラ/ガラル等の地域フォームを各言語で正しく表示
- `build_related_map()` — 戻り値を `(slug, ja_name)` → `(slug, meta_dict)` に変更し関連ポケモンも多言語表示
- `generate_html()` — hreflang タグ全言語分生成・`--output-root / --langs / --prefectures` オプション追加
- `POKEMON_SEO_DESCRIPTIONS` は日本語ページのみ表示（未翻訳）

### generate_pokemon_index_page.py
- `LP_INDEX_STRINGS` — 一覧ページ用UI文字列を5言語分定義
- `REGIONAL_TAGLINES` — 地域連携ポケモンのタグライン（北海道のロコンなど）を5言語で定義
- `_region_summary()` — 都道府県名翻訳対応
- `--output-root / --langs / --prefectures` オプション追加

### generate_sitemap.py
- `/en/pokemon/`, `/zh-CN/pokemon/` 等の多言語ポケモンインデックスURLを追加
- 各言語の個別ポケモンページURL（534体 × 4言語）を追加

## URL Structure

| 言語 | 個別LP | 一覧 |
|------|--------|------|
| ja | `/pokemon/{slug}/` | `/pokemon/` |
| en | `/en/pokemon/{slug}/` | `/en/pokemon/` |
| zh-CN | `/zh-CN/pokemon/{slug}/` | `/zh-CN/pokemon/` |
| zh-TW | `/zh-TW/pokemon/{slug}/` | `/zh-TW/pokemon/` |
| ko | `/ko/pokemon/{slug}/` | `/ko/pokemon/` |

## Test plan

- [ ] `python3 apps/scraper/generate_pokemon_pages.py --output-root dist --prefectures apps/web/i18n/prefectures.json` が全言語正常生成
- [ ] `python3 apps/scraper/generate_pokemon_index_page.py --output-root dist --prefectures apps/web/i18n/prefectures.json` が全言語正常生成
- [ ] `dist/en/pokemon/pikachu/index.html` に hreflang / 英語タイトル / Generation 1 が含まれる
- [ ] `dist/ko/pokemon/vulpix-alola/index.html` に "알로라 식스테일" が含まれる
- [ ] サイトマップに `/en/pokemon/` URLが存在する

🤖 Generated with [Claude Code](https://claude.com/claude-code)