### PR TITLE
fix: 都道府県パネルの上限撤廃 + i18n 告知バナー + 開発サーバー自動起動フック

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "lsof -ti:8000 >/dev/null 2>&1 || nohup python3 -m http.server 8000 --directory apps/web >/tmp/pokefuta-server.log 2>&1 &",
+            "async": true,
+            "statusMessage": "http://localhost:8000 を起動中..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -322,8 +322,29 @@
       <h1 id="hero-title">全国のポケふた・ポケモンマンホールマップ</h1>
       <p>旅行やお出かけのついでに、ご当地マンホール「ポケふた」を見つけよう</p>
       <a href="/pokemon/" class="hero-pokemon-link" onclick="if(window.trackEvent){window.trackEvent('click_pokemon_lp_hero',{event_category:'navigation',event_label:'hero_card'})}">好きなポケモンのポケふたを探す →</a>
+      <a id="i18n-notice" href="" hidden
+         style="display:block; margin-top:8px; padding-top:8px; border-top:1px solid rgba(110,80,44,.12); font-size:0.78rem; font-weight:700; color:#4a7c59; text-decoration:none;"
+      ></a>
     </section>
   </main>
+  <script>
+  (function () {
+    var lang = (navigator.languages && navigator.languages[0]) || navigator.language || '';
+    if (/^ja/i.test(lang)) return;
+    var map = [
+      { re: /^zh-(tw|hant)/i, path: '/zh-TW/', label: '查看繁體中文版 →' },
+      { re: /^zh/i,           path: '/zh-CN/', label: '查看简体中文版 →' },
+      { re: /^ko/i,           path: '/ko/',    label: '한국어로 보기 →' },
+      { re: /^en/i,           path: '/en/',    label: 'View in English →' },
+    ];
+    var entry = map.find(function (m) { return m.re.test(lang); }) || map[3];
+    var el = document.getElementById('i18n-notice');
+    if (!el) return;
+    el.href = entry.path;
+    el.textContent = entry.label;
+    el.removeAttribute('hidden');
+  })();
+  </script>
 
   <div id="controls" class="bottom-sheet" role="complementary" aria-labelledby="page-title">
     <span id="page-title" class="sr-only">全体パネル</span>


### PR DESCRIPTION
## Summary

- **fix**: `renderSpotResults` の `limit: 24` を `Infinity` に変更し、北海道など件数の多い都道府県でも全件表示されるよう修正
- **feat**: ブラウザ言語が日本語以外の訪問者に対し、左上ヒーローカードに対応言語版（英語・繁体字中国語・簡体字中国語・韓国語）へのリンクを表示
- **chore**: Claude Code Stop フックを `.claude/settings.json` に追加し、実装完了後に `http://localhost:8000` (apps/web/) が自動起動するよう設定
- **feat**: summary ページをデプロイ時生成・5言語対応に切り替え（`generate_summary_pages.py`）
- **refactor**: `apps/scraper/` スクリプトを役割別に整理（CI 用 vs 手動実行ツール）
- **chore**: 週次写真データ更新（116件）+ `/import-photos` スキル追加

## Test plan

- [ ] 都道府県パネルで北海道を選択し、全件表示されることを確認（以前は 24 件で打ち切られていた）
- [ ] ブラウザ言語を `en`/`zh-TW`/`zh-CN`/`ko` に切り替え、ヒーローカードに対応言語へのリンクが表示されることを確認
- [ ] ブラウザ言語を `ja` に戻し、バナーが表示されないことを確認
- [ ] 未対応言語（`fr` 等）で英語 fallback になることを確認
- [ ] Claude Code で作業後、`http://localhost:8000` が自動で立ち上がることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)