### PR TITLE
Update manhole semantic metadata (20260523)

### DIFF
--- a/dataset/manhole_titles.json
+++ b/dataset/manhole_titles.json
@@ -475,27 +475,32 @@
     },
     "15": {
       "tags": [
-        "seaside"
+        "seaside",
+        "near_station"
       ]
     },
     "16": {
       "tags": [
-        "seaside"
+        "seaside",
+        "station_front"
       ]
     },
     "17": {
       "tags": [
-        "seaside"
+        "seaside",
+        "near_station"
       ]
     },
     "18": {
       "tags": [
-        "seaside"
+        "seaside",
+        "near_station"
       ]
     },
     "19": {
       "tags": [
-        "seaside"
+        "seaside",
+        "station_front"
       ]
     },
     "35": {


### PR DESCRIPTION
## Summary

semantic metadata をセマンティックエディタで更新しました。

## 変更内容

- assign_station_tags: 5件

対象マンホール数（ユニーク）: 5件

## Tasks

- assign_station_tags: 5件

## Guardrails

- docs/pokefuta.ndjson は変更されていません
- dataset/manhole_titles.json のみ変更されています

## Validation

- [x] JSON parse OK
- [x] schema OK
- [x] docs/*.ndjson 汚染なし
- [x] changes.ndjson で操作ログ確認済み

🤖 Generated with Semantic Manhole Metadata Editor