### PR TITLE
feat: /social-post に画像生成機能を追加（SVGテンプレート + 曜日スケジュール）

### DIFF
--- a/.claude/commands/social-post.md
+++ b/.claude/commands/social-post.md
@@ -11,10 +11,16 @@ python3 apps/scraper/generate_social_posts.py
 
 1. `docs/social-post-candidates.json` を読み込む（全候補リスト）
 2. `docs/social-post-history.json` を読み込む（使用済みID管理）。ファイルが存在しない場合は `{"used": []}` として扱う
-3. 今日の日付・曜日・月・季節を踏まえて、最も面白い・タイムリーな候補を1件選ぶ
-   - `history.used` にある `id` で `used_at` が30日以内のものは選ばない
-   - 曜日ローテーションに縛られなくてよい。今日にふさわしいと思う候補を選ぶ
-   - 例：夏休み前なら旅行訴求が強い `prefecture_rank` や `rare_area`、最新投稿があれば `latest_photo` など
+3. 今日の曜日に対応するタイプを選ぶ（スケジュール厳守）：
+   - 月・日 → `prefecture_rank`
+   - 火    → `travel_trivia`
+   - 水    → `latest_photo`
+   - 木    → `pokemon_rank`
+   - 金    → `rare_area`
+   - 土    → `no_photo`
+
+   そのタイプの候補の中から、`history.used` にある `id` で `used_at` が30日以内のものを除外した上で最適な1件を選ぶ。
+   （同タイプの候補が全て30日除外済みの場合のみ、他タイプから代替してよい）
 4. 選んだ候補の `raw_data` をもとに X 投稿文を書く（以下のルールを守ること）：
    - 本文は140文字前後（URLを除いた文章部分）
    - 最初の1行に数字か驚きを入れる
