### PR TITLE
feat: マップヒーローカードにポケモンLP一覧リンクを追加

### DIFF
--- a/apps/web/assets/pokefuta-map.css
+++ b/apps/web/assets/pokefuta-map.css
@@ -81,6 +81,21 @@ body.pokefuta-map-page {
   font-weight: 900;
 }
 
+.pokefuta-map-page .map-hero-card .hero-pokemon-link {
+  display: inline-block;
+  margin-top: 10px;
+  color: #6F55A3;
+  font-size: .82rem;
+  font-weight: 900;
+  text-decoration: none;
+}
+
+.pokefuta-map-page .map-hero-card .hero-pokemon-link:hover,
+.pokefuta-map-page .map-hero-card .hero-pokemon-link:focus-visible {
+  text-decoration: underline;
+  color: #4a3080;
+}
+
 .pokefuta-map-page #controls {
   position: fixed;
   z-index: 1000;

--- a/apps/web/i18n/strings.en.json
+++ b/apps/web/i18n/strings.en.json
@@ -20,6 +20,7 @@
   "CONTROLS_TOGGLE_ARIA": "Open main panel",
   "CONTROLS_TOGGLE_TITLE": "Open / close main panel",
   "LOCATE_LABEL": "Find nearby Pokéfuta",
+  "POKEMON_LP_HREF": "/en/pokemon/",
   "PREF_DIR_HEADING": "Pokéfuta by Prefecture",
   "PREF_DIR_DESC": "Browse Pokémon manhole covers by prefecture to plan your trip.",
   "PREF_DIR_LINKS_ARIA": "Prefectures with Pokéfuta",

--- a/apps/web/i18n/strings.ja.json
+++ b/apps/web/i18n/strings.ja.json
@@ -20,6 +20,7 @@
   "CONTROLS_TOGGLE_ARIA": "全体パネルを開く",
   "CONTROLS_TOGGLE_TITLE": "全体パネルを開く/閉じる",
   "LOCATE_LABEL": "近くのポケふたを探す",
+  "POKEMON_LP_HREF": "/pokemon/",
   "PREF_DIR_HEADING": "都道府県別のポケふた一覧",
   "PREF_DIR_DESC": "旅行先やお出かけ先の近くにあるポケふたを、都道府県別に探せます。",
   "PREF_DIR_LINKS_ARIA": "ポケふたがある都道府県",

--- a/apps/web/i18n/strings.ko.json
+++ b/apps/web/i18n/strings.ko.json
@@ -20,6 +20,7 @@
   "CONTROLS_TOGGLE_ARIA": "메인 패널 열기",
   "CONTROLS_TOGGLE_TITLE": "메인 패널 열기／닫기",
   "LOCATE_LABEL": "근처 포케후타 찾기",
+  "POKEMON_LP_HREF": "/ko/pokemon/",
   "PREF_DIR_HEADING": "도도부현별 포케후타 목록",
   "PREF_DIR_DESC": "도도부현별로 포켓몬 맨홀을 검색하여 여행을 계획해보세요.",
   "PREF_DIR_LINKS_ARIA": "포케후타가 있는 도도부현",

--- a/apps/web/i18n/strings.zh-CN.json
+++ b/apps/web/i18n/strings.zh-CN.json
@@ -20,6 +20,7 @@
   "CONTROLS_TOGGLE_ARIA": "打开主面板",
   "CONTROLS_TOGGLE_TITLE": "打开／关闭主面板",
   "LOCATE_LABEL": "查找附近的 Pokéfuta",
+  "POKEMON_LP_HREF": "/zh-CN/pokemon/",
   "PREF_DIR_HEADING": "按都道府县分类的 Pokéfuta 一览",
   "PREF_DIR_DESC": "按都道府县浏览宝可梦井盖，规划旅游行程。",
   "PREF_DIR_LINKS_ARIA": "有 Pokéfuta 的都道府县",

--- a/apps/web/i18n/strings.zh-TW.json
+++ b/apps/web/i18n/strings.zh-TW.json
@@ -20,6 +20,7 @@
   "CONTROLS_TOGGLE_ARIA": "開啟主要面板",
   "CONTROLS_TOGGLE_TITLE": "開啟／關閉主要面板",
   "LOCATE_LABEL": "尋找附近的 Pokéfuta",
+  "POKEMON_LP_HREF": "/zh-TW/pokemon/",
   "PREF_DIR_HEADING": "依都道府縣分類的 Pokéfuta 一覽",
   "PREF_DIR_DESC": "依都道府縣瀏覽神奇寶貝人孔蓋，規劃旅遊行程。",
   "PREF_DIR_LINKS_ARIA": "有 Pokéfuta 的都道府縣",

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -322,6 +322,7 @@
       <h1 id="hero-title">全国のポケふた・ポケモンマンホールマップ</h1>
       <p>旅行やお出かけのついでに、ご当地マンホール「ポケふた」を見つけよう</p>
       <p class="map-hero-meta">📍 全国<span id="hero-city-count">0</span>の自治体に設置</p>
+      <a href="/pokemon/" class="hero-pokemon-link" onclick="if(window.trackEvent){window.trackEvent('click_pokemon_lp_hero',{event_category:'navigation',event_label:'hero_card'})}">→ ポケモン一覧を見る</a>
     </section>
   </main>
 

--- a/apps/web/index.template.html
+++ b/apps/web/index.template.html
@@ -358,6 +358,7 @@
       <h1 id="hero-title">%%HERO_TITLE%%</h1>
       <p>%%HERO_SUBTITLE%%</p>
       <p class="map-hero-meta">%%HERO_CITY_PREFIX%%<span id="hero-city-count">0</span>%%HERO_CITY_SUFFIX%%</p>
+      <a href="%%POKEMON_LP_HREF%%" class="hero-pokemon-link" onclick="if(window.trackEvent){window.trackEvent('click_pokemon_lp_hero',{event_category:'navigation',event_label:'hero_card'})}">%%POPULAR_LINK%%</a>
     </section>
   </main>
 


### PR DESCRIPTION
## Summary

- 地図ページ上部のヒーローカード（タイトルカード）末尾に「→ ポケモン一覧を見る」リンクを追加
- 全5言語対応：ja `/pokemon/` / en `/en/pokemon/` / zh-CN `/zh-CN/pokemon/` / zh-TW `/zh-TW/pokemon/` / ko `/ko/pokemon/`
- GA4 イベント `click_pokemon_lp_hero`（`event_category: navigation`, `event_label: hero_card`）で計測

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `apps/web/index.template.html` | ヒーローカードにリンク追加（`%%POKEMON_LP_HREF%%` プレースホルダ） |
| `apps/web/index.html` | 日本語マスターに同リンク追加 |
| `apps/web/assets/pokefuta-map.css` | `.hero-pokemon-link` スタイル追加（紫色・hover対応） |
| `apps/web/i18n/strings.{ja,en,zh-CN,zh-TW,ko}.json` | `POKEMON_LP_HREF` キー追加（言語別パス） |

## Test plan

- [ ] `dist/index.html` をブラウザで開き、ヒーローカード内に「→ ポケモン一覧を見る」が表示される
- [ ] リンクをクリックで `/pokemon/` に遷移する
- [ ] `dist/en/index.html` では「→ View all Pokémon」が `/en/pokemon/` にリンクされている
- [ ] GA4 DebugView で `click_pokemon_lp_hero` イベントが発火することを確認
- [ ] 既存の3ボタン（地図/新着/近く）の動作が壊れていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)