### PR TITLE
feat: マップポップアップのポケモン名をLPページへのリンクに変更

### DIFF
--- a/apps/web/assets/pokefuta-map.css
+++ b/apps/web/assets/pokefuta-map.css
@@ -835,6 +835,17 @@ body.pokefuta-map-page {
   font-weight: 900;
 }
 
+.pokefuta-map-page a.travel-popup-pokemon {
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.pokefuta-map-page a.travel-popup-pokemon:hover,
+.pokefuta-map-page a.travel-popup-pokemon:focus-visible {
+  background: rgba(101, 74, 160, .22);
+  color: #4a3080;
+}
+
 .pokefuta-map-page .travel-popup-actions {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -703,7 +703,12 @@
       const prefectureCode = window.PREFECTURE_CODE_MAP[prefecture] || '--';
       const pokemons = Array.isArray(d.pokemons) && d.pokemons.length ? d.pokemons : [];
       const pokemonsHtml = pokemons.length
-        ? pokemons.map(pokemon => `<span class="travel-popup-pokemon">${escapeHtml(pokemon)}</span>`).join('')
+        ? pokemons.map(pokemon => {
+            const url = getPokemonLpUrl(pokemon);
+            return url
+              ? `<a href="${escapeHtml(url)}" class="travel-popup-pokemon" target="_blank" rel="noopener noreferrer">${escapeHtml(pokemon)}</a>`
+              : `<span class="travel-popup-pokemon">${escapeHtml(pokemon)}</span>`;
+          }).join('')
         : '<span class="travel-popup-pokemon">ポケモン未設定</span>';
       const imageUrl = getLocalManholeImageUrl(d.id);
       const photoAlt = `${d.title || 'ポケふた'}の写真`;
@@ -811,6 +816,12 @@
     function getPokemonMetadata(nameJa) {
       if (!pokemonMetadata || !nameJa) return null;
       return pokemonMetadata.get(nameJa) || null;
+    }
+
+    function getPokemonLpUrl(jaName) {
+      const meta = getPokemonMetadata(jaName);
+      if (!meta || !meta.slug) return null;
+      return `${window.SITE_BASE_URL}pokemon/${meta.slug}/`;
     }
 
     function buildPokemonInfoCards(pokemons) {

--- a/apps/web/index.template.html
+++ b/apps/web/index.template.html
@@ -60,14 +60,15 @@
         const meta = getPokemonMetadata(jaName);
         return (meta && meta.names[_key]) || jaName;
       };
-
-      window.getPokemonLpUrl = function (jaName) {
-        const meta = getPokemonMetadata(jaName);
-        if (!meta || !meta.slug) return null;
-        const prefix = _lang === 'ja' ? '' : _lang + '/';
-        return `${window.SITE_ROOT_URL}${prefix}pokemon/${meta.slug}/`;
-      };
     })();
+
+    window.getPokemonLpUrl = function(jaName) {
+      const meta = getPokemonMetadata(jaName);
+      if (!meta || !meta.slug) return null;
+      const lang = (window.I18N && window.I18N.lang) || 'ja';
+      const prefix = lang === 'ja' ? '' : lang + '/';
+      return `${window.SITE_ROOT_URL}${prefix}pokemon/${meta.slug}/`;
+    };
 
     window.resolvePrefectureParam = function(prefParam) {
       if (!prefParam) return '';
@@ -718,7 +719,7 @@
             const displayName = escapeHtml(getPokemonDisplayName(pokemon));
             const url = getPokemonLpUrl(pokemon);
             return url
-              ? `<a href="${escapeHtml(url)}" class="travel-popup-pokemon travel-popup-pokemon--link" target="_blank" rel="noopener noreferrer">${displayName}</a>`
+              ? `<a href="${escapeHtml(url)}" class="travel-popup-pokemon" target="_blank" rel="noopener noreferrer">${displayName}</a>`
               : `<span class="travel-popup-pokemon">${displayName}</span>`;
           }).join('')
         : `<span class="travel-popup-pokemon">${I.noPokemon}</span>`;

--- a/apps/web/index.template.html
+++ b/apps/web/index.template.html
@@ -60,6 +60,13 @@
         const meta = getPokemonMetadata(jaName);
         return (meta && meta.names[_key]) || jaName;
       };