@@ -41,3 +47,9 @@ python3 apps/scraper/generate_social_posts.py
    {"id": "候補のid", "used_at": "YYYY-MM-DD"}
    ```
 7. 投稿文（body の内容）をそのままユーザーに表示する（コピーしやすいように）
+8. 以下を実行して OGP 画像を生成する：
+   ```bash
+   cd "$(git rev-parse --show-toplevel)"
+   python3 apps/scraper/generate_social_ogp.py
+   ```
+9. 「画像: docs/social-post-ogp.png」を投稿文の下に表示する

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ pokefuta.ndjson
 # SNS投稿（ローカル管理、リポジトリに含めない）
 docs/social-post-history.json
 docs/social-post-daily.json
+docs/social-post-ogp.png

--- a/apps/scraper/generate_social_ogp.py
+++ b/apps/scraper/generate_social_ogp.py
@@ -29,13 +29,20 @@ IMAGE_DIR = ROOT / "dataset" / "manhole" / "image"
 # ---------------------------------------------------------------------------
 
 def svg_to_png(svg_bytes: bytes, out_path: Path) -> None:
-    result = subprocess.run(
-        ["rsvg-convert", "-f", "png", "-w", "1200", "-h", "630", "-o", str(out_path), "-"],
-        input=svg_bytes,
-        capture_output=True,
-    )
-    if result.returncode != 0:
-        raise RuntimeError(f"rsvg-convert failed: {result.stderr.decode()}")
+    try:
+        subprocess.run(
+            ["rsvg-convert", "-f", "png", "-w", "1200", "-h", "630", "-o", str(out_path), "-"],
+            input=svg_bytes,
+            capture_output=True,
+            check=True,
+        )
+    except FileNotFoundError:
+        sys.exit(
+            "[generate_social_ogp] rsvg-convert が見つかりません。"
+            " brew install librsvg でインストールしてください。"
+        )
+    except subprocess.CalledProcessError as e:
+        sys.exit(f"[generate_social_ogp] rsvg-convert failed: {e.stderr.decode()}")
 
 
 # ---------------------------------------------------------------------------
@@ -155,14 +162,16 @@ _BUILDERS = {
 def main() -> None:
     if not DAILY_JSON.exists():
         sys.exit("[generate_social_ogp] docs/social-post-daily.json が見つかりません。先に /social-post を実行してください。")
+    if not CANDIDATES_JSON.exists():
+        sys.exit("[generate_social_ogp] docs/social-post-candidates.json が見つかりません。先に generate_social_posts.py を実行してください。")
 
-    daily = json.loads(DAILY_JSON.read_text())
+    daily = json.loads(DAILY_JSON.read_text(encoding="utf-8"))
     post_id = daily["id"]
     post_type = daily["type"]
 
-    candidates = [json.loads(l) for l in CANDIDATES_JSON.read_text().splitlines() if l.strip()] \
+    candidates = [json.loads(l) for l in CANDIDATES_JSON.read_text(encoding="utf-8").splitlines() if l.strip()] \
         if CANDIDATES_JSON.suffix == ".ndjson" \
-        else json.loads(CANDIDATES_JSON.read_text())
+        else json.loads(CANDIDATES_JSON.read_text(encoding="utf-8"))
 
     candidate = next((c for c in candidates if c["id"] == post_id), None)
     if candidate is None:
@@ -179,7 +188,7 @@ def main() -> None:
     if not template_path.exists():
         sys.exit(f"[generate_social_ogp] テンプレートが見つかりません: {template_path}")
 
-    svg_text = template_path.read_text()
+    svg_text = template_path.read_text(encoding="utf-8")
     for key, value in placeholders.items():
         svg_text = svg_text.replace(key, value)
 

--- a/apps/scraper/generate_social_ogp.py
+++ b/apps/scraper/generate_social_ogp.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Generate OGP PNG (1200×630) for today's social post.
+
+Reads docs/social-post-daily.json (id, type) and docs/social-post-candidates.json
+(raw_data), substitutes placeholders in docs/ogp_template/{type}.svg, then
+converts to docs/social-post-ogp.png via rsvg-convert.
+
+Usage:
+    python3 apps/scraper/generate_social_ogp.py
+"""
+from __future__ import annotations
+
+import base64
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+DAILY_JSON = ROOT / "docs" / "social-post-daily.json"
+CANDIDATES_JSON = ROOT / "docs" / "social-post-candidates.json"
+TEMPLATE_DIR = ROOT / "docs" / "ogp_template"
+OUTPUT_PNG = ROOT / "docs" / "social-post-ogp.png"
+IMAGE_DIR = ROOT / "dataset" / "manhole" / "image"
+
+
+# ---------------------------------------------------------------------------
+# SVG → PNG conversion
+# ---------------------------------------------------------------------------
+
+def svg_to_png(svg_bytes: bytes, out_path: Path) -> None:
+    result = subprocess.run(
+        ["rsvg-convert", "-f", "png", "-w", "1200", "-h", "630", "-o", str(out_path), "-"],
+        input=svg_bytes,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"rsvg-convert failed: {result.stderr.decode()}")
+
+
+# ---------------------------------------------------------------------------
+# Placeholder builders per type
+# ---------------------------------------------------------------------------
+
+def _placeholders_prefecture_rank(raw: dict) -> dict:
+    bar_width = max(4, int(float(raw["percent"]) / 100 * 540))
+    return {
+        "{{PREF}}": raw["pref"],
+        "{{RANK}}": str(raw["rank"]),
+        "{{COUNT}}": str(raw["count"]),
+        "{{TOTAL}}": str(raw["total"]),
+        "{{PERCENT}}": str(raw["percent"]),
+        "{{BAR_WIDTH}}": str(bar_width),
+    }
+
+
+def _placeholders_travel_trivia(raw: dict) -> dict:
+    ft = raw["fact_type"]
+    v = raw["values"]
+    if ft == "total_count":
+        line1, line2, line3, line4 = str(v["total"]), "全国ポケふた設置数", "", ""
+    elif ft == "empty_prefs":
+        line1 = f"{v['empty_count']}県"
+        line2 = "ポケふた未設置の都道府県"
+        line3 = "・".join(v["pref_names"])
+        line4 = ""
+    elif ft == "regional_top":
+        line1, line2 = v["region"], "ポケふたが最も多い地方"
+        line3, line4 = f"{v['count']}枚 / 全国{v['total']}枚", ""
+    elif ft == "pokemon_variety":
+        line1, line2, line3, line4 = str(v["species_count"]), "登場するポケモンの種類数", "", ""
+    elif ft == "pokemon_widest_spread":
+        line1 = str(v["city_count"])
+        line2, line3, line4 = f"{v['ja_name']}の設置市区町村数", "全国最多の分布", ""
+    elif ft == "top3_ranking":
+        line1, line2 = "TOP3", "都道府県別ランキング"
+        line3 = f"①{v['top3'][0]['pref']} {v['top3'][0]['count']}枚　②{v['top3'][1]['pref']} {v['top3'][1]['count']}枚"
+        line4 = f"③{v['top3'][2]['pref']} {v['top3'][2]['count']}枚"
+    else:
+        line1 = line2 = line3 = line4 = ""
+    return {
+        "{{LINE1}}": line1,
+        "{{LINE2}}": line2,
+        "{{LINE3}}": line3,
+        "{{LINE4}}": line4,
+    }
+
+
+def _placeholders_latest_photo(raw: dict) -> dict:
+    pokemon_str = "・".join(raw.get("pokemon_list", [raw["pokemon"]]))
+    date_str = raw["created_at"][:10].replace("-", "/")
+
+    photo_path = IMAGE_DIR / f"{raw['manhole_id']}_latest.jpeg"
+    if photo_path.exists():
+        b64 = base64.b64encode(photo_path.read_bytes()).decode()
+        photo_elem = (
+            f'<image href="data:image/jpeg;base64,{b64}" '
+            f'x="770" y="157" width="310" height="310" '
+            f'preserveAspectRatio="xMidYMid slice" clip-path="url(#photoClip)"/>'
+        )
+    else:
+        photo_elem = (
+            '<text x="925" y="318" class="reg" font-size="16" '
+            'fill="#9A7A3F" text-anchor="middle">写真なし</text>'
+        )
+
+    return {
+        "{{PREF}}": raw["pref"],
+        "{{CITY}}": raw["city"],
+        "{{POKEMON}}": pokemon_str,
+        "{{DATE}}": date_str,
+        "{{PHOTO_ELEMENT}}": photo_elem,
+    }
+
+
+def _placeholders_pokemon_rank(raw: dict) -> dict:
+    return {
+        "{{POKEMON}}": raw["ja_name"],
+        "{{RANK}}": str(raw["rank"]),
+        "{{COUNT}}": str(raw["count"]),
+        "{{CITY_COUNT}}": str(raw["city_count"]),
+    }
+
+
+def _placeholders_rare_area(raw: dict) -> dict:
+    return {
+        "{{PREF}}": raw["pref"],
+        "{{COUNT}}": str(raw["count"]),
+        "{{TOTAL}}": str(raw["total"]),
+    }
+
+
+def _placeholders_no_photo(raw: dict) -> dict:
+    return {
+        "{{PREF}}": raw["pref"],
+        "{{NO_PHOTO_COUNT}}": str(raw["no_photo_count"]),
+        "{{TOTAL_COUNT}}": str(raw["total_count"]),
+    }
+
+
+_BUILDERS = {
+    "prefecture_rank": _placeholders_prefecture_rank,
+    "travel_trivia": _placeholders_travel_trivia,
+    "latest_photo": _placeholders_latest_photo,
+    "pokemon_rank": _placeholders_pokemon_rank,
+    "rare_area": _placeholders_rare_area,
+    "no_photo": _placeholders_no_photo,
+}
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    if not DAILY_JSON.exists():
+        sys.exit("[generate_social_ogp] docs/social-post-daily.json が見つかりません。先に /social-post を実行してください。")
+
+    daily = json.loads(DAILY_JSON.read_text())
+    post_id = daily["id"]
+    post_type = daily["type"]
+
+    candidates = [json.loads(l) for l in CANDIDATES_JSON.read_text().splitlines() if l.strip()] \
+        if CANDIDATES_JSON.suffix == ".ndjson" \
+        else json.loads(CANDIDATES_JSON.read_text())
+
+    candidate = next((c for c in candidates if c["id"] == post_id), None)
+    if candidate is None:
+        sys.exit(f"[generate_social_ogp] candidates に id={post_id} が見つかりません。")
+
+    raw = candidate["raw_data"]
+    builder = _BUILDERS.get(post_type)
+    if builder is None:
+        sys.exit(f"[generate_social_ogp] 未対応タイプ: {post_type}")
+
+    placeholders = builder(raw)
+
+    template_path = TEMPLATE_DIR / f"{post_type}.svg"
+    if not template_path.exists():
+        sys.exit(f"[generate_social_ogp] テンプレートが見つかりません: {template_path}")
+
+    svg_text = template_path.read_text()
+    for key, value in placeholders.items():
+        svg_text = svg_text.replace(key, value)
+
+    svg_bytes = svg_text.encode("utf-8")
+    svg_to_png(svg_bytes, OUTPUT_PNG)
+    print(f"[generate_social_ogp] 生成完了 → {OUTPUT_PNG}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/ogp_template/latest_photo.svg
+++ b/docs/ogp_template/latest_photo.svg
@@ -1,0 +1,93 @@
+<svg width="1200" height="630" viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="paper" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#FBF6EA"/>
+      <stop offset="1" stop-color="#F4ECDA"/>
+    </linearGradient>
+    <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#DCEFF7"/>
+      <stop offset="1" stop-color="#EAF6FB"/>
+    </linearGradient>
+    <linearGradient id="brand" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#6F55A3"/>
+      <stop offset="1" stop-color="#5B4A8F"/>
+    </linearGradient>
+    <filter id="soft" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="8" flood-color="#3A2C1F" flood-opacity="0.16"/>
+    </filter>
+    <clipPath id="photoClip">
+      <circle cx="925" cy="312" r="155"/>
+    </clipPath>
+    <style>
+      .ttl{font-family:'Noto Sans CJK JP','Hiragino Sans',sans-serif;font-weight:700}
+      .reg{font-family:'Noto Sans CJK JP','Hiragino Sans',sans-serif;font-weight:400}
+    </style>
+  </defs>
+
+  <!-- Paper base -->
+  <rect width="1200" height="630" fill="url(#paper)"/>
+
+  <!-- Right panel: sky background -->
+  <rect x="690" y="92" width="470" height="446" rx="28" fill="url(#sky)"/>
+  <!-- Subtle map grid -->
+  <g stroke="#9DBFD0" stroke-width="1" opacity="0.18">
+    <line x1="690" y1="190" x2="1160" y2="190"/><line x1="690" y1="300" x2="1160" y2="300"/>
+    <line x1="690" y1="410" x2="1160" y2="410"/><line x1="820" y1="92" x2="820" y2="538"/>
+    <line x1="950" y1="92" x2="950" y2="538"/><line x1="1080" y1="92" x2="1080" y2="538"/>
+  </g>
+
+  <!-- Photo shadow -->
+  <circle cx="925" cy="320" r="155" fill="#3A2C1F" opacity="0.18"/>
+  <!-- Photo fallback background -->
+  <circle cx="925" cy="312" r="155" fill="#D4C8B0"/>
+  <!-- Photo image (populated by generate_social_ogp.py) -->
+  {{PHOTO_ELEMENT}}
+  <!-- Photo border ring -->
+  <circle cx="925" cy="312" r="158" fill="none" stroke="#FFFFFF" stroke-width="5" opacity="0.9" filter="url(#soft)"/>
+
+  <!-- "NEW" badge -->
+  <circle cx="1055" cy="175" r="38" fill="#E8954B" filter="url(#soft)"/>
+  <text x="1055" y="169" class="ttl" font-size="13" fill="#FFFFFF" text-anchor="middle">NEW</text>
+  <text x="1055" y="184" class="reg" font-size="11" fill="#FFFFFF" text-anchor="middle">写真</text>
+
+  <!-- Map pins -->
+  <g transform="translate(742,480)"><path d="M0 0 C-10 -14 -10 -26 0 -26 C10 -26 10 -14 0 0 Z" fill="#6F55A3"/><circle cx="0" cy="-17" r="5" fill="#FFF9ED"/></g>
+  <g transform="translate(1100,480)"><path d="M0 0 C-10 -14 -10 -26 0 -26 C10 -26 10 -14 0 0 Z" fill="#5FA4C9"/><circle cx="0" cy="-17" r="5" fill="#FFF9ED"/></g>
+
+  <!-- Header band -->
+  <g>
+    <rect x="40" y="26" width="600" height="50" rx="16" fill="#FFFFFF" filter="url(#soft)"/>
+    <path d="M58 40 l5 11 11 1 -8 8 2 12 -10 -6 -10 6 2 -12 -8 -8 11 -1 z" fill="#6F55A3" opacity="0.8"/>
+    <text x="86" y="58" class="ttl" font-size="24" fill="#5B4A8F">全国のポケふた・ポケモンマンホール</text>
+  </g>
+
+  <!-- Tag -->
+  <rect x="40" y="96" width="155" height="30" rx="15" fill="#E8954B" opacity="0.15"/>
+  <text x="117" y="116" class="reg" font-size="14" fill="#C47020" text-anchor="middle">最新写真投稿</text>
+
+  <!-- Prefecture -->
+  <text x="44" y="195" class="ttl" font-size="58" fill="#3C342C">{{PREF}}</text>
+
+  <!-- City -->
+  <text x="44" y="260" class="ttl" font-size="46" fill="#6F55A3">{{CITY}}</text>
+
+  <!-- Divider line -->
+  <line x1="44" y1="285" x2="600" y2="285" stroke="#E8D6B8" stroke-width="1.5"/>
+
+  <!-- Pokemon label + value -->
+  <text x="44" y="322" class="reg" font-size="16" fill="#9A7A3F">登場ポケモン</text>
+  <text x="44" y="360" class="ttl" font-size="26" fill="#3C342C">{{POKEMON}}</text>
+
+  <!-- Date label + value -->
+  <text x="44" y="410" class="reg" font-size="16" fill="#9A7A3F">写真投稿日</text>
+  <text x="44" y="445" class="reg" font-size="22" fill="#5B4A8F">{{DATE}}</text>
+
+  <!-- Bottom brand band -->
+  <rect x="0" y="556" width="1200" height="74" fill="url(#brand)"/>
+  <circle cx="49" cy="587" r="9" fill="#FFFFFF" opacity="0.9"/>
+  <circle cx="49" cy="587" r="5" fill="#6F55A3"/>
+  <text x="66" y="587" class="ttl" font-size="22" fill="#FFFFFF">ポケふたマップ</text>
+  <text x="66" y="610" class="reg" font-size="14" fill="#E8DEF5">旅の思い出に、ポケふた探しの冒険を！</text>
+  <text x="600" y="600" class="ttl" font-size="18" fill="#FFFFFF" text-anchor="middle">全国470箇所以上掲載！</text>
+  <text x="1160" y="600" class="ttl" font-size="20" fill="#FFFFFF" text-anchor="end">data.pokefuta.com</text>
+</svg>

--- a/docs/ogp_template/no_photo.svg
+++ b/docs/ogp_template/no_photo.svg
@@ -1,0 +1,95 @@
+<svg width="1200" height="630" viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="paper" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#FBF6EA"/>
+      <stop offset="1" stop-color="#F4ECDA"/>
+    </linearGradient>
+    <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#DCEFF7"/>
+      <stop offset="1" stop-color="#EAF6FB"/>
+    </linearGradient>
+    <linearGradient id="brand" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#6F55A3"/>
+      <stop offset="1" stop-color="#5B4A8F"/>
+    </linearGradient>
+    <filter id="soft" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="8" flood-color="#3A2C1F" flood-opacity="0.16"/>
+    </filter>
+    <style>
+      .ttl{font-family:'Noto Sans CJK JP','Hiragino Sans',sans-serif;font-weight:700}
+      .reg{font-family:'Noto Sans CJK JP','Hiragino Sans',sans-serif;font-weight:400}
+    </style>
+  </defs>
+
+  <!-- Paper base -->
+  <rect width="1200" height="630" fill="url(#paper)"/>
+
+  <!-- Right travel scene panel -->
+  <g>
+    <rect x="690" y="92" width="470" height="446" rx="28" fill="url(#sky)"/>
+    <path d="M770 470 q40 -70 120 -60 q70 6 120 -40 q60 -54 130 -22 q40 18 50 70 q12 70 -60 96 q-120 40 -260 24 q-130 -16 -150 -22 q-12 -30 -50 -46 z" fill="#C7E6C3" opacity="0.7"/>
+    <path d="M860 250 q60 -36 130 -14 q70 22 130 -6 q-6 70 -74 96 q-90 32 -176 6 q-58 -20 -10 -82 z" fill="#BFE0CF" opacity="0.55"/>
+    <g stroke="#9DBFD0" stroke-width="1" opacity="0.25">
+      <line x1="690" y1="190" x2="1160" y2="190"/><line x1="690" y1="300" x2="1160" y2="300"/>
+      <line x1="690" y1="410" x2="1160" y2="410"/><line x1="820" y1="92" x2="820" y2="538"/>
+      <line x1="950" y1="92" x2="950" y2="538"/><line x1="1080" y1="92" x2="1080" y2="538"/>
+    </g>
+    <g>
+      <g transform="translate(742,150)"><polygon points="0,-30 16,8 -16,8" fill="#7FB892"/><polygon points="0,-14 20,28 -20,28" fill="#6FAE85"/><rect x="-4" y="28" width="8" height="12" fill="#9A7B53"/></g>
+      <g transform="translate(1118,180)"><polygon points="0,-26 14,8 -14,8" fill="#7FB892"/><polygon points="0,-12 18,26 -18,26" fill="#6FAE85"/><rect x="-4" y="26" width="8" height="10" fill="#9A7B53"/></g>
+      <g transform="translate(1110,470)"><polygon points="0,-24 13,7 -13,7" fill="#7FB892"/><polygon points="0,-10 17,24 -17,24" fill="#6FAE85"/><rect x="-3" y="24" width="6" height="10" fill="#9A7B53"/></g>
+    </g>
+    <g>
+      <g transform="translate(760,300)"><path d="M0 0 C-16 -22 -16 -40 0 -40 C16 -40 16 -22 0 0 Z" fill="#6F55A3"/><circle cx="0" cy="-26" r="7" fill="#FFF9ED"/></g>
+      <g transform="translate(1108,330)"><path d="M0 0 C-13 -18 -13 -33 0 -33 C13 -33 13 -18 0 0 Z" fill="#E8954B"/><circle cx="0" cy="-21" r="6" fill="#FFF9ED"/></g>
+      <g transform="translate(800,500)"><path d="M0 0 C-11 -16 -11 -28 0 -28 C11 -28 11 -16 0 0 Z" fill="#5FA4C9"/><circle cx="0" cy="-18" r="5" fill="#FFF9ED"/></g>
+    </g>
+    <g stroke="#A9D4E6" stroke-width="4" fill="none" opacity="0.6" stroke-linecap="round">
+      <path d="M712 512 q20 -14 40 0 q20 14 40 0 q20 -14 40 0"/>
+      <path d="M1010 506 q20 -14 40 0 q20 14 40 0 q20 -14 40 0"/>
+    </g>
+    <!-- Camera icon (large placeholder) -->
+    <circle cx="925" cy="295" r="105" fill="#9A7A3F" opacity="0.12"/>
+    <!-- Camera body -->
+    <rect x="865" y="256" width="120" height="86" rx="14" fill="#9A7A3F" opacity="0.35"/>
+    <rect x="896" y="242" width="38" height="18" rx="6" fill="#9A7A3F" opacity="0.35"/>
+    <circle cx="925" cy="299" r="26" fill="none" stroke="#9A7A3F" stroke-width="5" opacity="0.5"/>
+    <circle cx="925" cy="299" r="14" fill="#9A7A3F" opacity="0.3"/>
+    <text x="925" y="404" class="reg" font-size="16" fill="#9A7A3F" text-anchor="middle">写真を投稿しよう</text>
+  </g>
+
+  <!-- Header band -->
+  <g>
+    <rect x="40" y="26" width="600" height="50" rx="16" fill="#FFFFFF" filter="url(#soft)"/>
+    <path d="M58 40 l5 11 11 1 -8 8 2 12 -10 -6 -10 6 2 -12 -8 -8 11 -1 z" fill="#6F55A3" opacity="0.8"/>
+    <text x="86" y="58" class="ttl" font-size="24" fill="#5B4A8F">全国のポケふた・ポケモンマンホール</text>
+  </g>
+
+  <!-- Tag -->
+  <rect x="40" y="96" width="155" height="30" rx="15" fill="#E8954B" opacity="0.20"/>
+  <text x="117" y="116" class="reg" font-size="14" fill="#B87020" text-anchor="middle">写真募集中</text>
+
+  <!-- Prefecture name (large) -->
+  <text x="44" y="224" class="ttl" font-size="82" fill="#3C342C">{{PREF}}</text>
+
+  <!-- Stats -->
+  <text x="44" y="295" class="reg" font-size="22" fill="#9A7A3F">のポケふた</text>
+  <text x="44" y="385" class="ttl" font-size="72" fill="#6F55A3">{{NO_PHOTO_COUNT}}<tspan class="reg" font-size="30">枚</tspan></text>
+  <text x="44" y="432" class="reg" font-size="22" fill="#9A7A3F">に写真がまだありません</text>
+
+  <!-- Detail -->
+  <text x="44" y="480" class="reg" font-size="16" fill="#9A7A3F">（全{{TOTAL_COUNT}}枚 / 写真ゼロ）</text>
+
+  <!-- CTA button -->
+  <rect x="44" y="502" width="300" height="38" rx="19" fill="#6F55A3" opacity="0.9"/>
+  <text x="194" y="526" class="ttl" font-size="16" fill="#FFFFFF" text-anchor="middle">あなたの写真を投稿しませんか？</text>
+
+  <!-- Bottom brand band -->
+  <rect x="0" y="556" width="1200" height="74" fill="url(#brand)"/>
+  <circle cx="49" cy="587" r="9" fill="#FFFFFF" opacity="0.9"/>
+  <circle cx="49" cy="587" r="5" fill="#6F55A3"/>
+  <text x="66" y="587" class="ttl" font-size="22" fill="#FFFFFF">ポケふたマップ</text>
+  <text x="66" y="610" class="reg" font-size="14" fill="#E8DEF5">旅の思い出に、ポケふた探しの冒険を！</text>
+  <text x="600" y="600" class="ttl" font-size="18" fill="#FFFFFF" text-anchor="middle">全国470箇所以上掲載！</text>
+  <text x="1160" y="600" class="ttl" font-size="20" fill="#FFFFFF" text-anchor="end">data.pokefuta.com</text>
+</svg>

--- a/docs/ogp_template/pokemon_rank.svg
+++ b/docs/ogp_template/pokemon_rank.svg
@@ -1,0 +1,91 @@
+<svg width="1200" height="630" viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="paper" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#FBF6EA"/>
+      <stop offset="1" stop-color="#F4ECDA"/>
+    </linearGradient>
+    <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#DCEFF7"/>
+      <stop offset="1" stop-color="#EAF6FB"/>
+    </linearGradient>
+    <linearGradient id="brand" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#6F55A3"/>
+      <stop offset="1" stop-color="#5B4A8F"/>
+    </linearGradient>
+    <filter id="soft" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="8" flood-color="#3A2C1F" flood-opacity="0.16"/>
+    </filter>
+    <style>
+      .ttl{font-family:'Noto Sans CJK JP','Hiragino Sans',sans-serif;font-weight:700}
+      .reg{font-family:'Noto Sans CJK JP','Hiragino Sans',sans-serif;font-weight:400}
+    </style>
+  </defs>
+
+  <!-- Paper base -->
+  <rect width="1200" height="630" fill="url(#paper)"/>
+
+  <!-- Right travel scene panel -->
+  <g>
+    <rect x="690" y="92" width="470" height="446" rx="28" fill="url(#sky)"/>
+    <path d="M770 470 q40 -70 120 -60 q70 6 120 -40 q60 -54 130 -22 q40 18 50 70 q12 70 -60 96 q-120 40 -260 24 q-130 -16 -150 -22 q-12 -30 -50 -46 z" fill="#C7E6C3" opacity="0.7"/>
+    <path d="M860 250 q60 -36 130 -14 q70 22 130 -6 q-6 70 -74 96 q-90 32 -176 6 q-58 -20 -10 -82 z" fill="#BFE0CF" opacity="0.55"/>
+    <g stroke="#9DBFD0" stroke-width="1" opacity="0.25">
+      <line x1="690" y1="190" x2="1160" y2="190"/><line x1="690" y1="300" x2="1160" y2="300"/>
+      <line x1="690" y1="410" x2="1160" y2="410"/><line x1="820" y1="92" x2="820" y2="538"/>
+      <line x1="950" y1="92" x2="950" y2="538"/><line x1="1080" y1="92" x2="1080" y2="538"/>
+    </g>
+    <g>
+      <g transform="translate(742,150)"><polygon points="0,-30 16,8 -16,8" fill="#7FB892"/><polygon points="0,-14 20,28 -20,28" fill="#6FAE85"/><rect x="-4" y="28" width="8" height="12" fill="#9A7B53"/></g>
+      <g transform="translate(1118,180)"><polygon points="0,-26 14,8 -14,8" fill="#7FB892"/><polygon points="0,-12 18,26 -18,26" fill="#6FAE85"/><rect x="-4" y="26" width="8" height="10" fill="#9A7B53"/></g>
+      <g transform="translate(1110,470)"><polygon points="0,-24 13,7 -13,7" fill="#7FB892"/><polygon points="0,-10 17,24 -17,24" fill="#6FAE85"/><rect x="-3" y="24" width="6" height="10" fill="#9A7B53"/></g>
+    </g>
+    <g>
+      <g transform="translate(760,300)"><path d="M0 0 C-16 -22 -16 -40 0 -40 C16 -40 16 -22 0 0 Z" fill="#6F55A3"/><circle cx="0" cy="-26" r="7" fill="#FFF9ED"/></g>
+      <g transform="translate(1108,330)"><path d="M0 0 C-13 -18 -13 -33 0 -33 C13 -33 13 -18 0 0 Z" fill="#E8954B"/><circle cx="0" cy="-21" r="6" fill="#FFF9ED"/></g>
+      <g transform="translate(800,500)"><path d="M0 0 C-11 -16 -11 -28 0 -28 C11 -28 11 -16 0 0 Z" fill="#5FA4C9"/><circle cx="0" cy="-18" r="5" fill="#FFF9ED"/></g>
+    </g>
+    <g stroke="#A9D4E6" stroke-width="4" fill="none" opacity="0.6" stroke-linecap="round">
+      <path d="M712 512 q20 -14 40 0 q20 14 40 0 q20 -14 40 0"/>
+      <path d="M1010 506 q20 -14 40 0 q20 14 40 0 q20 -14 40 0"/>
+    </g>
+    <!-- Rank badge -->
+    <circle cx="925" cy="300" r="100" fill="#6F55A3" filter="url(#soft)"/>
+    <text x="925" y="273" class="reg" font-size="18" fill="#FFFFFF" text-anchor="middle">登場数</text>
+    <text x="925" y="315" class="ttl" font-size="48" fill="#FFFFFF" text-anchor="middle">{{RANK}}</text>
+    <text x="925" y="348" class="reg" font-size="22" fill="#FFFFFF" text-anchor="middle">位</text>
+  </g>
+
+  <!-- Header band -->
+  <g>
+    <rect x="40" y="26" width="600" height="50" rx="16" fill="#FFFFFF" filter="url(#soft)"/>
+    <path d="M58 40 l5 11 11 1 -8 8 2 12 -10 -6 -10 6 2 -12 -8 -8 11 -1 z" fill="#6F55A3" opacity="0.8"/>
+    <text x="86" y="58" class="ttl" font-size="24" fill="#5B4A8F">全国のポケふた・ポケモンマンホール</text>
+  </g>
+
+  <!-- Tag -->
+  <rect x="40" y="96" width="205" height="30" rx="15" fill="#6F55A3" opacity="0.12"/>
+  <text x="142" y="116" class="reg" font-size="14" fill="#5B4A8F" text-anchor="middle">ポケモン登場数ランキング</text>
+
+  <!-- Pokemon name (large) -->
+  <text x="44" y="240" class="ttl" font-size="84" fill="#3C342C">{{POKEMON}}</text>
+
+  <!-- Divider -->
+  <line x1="44" y1="268" x2="630" y2="268" stroke="#E8D6B8" stroke-width="1.5"/>
+
+  <!-- Count stat -->
+  <text x="44" y="350" class="reg" font-size="18" fill="#9A7A3F">登場するポケふた</text>
+  <text x="44" y="400" class="ttl" font-size="52" fill="#6F55A3">{{COUNT}}<tspan class="reg" font-size="26">枚</tspan></text>
+
+  <!-- City count stat -->
+  <text x="44" y="450" class="reg" font-size="18" fill="#9A7A3F">設置市区町村</text>
+  <text x="44" y="498" class="ttl" font-size="36" fill="#5B4A8F">{{CITY_COUNT}}<tspan class="reg" font-size="20">市区町村</tspan></text>
+
+  <!-- Bottom brand band -->
+  <rect x="0" y="556" width="1200" height="74" fill="url(#brand)"/>
+  <circle cx="49" cy="587" r="9" fill="#FFFFFF" opacity="0.9"/>
+  <circle cx="49" cy="587" r="5" fill="#6F55A3"/>
+  <text x="66" y="587" class="ttl" font-size="22" fill="#FFFFFF">ポケふたマップ</text>
+  <text x="66" y="610" class="reg" font-size="14" fill="#E8DEF5">旅の思い出に、ポケふた探しの冒険を！</text>
+  <text x="600" y="600" class="ttl" font-size="18" fill="#FFFFFF" text-anchor="middle">全国470箇所以上掲載！</text>
+  <text x="1160" y="600" class="ttl" font-size="20" fill="#FFFFFF" text-anchor="end">data.pokefuta.com</text>
+</svg>

--- a/docs/ogp_template/prefecture_rank.svg
+++ b/docs/ogp_template/prefecture_rank.svg
@@ -1,0 +1,90 @@
+<svg width="1200" height="630" viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="paper" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#FBF6EA"/>
+      <stop offset="1" stop-color="#F4ECDA"/>
+    </linearGradient>
+    <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#DCEFF7"/>
+      <stop offset="1" stop-color="#EAF6FB"/>
+    </linearGradient>
+    <linearGradient id="brand" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#6F55A3"/>
+      <stop offset="1" stop-color="#5B4A8F"/>
+    </linearGradient>
+    <filter id="soft" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="8" flood-color="#3A2C1F" flood-opacity="0.16"/>
+    </filter>
+    <style>
+      .ttl{font-family:'Noto Sans CJK JP','Hiragino Sans',sans-serif;font-weight:700}
+      .reg{font-family:'Noto Sans CJK JP','Hiragino Sans',sans-serif;font-weight:400}
+    </style>
+  </defs>
+
+  <!-- Paper base -->
+  <rect width="1200" height="630" fill="url(#paper)"/>
+
+  <!-- Right travel scene panel -->
+  <g>
+    <rect x="690" y="92" width="470" height="446" rx="28" fill="url(#sky)"/>
+    <path d="M770 470 q40 -70 120 -60 q70 6 120 -40 q60 -54 130 -22 q40 18 50 70 q12 70 -60 96 q-120 40 -260 24 q-130 -16 -150 -22 q-12 -30 -50 -46 z" fill="#C7E6C3" opacity="0.7"/>
+    <path d="M860 250 q60 -36 130 -14 q70 22 130 -6 q-6 70 -74 96 q-90 32 -176 6 q-58 -20 -10 -82 z" fill="#BFE0CF" opacity="0.55"/>
+    <g stroke="#9DBFD0" stroke-width="1" opacity="0.25">
+      <line x1="690" y1="190" x2="1160" y2="190"/><line x1="690" y1="300" x2="1160" y2="300"/>
+      <line x1="690" y1="410" x2="1160" y2="410"/><line x1="820" y1="92" x2="820" y2="538"/>
+      <line x1="950" y1="92" x2="950" y2="538"/><line x1="1080" y1="92" x2="1080" y2="538"/>
+    </g>
+    <g>
+      <g transform="translate(742,150)"><polygon points="0,-30 16,8 -16,8" fill="#7FB892"/><polygon points="0,-14 20,28 -20,28" fill="#6FAE85"/><rect x="-4" y="28" width="8" height="12" fill="#9A7B53"/></g>
+      <g transform="translate(1118,180)"><polygon points="0,-26 14,8 -14,8" fill="#7FB892"/><polygon points="0,-12 18,26 -18,26" fill="#6FAE85"/><rect x="-4" y="26" width="8" height="10" fill="#9A7B53"/></g>
+      <g transform="translate(1110,470)"><polygon points="0,-24 13,7 -13,7" fill="#7FB892"/><polygon points="0,-10 17,24 -17,24" fill="#6FAE85"/><rect x="-3" y="24" width="6" height="10" fill="#9A7B53"/></g>
+    </g>
+    <g>
+      <g transform="translate(760,300)"><path d="M0 0 C-16 -22 -16 -40 0 -40 C16 -40 16 -22 0 0 Z" fill="#6F55A3"/><circle cx="0" cy="-26" r="7" fill="#FFF9ED"/></g>
+      <g transform="translate(1108,330)"><path d="M0 0 C-13 -18 -13 -33 0 -33 C13 -33 13 -18 0 0 Z" fill="#E8954B"/><circle cx="0" cy="-21" r="6" fill="#FFF9ED"/></g>
+      <g transform="translate(800,500)"><path d="M0 0 C-11 -16 -11 -28 0 -28 C11 -28 11 -16 0 0 Z" fill="#5FA4C9"/><circle cx="0" cy="-18" r="5" fill="#FFF9ED"/></g>
+    </g>
+    <g stroke="#A9D4E6" stroke-width="4" fill="none" opacity="0.6" stroke-linecap="round">
+      <path d="M712 512 q20 -14 40 0 q20 14 40 0 q20 -14 40 0"/>
+      <path d="M1010 506 q20 -14 40 0 q20 14 40 0 q20 -14 40 0"/>
+    </g>
+    <!-- Rank badge -->
+    <circle cx="925" cy="300" r="100" fill="#6F55A3" filter="url(#soft)"/>
+    <text x="925" y="273" class="reg" font-size="18" fill="#FFFFFF" text-anchor="middle">全国</text>
+    <text x="925" y="315" class="ttl" font-size="48" fill="#FFFFFF" text-anchor="middle">{{RANK}}</text>
+    <text x="925" y="348" class="reg" font-size="22" fill="#FFFFFF" text-anchor="middle">位</text>
+  </g>
+
+  <!-- Header band -->
+  <g>
+    <rect x="40" y="26" width="600" height="50" rx="16" fill="#FFFFFF" filter="url(#soft)"/>
+    <path d="M58 40 l5 11 11 1 -8 8 2 12 -10 -6 -10 6 2 -12 -8 -8 11 -1 z" fill="#6F55A3" opacity="0.8"/>
+    <text x="86" y="58" class="ttl" font-size="24" fill="#5B4A8F">全国のポケふた・ポケモンマンホール</text>
+  </g>
+
+  <!-- Tag -->
+  <rect x="40" y="96" width="200" height="30" rx="15" fill="#6F55A3" opacity="0.12"/>
+  <text x="140" y="116" class="reg" font-size="14" fill="#5B4A8F" text-anchor="middle">都道府県別ランキング</text>
+
+  <!-- Prefecture name (large) -->
+  <text x="44" y="240" class="ttl" font-size="92" fill="#3C342C">{{PREF}}</text>
+
+  <!-- Count display -->
+  <text x="44" y="348" class="ttl" font-size="66" fill="#6F55A3">{{COUNT}}<tspan class="reg" font-size="32">枚</tspan></text>
+
+  <!-- Progress bar -->
+  <rect x="44" y="376" width="540" height="14" rx="7" fill="#E8D6B8"/>
+  <rect x="44" y="376" width="{{BAR_WIDTH}}" height="14" rx="7" fill="#6F55A3"/>
+
+  <!-- Detail stats -->
+  <text x="44" y="414" class="reg" font-size="18" fill="#9A7A3F">全国{{TOTAL}}枚中　{{PERCENT}}%</text>
+
+  <!-- Bottom brand band -->
+  <rect x="0" y="556" width="1200" height="74" fill="url(#brand)"/>
+  <circle cx="49" cy="587" r="9" fill="#FFFFFF" opacity="0.9"/>
+  <circle cx="49" cy="587" r="5" fill="#6F55A3"/>
+  <text x="66" y="587" class="ttl" font-size="22" fill="#FFFFFF">ポケふたマップ</text>
+  <text x="66" y="610" class="reg" font-size="14" fill="#E8DEF5">旅の思い出に、ポケふた探しの冒険を！</text>
+  <text x="600" y="600" class="ttl" font-size="18" fill="#FFFFFF" text-anchor="middle">全国470箇所以上掲載！</text>
+  <text x="1160" y="600" class="ttl" font-size="20" fill="#FFFFFF" text-anchor="end">data.pokefuta.com</text>
+</svg>

--- a/docs/ogp_template/rare_area.svg
+++ b/docs/ogp_template/rare_area.svg
@@ -1,0 +1,88 @@
+<svg width="1200" height="630" viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="paper" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#FBF6EA"/>
+      <stop offset="1" stop-color="#F4ECDA"/>
+    </linearGradient>
+    <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#DCEFF7"/>
+      <stop offset="1" stop-color="#EAF6FB"/>
+    </linearGradient>
+    <linearGradient id="brand" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#6F55A3"/>
+      <stop offset="1" stop-color="#5B4A8F"/>
+    </linearGradient>
+    <filter id="soft" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="8" flood-color="#3A2C1F" flood-opacity="0.16"/>
+    </filter>
+    <style>
+      .ttl{font-family:'Noto Sans CJK JP','Hiragino Sans',sans-serif;font-weight:700}
+      .reg{font-family:'Noto Sans CJK JP','Hiragino Sans',sans-serif;font-weight:400}
+    </style>
+  </defs>
+
+  <!-- Paper base -->
+  <rect width="1200" height="630" fill="url(#paper)"/>
+
+  <!-- Right travel scene panel -->
+  <g>
+    <rect x="690" y="92" width="470" height="446" rx="28" fill="url(#sky)"/>
+    <path d="M770 470 q40 -70 120 -60 q70 6 120 -40 q60 -54 130 -22 q40 18 50 70 q12 70 -60 96 q-120 40 -260 24 q-130 -16 -150 -22 q-12 -30 -50 -46 z" fill="#C7E6C3" opacity="0.7"/>
+    <path d="M860 250 q60 -36 130 -14 q70 22 130 -6 q-6 70 -74 96 q-90 32 -176 6 q-58 -20 -10 -82 z" fill="#BFE0CF" opacity="0.55"/>
+    <g stroke="#9DBFD0" stroke-width="1" opacity="0.25">
+      <line x1="690" y1="190" x2="1160" y2="190"/><line x1="690" y1="300" x2="1160" y2="300"/>
+      <line x1="690" y1="410" x2="1160" y2="410"/><line x1="820" y1="92" x2="820" y2="538"/>
+      <line x1="950" y1="92" x2="950" y2="538"/><line x1="1080" y1="92" x2="1080" y2="538"/>
+    </g>
+    <g>
+      <g transform="translate(742,150)"><polygon points="0,-30 16,8 -16,8" fill="#7FB892"/><polygon points="0,-14 20,28 -20,28" fill="#6FAE85"/><rect x="-4" y="28" width="8" height="12" fill="#9A7B53"/></g>
+      <g transform="translate(1118,180)"><polygon points="0,-26 14,8 -14,8" fill="#7FB892"/><polygon points="0,-12 18,26 -18,26" fill="#6FAE85"/><rect x="-4" y="26" width="8" height="10" fill="#9A7B53"/></g>
+      <g transform="translate(1110,470)"><polygon points="0,-24 13,7 -13,7" fill="#7FB892"/><polygon points="0,-10 17,24 -17,24" fill="#6FAE85"/><rect x="-3" y="24" width="6" height="10" fill="#9A7B53"/></g>
+    </g>
+    <g>
+      <g transform="translate(760,300)"><path d="M0 0 C-16 -22 -16 -40 0 -40 C16 -40 16 -22 0 0 Z" fill="#6F55A3"/><circle cx="0" cy="-26" r="7" fill="#FFF9ED"/></g>
+      <g transform="translate(1108,330)"><path d="M0 0 C-13 -18 -13 -33 0 -33 C13 -33 13 -18 0 0 Z" fill="#E8954B"/><circle cx="0" cy="-21" r="6" fill="#FFF9ED"/></g>
+      <g transform="translate(800,500)"><path d="M0 0 C-11 -16 -11 -28 0 -28 C11 -28 11 -16 0 0 Z" fill="#5FA4C9"/><circle cx="0" cy="-18" r="5" fill="#FFF9ED"/></g>
+    </g>
+    <g stroke="#A9D4E6" stroke-width="4" fill="none" opacity="0.6" stroke-linecap="round">
+      <path d="M712 512 q20 -14 40 0 q20 14 40 0 q20 -14 40 0"/>
+      <path d="M1010 506 q20 -14 40 0 q20 14 40 0 q20 -14 40 0"/>
+    </g>
+    <!-- Exclamation badge -->
+    <circle cx="925" cy="300" r="90" fill="#D4542A" filter="url(#soft)"/>
+    <text x="925" y="270" class="ttl" font-size="64" fill="#FFFFFF" text-anchor="middle">!</text>
+    <text x="925" y="336" class="reg" font-size="15" fill="#FFFFFF" text-anchor="middle">レアエリア</text>
+  </g>
+
+  <!-- Header band -->
+  <g>
+    <rect x="40" y="26" width="600" height="50" rx="16" fill="#FFFFFF" filter="url(#soft)"/>
+    <path d="M58 40 l5 11 11 1 -8 8 2 12 -10 -6 -10 6 2 -12 -8 -8 11 -1 z" fill="#6F55A3" opacity="0.8"/>
+    <text x="86" y="58" class="ttl" font-size="24" fill="#5B4A8F">全国のポケふた・ポケモンマンホール</text>
+  </g>
+
+  <!-- Tag -->
+  <rect x="40" y="96" width="168" height="30" rx="15" fill="#D4542A" opacity="0.15"/>
+  <text x="124" y="116" class="reg" font-size="14" fill="#B03A1A" text-anchor="middle">レアエリア情報</text>
+
+  <!-- Prefecture name (large) -->
+  <text x="44" y="230" class="ttl" font-size="82" fill="#3C342C">{{PREF}}</text>
+
+  <!-- "わずか" accent -->
+  <text x="44" y="302" class="reg" font-size="30" fill="#9A7A3F">に、ポケふたは</text>
+
+  <!-- Count (very large, accent) -->
+  <text x="44" y="410" class="ttl" font-size="100" fill="#D4542A">{{COUNT}}<tspan class="reg" font-size="42" fill="#D4542A">枚</tspan></text>
+
+  <!-- Detail -->
+  <text x="44" y="460" class="reg" font-size="18" fill="#9A7A3F">全国{{TOTAL}}枚中　とても少ない設置数</text>
+
+  <!-- Bottom brand band -->
+  <rect x="0" y="556" width="1200" height="74" fill="url(#brand)"/>
+  <circle cx="49" cy="587" r="9" fill="#FFFFFF" opacity="0.9"/>
+  <circle cx="49" cy="587" r="5" fill="#6F55A3"/>
+  <text x="66" y="587" class="ttl" font-size="22" fill="#FFFFFF">ポケふたマップ</text>
+  <text x="66" y="610" class="reg" font-size="14" fill="#E8DEF5">旅の思い出に、ポケふた探しの冒険を！</text>
+  <text x="600" y="600" class="ttl" font-size="18" fill="#FFFFFF" text-anchor="middle">全国470箇所以上掲載！</text>
+  <text x="1160" y="600" class="ttl" font-size="20" fill="#FFFFFF" text-anchor="end">data.pokefuta.com</text>
+</svg>

--- a/docs/ogp_template/travel_trivia.svg
+++ b/docs/ogp_template/travel_trivia.svg
@@ -1,0 +1,90 @@
+<svg width="1200" height="630" viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="paper" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#FBF6EA"/>
+      <stop offset="1" stop-color="#F4ECDA"/>
+    </linearGradient>
+    <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#DCEFF7"/>
+      <stop offset="1" stop-color="#EAF6FB"/>
+    </linearGradient>
+    <linearGradient id="brand" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#6F55A3"/>
+      <stop offset="1" stop-color="#5B4A8F"/>
+    </linearGradient>
+    <filter id="soft" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="6" stdDeviation="8" flood-color="#3A2C1F" flood-opacity="0.16"/>
+    </filter>
+    <style>
+      .ttl{font-family:'Noto Sans CJK JP','Hiragino Sans',sans-serif;font-weight:700}
+      .reg{font-family:'Noto Sans CJK JP','Hiragino Sans',sans-serif;font-weight:400}
+    </style>
+  </defs>
+
+  <!-- Paper base -->
+  <rect width="1200" height="630" fill="url(#paper)"/>
+
+  <!-- Right travel scene panel -->
+  <g>
+    <rect x="690" y="92" width="470" height="446" rx="28" fill="url(#sky)"/>
+    <path d="M770 470 q40 -70 120 -60 q70 6 120 -40 q60 -54 130 -22 q40 18 50 70 q12 70 -60 96 q-120 40 -260 24 q-130 -16 -150 -22 q-12 -30 -50 -46 z" fill="#C7E6C3" opacity="0.7"/>
+    <path d="M860 250 q60 -36 130 -14 q70 22 130 -6 q-6 70 -74 96 q-90 32 -176 6 q-58 -20 -10 -82 z" fill="#BFE0CF" opacity="0.55"/>
+    <g stroke="#9DBFD0" stroke-width="1" opacity="0.25">
+      <line x1="690" y1="190" x2="1160" y2="190"/><line x1="690" y1="300" x2="1160" y2="300"/>
+      <line x1="690" y1="410" x2="1160" y2="410"/><line x1="820" y1="92" x2="820" y2="538"/>
+      <line x1="950" y1="92" x2="950" y2="538"/><line x1="1080" y1="92" x2="1080" y2="538"/>
+    </g>
+    <g>
+      <g transform="translate(742,150)"><polygon points="0,-30 16,8 -16,8" fill="#7FB892"/><polygon points="0,-14 20,28 -20,28" fill="#6FAE85"/><rect x="-4" y="28" width="8" height="12" fill="#9A7B53"/></g>
+      <g transform="translate(1118,180)"><polygon points="0,-26 14,8 -14,8" fill="#7FB892"/><polygon points="0,-12 18,26 -18,26" fill="#6FAE85"/><rect x="-4" y="26" width="8" height="10" fill="#9A7B53"/></g>
+      <g transform="translate(1110,470)"><polygon points="0,-24 13,7 -13,7" fill="#7FB892"/><polygon points="0,-10 17,24 -17,24" fill="#6FAE85"/><rect x="-3" y="24" width="6" height="10" fill="#9A7B53"/></g>
+    </g>
+    <g>
+      <g transform="translate(760,300)"><path d="M0 0 C-16 -22 -16 -40 0 -40 C16 -40 16 -22 0 0 Z" fill="#6F55A3"/><circle cx="0" cy="-26" r="7" fill="#FFF9ED"/></g>
+      <g transform="translate(1108,330)"><path d="M0 0 C-13 -18 -13 -33 0 -33 C13 -33 13 -18 0 0 Z" fill="#E8954B"/><circle cx="0" cy="-21" r="6" fill="#FFF9ED"/></g>
+      <g transform="translate(800,500)"><path d="M0 0 C-11 -16 -11 -28 0 -28 C11 -28 11 -16 0 0 Z" fill="#5FA4C9"/><circle cx="0" cy="-18" r="5" fill="#FFF9ED"/></g>
+    </g>
+    <g stroke="#A9D4E6" stroke-width="4" fill="none" opacity="0.6" stroke-linecap="round">
+      <path d="M712 512 q20 -14 40 0 q20 14 40 0 q20 -14 40 0"/>
+      <path d="M1010 506 q20 -14 40 0 q20 14 40 0 q20 -14 40 0"/>
+    </g>
+    <!-- Question mark decoration -->
+    <text x="925" y="340" class="ttl" font-size="160" fill="#6F55A3" opacity="0.12" text-anchor="middle">?</text>
+    <text x="925" y="340" class="ttl" font-size="160" fill="#6F55A3" opacity="0.08" text-anchor="middle">!</text>
+  </g>
+
+  <!-- Header band -->
+  <g>
+    <rect x="40" y="26" width="600" height="50" rx="16" fill="#FFFFFF" filter="url(#soft)"/>
+    <path d="M58 40 l5 11 11 1 -8 8 2 12 -10 -6 -10 6 2 -12 -8 -8 11 -1 z" fill="#6F55A3" opacity="0.8"/>
+    <text x="86" y="58" class="ttl" font-size="24" fill="#5B4A8F">全国のポケふた・ポケモンマンホール</text>
+  </g>
+
+  <!-- Tag -->
+  <rect x="40" y="96" width="170" height="30" rx="15" fill="#6F55A3" opacity="0.12"/>
+  <text x="125" y="116" class="reg" font-size="14" fill="#5B4A8F" text-anchor="middle">ポケふた豆知識</text>
+
+  <!-- Divider -->
+  <line x1="40" y1="140" x2="640" y2="140" stroke="#E8D6B8" stroke-width="1.5"/>
+
+  <!-- LINE1: large central number/keyword -->
+  <text x="330" y="270" class="ttl" font-size="110" fill="#6F55A3" text-anchor="middle">{{LINE1}}</text>
+
+  <!-- LINE2: label -->
+  <text x="330" y="330" class="ttl" font-size="28" fill="#3C342C" text-anchor="middle">{{LINE2}}</text>
+
+  <!-- LINE3: detail -->
+  <text x="330" y="378" class="reg" font-size="20" fill="#9A7A3F" text-anchor="middle">{{LINE3}}</text>
+
+  <!-- LINE4: further detail -->
+  <text x="330" y="418" class="reg" font-size="18" fill="#9A7A3F" text-anchor="middle">{{LINE4}}</text>
+
+  <!-- Bottom brand band -->
+  <rect x="0" y="556" width="1200" height="74" fill="url(#brand)"/>
+  <circle cx="49" cy="587" r="9" fill="#FFFFFF" opacity="0.9"/>
+  <circle cx="49" cy="587" r="5" fill="#6F55A3"/>
+  <text x="66" y="587" class="ttl" font-size="22" fill="#FFFFFF">ポケふたマップ</text>
+  <text x="66" y="610" class="reg" font-size="14" fill="#E8DEF5">旅の思い出に、ポケふた探しの冒険を！</text>
+  <text x="600" y="600" class="ttl" font-size="18" fill="#FFFFFF" text-anchor="middle">全国470箇所以上掲載！</text>
+  <text x="1160" y="600" class="ttl" font-size="20" fill="#FFFFFF" text-anchor="end">data.pokefuta.com</text>
+</svg>


### PR DESCRIPTION
## Summary

- 曜日スケジュール制の導入：月日→`prefecture_rank` / 火→`travel_trivia` / 水→`latest_photo` / 木→`pokemon_rank` / 金→`rare_area` / 土→`no_photo`
- `docs/ogp_template/` に6種の SVG テンプレートを新規追加（1200×630、既存ブランドカラー統一）
- `apps/scraper/generate_social_ogp.py` を新規追加：daily.json の候補に応じて SVG プレースホルダーを置換 → `rsvg-convert` で `docs/social-post-ogp.png` を生成
- `latest_photo` タイプは `dataset/manhole/image/{id}_latest.jpeg` を base64 埋め込みして写真付き画像を生成
- `.gitignore` に `docs/social-post-ogp.png` を追加（ローカル管理、コミット不要）
- `.claude/commands/social-post.md` にステップ 8-9（画像生成・パス表示）を追加

## Test plan

- [ ] `python3 apps/scraper/generate_social_ogp.py` が各タイプで 1200×630 PNG を生成すること
- [ ] `open docs/social-post-ogp.png` で各テンプレートのレイアウトを目視確認
- [ ] `/social-post` スキル実行後に投稿文＋`画像: docs/social-post-ogp.png` が表示されること
- [ ] `latest_photo` タイプで写真埋め込みが機能すること（`dataset/manhole/image/` に画像がある場合）
- [ ] `docs/social-post-ogp.png` が `git status` で追跡されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)