### PR TITLE
fix: 都道府県パネルのマンホール表示件数上限を撤廃

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1628,7 +1628,7 @@
         .sort((a, b) => String(a.city || '').localeCompare(String(b.city || ''), 'ja'));
       heading.textContent = `${prefecture}のポケふた`;
       renderSpotResults(list, spots, {
-        limit: 24,
+        limit: Infinity,
         badge: d => isWithinLastDays(d._addedDate, 30) ? '<img src="./assets/icon-fire.svg" alt="" aria-hidden="true">NEW' : ''
       });
       panel.hidden = spots.length === 0;


### PR DESCRIPTION
## Summary

- 都道府県をクリックした際のマンホール一覧が `limit: 24` により最大24件しか表示されていなかった問題を修正
- 北海道など50件以上のデータがある都道府県で全件表示されるよう `limit: Infinity` に変更
- 「近く」「最近追加」リストのデフォルト上限 (24件) は変更なし

## Test plan

- [ ] 北海道をクリックして50件すべてが表示されることを確認
- [ ] 「近く」「最近追加」リストが引き続き24件以内で表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)