### PR TITLE
feat: add robots.txt to exclude data files from crawlers

### DIFF
--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Disallow: /*.ndjson$
+Disallow: /pokemon_metadata.json
+Disallow: /latest-manhole-photos.json


### PR DESCRIPTION
## Summary

- `docs/robots.txt` を新規追加
- SEO的に不要なデータファイルをクローラーから除外
  - `*.ndjson` (pokefuta.ndjson / gmanhole.ndjson)
  - `pokemon_metadata.json`
  - `latest-manhole-photos.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)