### PR TITLE
refactor: ヒーローカードの統計行削除・CTAテキスト改善（全5言語）

### DIFF
--- a/apps/web/assets/pokefuta-map.css
+++ b/apps/web/assets/pokefuta-map.css
@@ -74,13 +74,6 @@ body.pokefuta-map-page {
   font-weight: 650;
 }
 
-.pokefuta-map-page .map-hero-card .map-hero-meta {
-  margin-top: 8px;
-  color: #2b213a;
-  font-size: .86rem;
-  font-weight: 900;
-}
-
 .pokefuta-map-page .map-hero-card .hero-pokemon-link {
   display: inline-block;
   margin-top: 10px;

--- a/apps/web/i18n/strings.en.json
+++ b/apps/web/i18n/strings.en.json
@@ -9,8 +9,6 @@
   "MAP_ARIA": "Pokéfuta exploration map",
   "HERO_TITLE": "Pokémon Manhole (Pokéfuta) Map of Japan",
   "HERO_SUBTITLE": "Discover regional Pokémon manholes on your travels around Japan",
-  "HERO_CITY_PREFIX": "📍 Installed in ",
-  "HERO_CITY_SUFFIX": " municipalities nationwide",
   "PANEL_TITLE": "Main panel",
   "PANEL_CONTENT_ARIA": "Main panel contents",
   "EXPLORE_MENU_ARIA": "Explore menu",
@@ -31,7 +29,7 @@
   "PREF_SPOTS_HEADING": "Pokéfuta in this prefecture",
   "POPULAR_NAV_ARIA": "Popular Pokémon",
   "POPULAR_HEADING": "Popular Pokémon",
-  "POPULAR_LINK": "→ View all Pokémon",
+  "POPULAR_LINK": "Find your favorite Pokémon's Pokéfuta →",
   "POPULAR_ITEMS": "      <li><a href=\"/pokemon/chansey/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">Chansey</a></li>\n      <li><a href=\"/pokemon/lapras/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">Lapras</a></li>\n      <li><a href=\"/pokemon/vulpix-alola/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">Alolan Vulpix</a></li>\n      <li><a href=\"/pokemon/oshawott/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">Oshawott</a></li>\n      <li><a href=\"/pokemon/vulpix/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">Vulpix</a></li>\n      <li><a href=\"/pokemon/geodude/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">Geodude</a></li>\n      <li><a href=\"/pokemon/quagsire/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">Quagsire</a></li>\n      <li><a href=\"/pokemon/exeggutor/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">Exeggutor</a></li>\n      <li><a href=\"/pokemon/dragonite/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">Dragonite</a></li>\n      <li><a href=\"/pokemon/slowpoke/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">Slowpoke</a></li>\n      <li><a href=\"/pokemon/sandshrew/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">Sandshrew</a></li>\n      <li><a href=\"/pokemon/pikachu/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">Pikachu</a></li>\n      <li><a href=\"/pokemon/eevee/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">Eevee</a></li>\n      <li><a href=\"/pokemon/snorlax/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">Snorlax</a></li>",
   "FOOTER_EXPORT": "📡 Data Export:",
   "I18N_OBJECT": {

--- a/apps/web/i18n/strings.ja.json
+++ b/apps/web/i18n/strings.ja.json
@@ -9,8 +9,6 @@
   "MAP_ARIA": "ポケふた探索マップ",
   "HERO_TITLE": "全国のポケふた・ポケモンマンホールマップ",
   "HERO_SUBTITLE": "旅行やお出かけのついでに、ご当地マンホール「ポケふた」を見つけよう",
-  "HERO_CITY_PREFIX": "📍 全国",
-  "HERO_CITY_SUFFIX": "の自治体に設置",
   "PANEL_TITLE": "全体パネル",
   "PANEL_CONTENT_ARIA": "全体パネルの内容",
   "EXPLORE_MENU_ARIA": "探索メニュー",
@@ -31,7 +29,7 @@
   "PREF_SPOTS_HEADING": "県内のポケふた",
   "POPULAR_NAV_ARIA": "人気のポケモン",
   "POPULAR_HEADING": "人気のポケモン",
-  "POPULAR_LINK": "→ ポケモン一覧を見る",
+  "POPULAR_LINK": "好きなポケモンのポケふたを探す →",
   "POPULAR_ITEMS": "      <li><a href=\"/pokemon/chansey/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">ラッキー</a></li>\n      <li><a href=\"/pokemon/lapras/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">ラプラス</a></li>\n      <li><a href=\"/pokemon/vulpix-alola/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">アローラロコン</a></li>\n      <li><a href=\"/pokemon/oshawott/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">ミジュマル</a></li>\n      <li><a href=\"/pokemon/vulpix/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">ロコン</a></li>\n      <li><a href=\"/pokemon/geodude/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">イシツブテ</a></li>\n      <li><a href=\"/pokemon/quagsire/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">ヌオー</a></li>\n      <li><a href=\"/pokemon/exeggutor/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">ナッシー</a></li>\n      <li><a href=\"/pokemon/dragonite/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">カイリュー</a></li>\n      <li><a href=\"/pokemon/slowpoke/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">ヤドン</a></li>\n      <li><a href=\"/pokemon/sandshrew/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">サンド</a></li>\n      <li><a href=\"/pokemon/pikachu/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">ピカチュウ</a></li>\n      <li><a href=\"/pokemon/eevee/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">イーブイ</a></li>\n      <li><a href=\"/pokemon/snorlax/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">カビゴン</a></li>",
   "FOOTER_EXPORT": "📡 データエクスポート:",
   "I18N_OBJECT": {

--- a/apps/web/i18n/strings.ko.json
+++ b/apps/web/i18n/strings.ko.json
@@ -9,8 +9,6 @@
   "MAP_ARIA": "포케후타 탐색 지도",
   "HERO_TITLE": "일본 전국 포켓몬 맨홀(포케후타) 지도",
   "HERO_SUBTITLE": "일본 여행 중에 각 지역의 포켓몬 맨홀을 찾아보세요!",
-  "HERO_CITY_PREFIX": "📍 전국 ",
-  "HERO_CITY_SUFFIX": "개 지자체에 설치됨",
   "PANEL_TITLE": "메인 패널",
   "PANEL_CONTENT_ARIA": "메인 패널 내용",
   "EXPLORE_MENU_ARIA": "탐색 메뉴",
@@ -31,7 +29,7 @@
   "PREF_SPOTS_HEADING": "해당 현의 포케후타",
   "POPULAR_NAV_ARIA": "인기 포켓몬",
   "POPULAR_HEADING": "인기 포켓몬",
-  "POPULAR_LINK": "→ 포켓몬 목록 보기",
+  "POPULAR_LINK": "좋아하는 포켓몬의 포케후타 찾기 →",
   "POPULAR_ITEMS": "      <li><a href=\"/pokemon/chansey/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">럭키</a></li>\n      <li><a href=\"/pokemon/lapras/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">라프라스</a></li>\n      <li><a href=\"/pokemon/vulpix-alola/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">알로라 식스테일</a></li>\n      <li><a href=\"/pokemon/oshawott/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">수댕이</a></li>\n      <li><a href=\"/pokemon/vulpix/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">식스테일</a></li>\n      <li><a href=\"/pokemon/geodude/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">꼬마돌</a></li>\n      <li><a href=\"/pokemon/quagsire/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">누오</a></li>\n      <li><a href=\"/pokemon/exeggutor/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">나시</a></li>\n      <li><a href=\"/pokemon/dragonite/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">망나뇽</a></li>\n      <li><a href=\"/pokemon/slowpoke/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">야돈</a></li>\n      <li><a href=\"/pokemon/sandshrew/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">모래두지</a></li>\n      <li><a href=\"/pokemon/pikachu/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">피카츄</a></li>\n      <li><a href=\"/pokemon/eevee/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">이브이</a></li>\n      <li><a href=\"/pokemon/snorlax/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">잠만보</a></li>",
   "FOOTER_EXPORT": "📡 데이터 내보내기:",
   "I18N_OBJECT": {

--- a/apps/web/i18n/strings.zh-CN.json
+++ b/apps/web/i18n/strings.zh-CN.json
@@ -9,8 +9,6 @@
   "MAP_ARIA": "宝可梦井盖探索地图",
   "HERO_TITLE": "日本全国宝可梦井盖（Pokéfuta）地图",
   "HERO_SUBTITLE": "在日本旅游时，寻找各地的宝可梦井盖吧！",
-  "HERO_CITY_PREFIX": "📍 全国共 ",
-  "HERO_CITY_SUFFIX": " 个自治体设置中",
   "PANEL_TITLE": "主面板",
   "PANEL_CONTENT_ARIA": "主面板内容",
   "EXPLORE_MENU_ARIA": "探索菜单",
@@ -31,7 +29,7 @@
   "PREF_SPOTS_HEADING": "该县的 Pokéfuta",
   "POPULAR_NAV_ARIA": "热门宝可梦",
   "POPULAR_HEADING": "热门宝可梦",
-  "POPULAR_LINK": "→ 查看全部宝可梦",
+  "POPULAR_LINK": "找你喜欢的宝可梦的 Pokéfuta →",
   "POPULAR_ITEMS": "      <li><a href=\"/pokemon/chansey/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">幸福蛋</a></li>\n      <li><a href=\"/pokemon/lapras/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">拉普拉斯</a></li>\n      <li><a href=\"/pokemon/vulpix-alola/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">阿罗拉六尾</a></li>\n      <li><a href=\"/pokemon/oshawott/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">水水獭</a></li>\n      <li><a href=\"/pokemon/vulpix/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">六尾</a></li>\n      <li><a href=\"/pokemon/geodude/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">小拳石</a></li>\n      <li><a href=\"/pokemon/quagsire/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">沼王</a></li>\n      <li><a href=\"/pokemon/exeggutor/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">椰蛋树</a></li>\n      <li><a href=\"/pokemon/dragonite/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">快龙</a></li>\n      <li><a href=\"/pokemon/slowpoke/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">呆呆兽</a></li>\n      <li><a href=\"/pokemon/sandshrew/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">穿山鼠</a></li>\n      <li><a href=\"/pokemon/pikachu/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">皮卡丘</a></li>\n      <li><a href=\"/pokemon/eevee/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">伊布</a></li>\n      <li><a href=\"/pokemon/snorlax/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">卡比兽</a></li>",
   "FOOTER_EXPORT": "📡 数据导出：",
   "I18N_OBJECT": {

--- a/apps/web/i18n/strings.zh-TW.json
+++ b/apps/web/i18n/strings.zh-TW.json
@@ -9,8 +9,6 @@
   "MAP_ARIA": "神奇寶貝人孔蓋探索地圖",
   "HERO_TITLE": "日本全國神奇寶貝人孔蓋（Pokéfuta）地圖",
   "HERO_SUBTITLE": "在日本旅遊時，尋找各地的神奇寶貝人孔蓋吧！",
-  "HERO_CITY_PREFIX": "📍 全國共 ",
-  "HERO_CITY_SUFFIX": " 個自治體設置中",
   "PANEL_TITLE": "主要面板",
   "PANEL_CONTENT_ARIA": "主要面板內容",
   "EXPLORE_MENU_ARIA": "探索選單",
@@ -31,7 +29,7 @@
   "PREF_SPOTS_HEADING": "該縣的 Pokéfuta",
   "POPULAR_NAV_ARIA": "熱門神奇寶貝",
   "POPULAR_HEADING": "熱門神奇寶貝",
-  "POPULAR_LINK": "→ 查看全部神奇寶貝",
+  "POPULAR_LINK": "找你喜歡的神奇寶貝的 Pokéfuta →",
   "POPULAR_ITEMS": "      <li><a href=\"/pokemon/chansey/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">幸福蛋</a></li>\n      <li><a href=\"/pokemon/lapras/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">拉普拉斯</a></li>\n      <li><a href=\"/pokemon/vulpix-alola/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">阿羅拉六尾</a></li>\n      <li><a href=\"/pokemon/oshawott/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">水水獺</a></li>\n      <li><a href=\"/pokemon/vulpix/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">六尾</a></li>\n      <li><a href=\"/pokemon/geodude/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">小拳石</a></li>\n      <li><a href=\"/pokemon/quagsire/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">沼王</a></li>\n      <li><a href=\"/pokemon/exeggutor/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">椰蛋樹</a></li>\n      <li><a href=\"/pokemon/dragonite/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">快龍</a></li>\n      <li><a href=\"/pokemon/slowpoke/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">呆呆獸</a></li>\n      <li><a href=\"/pokemon/sandshrew/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">穿山鼠</a></li>\n      <li><a href=\"/pokemon/pikachu/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">皮卡丘</a></li>\n      <li><a href=\"/pokemon/eevee/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">伊布</a></li>\n      <li><a href=\"/pokemon/snorlax/\" style=\"font-size:0.85rem; color:#6F55A3; text-decoration:none;\">卡比獸</a></li>",
   "FOOTER_EXPORT": "📡 資料匯出：",
   "I18N_OBJECT": {

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -321,8 +321,7 @@
     <section class="map-hero-card" aria-labelledby="hero-title">
       <h1 id="hero-title">全国のポケふた・ポケモンマンホールマップ</h1>
       <p>旅行やお出かけのついでに、ご当地マンホール「ポケふた」を見つけよう</p>
-      <p class="map-hero-meta">📍 全国<span id="hero-city-count">0</span>の自治体に設置</p>
-      <a href="/pokemon/" class="hero-pokemon-link" onclick="if(window.trackEvent){window.trackEvent('click_pokemon_lp_hero',{event_category:'navigation',event_label:'hero_card'})}">→ ポケモン一覧を見る</a>
+      <a href="/pokemon/" class="hero-pokemon-link" onclick="if(window.trackEvent){window.trackEvent('click_pokemon_lp_hero',{event_category:'navigation',event_label:'hero_card'})}">好きなポケモンのポケふたを探す →</a>
     </section>
   </main>
 
@@ -391,7 +390,7 @@
   </div>
   <nav aria-label="人気のポケモン" style="margin:16px auto 0; max-width:960px; padding:12px 16px; background:#fff8ec; border-radius:8px; border:1px solid #e8e0d0;">
     <p style="font-size:0.85rem; font-weight:bold; color:#6F55A3; margin:0 0 4px;">人気のポケモン</p>
-    <p style="margin:0 0 8px;"><a href="/pokemon/" style="font-size:0.85rem; color:#6F55A3; font-weight:bold;">→ ポケモン一覧を見る</a></p>
+    <p style="margin:0 0 8px;"><a href="/pokemon/" style="font-size:0.85rem; color:#6F55A3; font-weight:bold;">好きなポケモンのポケふたを探す →</a></p>
     <ul style="list-style:none; display:flex; flex-wrap:wrap; gap:8px; margin:0; padding:0;">
       <li><a href="/pokemon/chansey/" style="font-size:0.85rem; color:#6F55A3; text-decoration:none;">ラッキー</a></li>
       <li><a href="/pokemon/lapras/" style="font-size:0.85rem; color:#6F55A3; text-decoration:none;">ラプラス</a></li>

--- a/apps/web/index.template.html
+++ b/apps/web/index.template.html
@@ -357,8 +357,7 @@
     <section class="map-hero-card" aria-labelledby="hero-title">
       <h1 id="hero-title">%%HERO_TITLE%%</h1>
       <p>%%HERO_SUBTITLE%%</p>
-      <p class="map-hero-meta">%%HERO_CITY_PREFIX%%<span id="hero-city-count">0</span>%%HERO_CITY_SUFFIX%%</p>
-      <a href="%%POKEMON_LP_HREF%%" class="hero-pokemon-link" onclick="if(window.trackEvent){window.trackEvent('click_pokemon_lp_hero',{event_category:'navigation',event_label:'hero_card'})}">%%POPULAR_LINK%%</a>
+<a href="%%POKEMON_LP_HREF%%" class="hero-pokemon-link" onclick="if(window.trackEvent){window.trackEvent('click_pokemon_lp_hero',{event_category:'navigation',event_label:'hero_card'})}">%%POPULAR_LINK%%</a>
     </section>
   </main>
 


### PR DESCRIPTION
## Summary

- **統計行削除**: `📍 全国Nの自治体に設置` の行を削除。マップ利用への誘導に繋がらない視覚的ノイズのため
- **CTAテキスト改善**: `→ ポケモン一覧を見る`（受動的）→ `好きなポケモンのポケふたを探す →`（能動的）に変更
- GAイベント `click_pokemon_lp_hero` は維持（需要測定継続）

## 変更言語

| 言語 | Before | After |
|---|---|---|
| 日本語 | → ポケモン一覧を見る | 好きなポケモンのポケふたを探す → |
| 英語 | → View all Pokémon | Find your favorite Pokémon's Pokéfuta → |
| 韓国語 | → 포켓몬 목록 보기 | 좋아하는 포켓몬의 포케후타 찾기 → |
| 中国語簡体 | → 查看全部宝可梦 | 找你喜欢的宝可梦的 Pokéfuta → |
| 中国語繁体 | → 查看全部神奇寶貝 | 找你喜歡的神奇寶貝的 Pokéfuta → |

## Test plan

- [ ] ローカルでヒーローカードの統計行が消えていることを確認
- [ ] CTAテキストが変わっていることを確認（日本語・英語版）
- [ ] クリック時に `click_pokemon_lp_hero` GA イベントが発火することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)