+
+      window.getPokemonLpUrl = function (jaName) {
+        const meta = getPokemonMetadata(jaName);
+        if (!meta || !meta.slug) return null;
+        const prefix = _lang === 'ja' ? '' : _lang + '/';
+        return `${window.SITE_ROOT_URL}${prefix}pokemon/${meta.slug}/`;
+      };
     })();
 
     window.resolvePrefectureParam = function(prefParam) {
@@ -707,7 +714,13 @@
       const prefectureCode = window.PREFECTURE_CODE_MAP[d.prefecture] || '--';
       const pokemons = Array.isArray(d.pokemons) && d.pokemons.length ? d.pokemons : [];
       const pokemonsHtml = pokemons.length
-        ? pokemons.map(pokemon => `<span class="travel-popup-pokemon">${escapeHtml(getPokemonDisplayName(pokemon))}</span>`).join('')
+        ? pokemons.map(pokemon => {
+            const displayName = escapeHtml(getPokemonDisplayName(pokemon));
+            const url = getPokemonLpUrl(pokemon);
+            return url
+              ? `<a href="${escapeHtml(url)}" class="travel-popup-pokemon travel-popup-pokemon--link" target="_blank" rel="noopener noreferrer">${displayName}</a>`
+              : `<span class="travel-popup-pokemon">${displayName}</span>`;
+          }).join('')
         : `<span class="travel-popup-pokemon">${I.noPokemon}</span>`;
       const imageUrl = getLocalManholeImageUrl(d.id);
       const photoAlt = `${d.title || I.manholeTitle}${I.photoAltSuffix}`;

--- a/tools/make_template.py
+++ b/tools/make_template.py
@@ -383,6 +383,42 @@ t = t.replace(
 )
 
 # ──────────────────────────────────────────
+# I-2. getPokemonLpUrl — Japanese → i18n-aware
+# ──────────────────────────────────────────
+
+t = t.replace(
+    '''    function getPokemonLpUrl(jaName) {
+      const meta = getPokemonMetadata(jaName);
+      if (!meta || !meta.slug) return null;
+      return `${window.SITE_BASE_URL}pokemon/${meta.slug}/`;
+    }''',
+    '''    window.getPokemonLpUrl = function(jaName) {
+      const meta = getPokemonMetadata(jaName);
+      if (!meta || !meta.slug) return null;
+      const lang = (window.I18N && window.I18N.lang) || 'ja';
+      const prefix = lang === 'ja' ? '' : lang + '/';
+      return `${window.SITE_ROOT_URL}${prefix}pokemon/${meta.slug}/`;
+    };''',
+    1
+)
+t = t.replace(
+    '''        ? pokemons.map(pokemon => {
+            const url = getPokemonLpUrl(pokemon);
+            return url
+              ? `<a href="${escapeHtml(url)}" class="travel-popup-pokemon" target="_blank" rel="noopener noreferrer">${escapeHtml(pokemon)}</a>`
+              : `<span class="travel-popup-pokemon">${escapeHtml(pokemon)}</span>`;
+          }).join('')''',
+    '''        ? pokemons.map(pokemon => {
+            const displayName = escapeHtml(getPokemonDisplayName(pokemon));
+            const url = getPokemonLpUrl(pokemon);
+            return url
+              ? `<a href="${escapeHtml(url)}" class="travel-popup-pokemon" target="_blank" rel="noopener noreferrer">${displayName}</a>`
+              : `<span class="travel-popup-pokemon">${displayName}</span>`;
+          }).join('')''',
+    1
+)
+
+# ──────────────────────────────────────────
 # J. buildPokemonInfoCards — use window.I18N
 # ──────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- マップ上のマンホールポップアップに表示されるポケモン名ピルを `<span>` から `<a>` リンクに変更
- クリックするとそのポケモンの LP ページ（`/pokemon/{slug}/` 等）が新タブで開く
- 現在の表示言語に応じた URL を生成（例: 英語表示時 → `/en/pokemon/bulbasaur/`）
- `pokemon_metadata.json` にスラグが存在しない場合は `<span>` にフォールバック（後方互換性維持）

## Changes

| ファイル | 変更内容 |
|---|---|
| `apps/web/index.template.html` | IIFE に `window.getPokemonLpUrl` を追加、`buildPokefutaPopup` のポケモン表示を `<a>` に変更 |
| `apps/web/assets/pokefuta-map.css` | `a.travel-popup-pokemon` のホバー・フォーカススタイルを追加 |

## Test plan

- [ ] 地図でマンホールをクリック → ポップアップのポケモン名がリンク（ポインターカーソル）になっている
- [ ] リンクをクリックすると正しい LP ページが新タブで開く
- [ ] 言語切り替え後（en / zh-CN / zh-TW / ko）にリンク URL が対応する言語プレフィックスを持つ
- [ ] スラグ未解決のポケモンは `<span>` のままで表示崩れなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)