### PR TITLE
Improve summary social fact cards

### DIFF
--- a/apps/scraper/generate_summary_pages.py
+++ b/apps/scraper/generate_summary_pages.py
@@ -27,7 +27,6 @@ IMAGE_DIR = ROOT / "dataset" / "manhole" / "image"
 
 BASE_URL = "https://data.pokefuta.com"
 OGP_IMAGE = f"{BASE_URL}/assets/ogp/pokefuta_summary_ogp.png"
-SUMMARY_SHARE_URL = f"{BASE_URL}/summary"
 
 PREFECTURE_ORDER: list[str] = [
     "北海道", "青森県", "岩手県", "宮城県", "秋田県",
@@ -587,11 +586,16 @@ _CSS = """\
       list-style: none;
     }
 
+    .fact-card-grid > li {
+      display: flex;
+      min-width: 0;
+    }
+
     .summary-fact-card {
       display: flex;
       flex-direction: column;
       gap: 10px;
-      min-height: 100%;
+      width: 100%;
       padding: 15px;
       border: 1px solid rgba(93, 67, 35, .14);
       border-radius: 8px;
@@ -1052,16 +1056,16 @@ def _build_discovery_section(s: dict, stats: dict, tr) -> str:
     )
 
 
-def _twitter_intent_url(text: str) -> str:
+def _twitter_intent_url(text: str, url: str) -> str:
     return (
         "https://twitter.com/intent/tweet"
         f"?text={quote(text, safe='')}"
-        f"&url={quote(SUMMARY_SHARE_URL, safe='')}"
+        f"&url={quote(url, safe='')}"
     )
 
 
-def _map_href(pref_ja: str | None = None) -> str:
-    return f"/?pref={quote(pref_ja)}" if pref_ja else "/"
+def _map_href(map_base: str, pref_ja: str | None = None) -> str:
+    return f"{map_base}?pref={quote(pref_ja)}" if pref_ja else map_base
 
 
 def _track_attrs(event_name: str, fact: dict, target_url: str) -> str:
@@ -1069,6 +1073,7 @@ def _track_attrs(event_name: str, fact: dict, target_url: str) -> str:
         f'data-summary-event="{escape(event_name)}" '
         f'data-fact-id="{escape(fact["id"])}" '
         f'data-fact-title="{escape(fact["title"])}" '
+        f'data-image-type="{escape(fact["image_type"])}" '
         f'data-target-url="{escape(target_url)}"'
     )
 
@@ -1096,7 +1101,710 @@ def _format_summary_text(value: str, s: dict, stats: dict) -> str:
     return value.format(**_top_rank_context(stats))
 
 
-def _build_ja_facts(stats: dict) -> list[dict]:
+FACT_COPY: dict[str, dict] = {
+    "ja": {
+        "daily": "今日のポケふた雑学",
+        "section": "ポケふた雑学",
+        "share": "Xで共有",
+        "hashtags": ["#ポケふた", "#ポケモンマンホール"],
+        "empty_status": "まだ{empty_count}県には設置されていません。",
+        "empty_share_lead": "まだ設置されていない県は{empty_count}県あります。",
+        "map_all": "全国マップを見る",
+        "map_rank": "ランキングを見る",
+        "map_pref": "{pref}を地図で見る",
+        "facts": {
+            "hokkaido": {
+                "type": "prefecture_rank",
+                "title": "{hokkaido_name}だけで{hokkaido}枚",
+                "stat": "{hokkaido}枚",
+                "main": "{hokkaido_name}には{hokkaido}枚のポケふたがあります。全国{total}枚の約{hokkaido_pct}%です。",
+                "note": "広い北海道では、ポケふた巡りも立派な旅になります。",
+                "share_title": "{hokkaido_name}だけでポケふたは{hokkaido}枚。",
+                "share_lead": "全国{total}枚の約{hokkaido_pct}%が北海道にあります。",
+                "share_body": "地域ごとの数を眺めると、旅の行き先候補も少し変わって見えます。",
+                "image_type": "summary_prefecture_rank",
+                "image_title": "{hokkaido_name}だけで{hokkaido}枚",
+                "image_main_value": "{hokkaido}枚",
+                "image_subtitle": "全国の約{hokkaido_pct}%",
+                "image_footer": "ポケふた都道府県別ランキング",
+                "map_pref": "北海道",
+            },
+            "installed-prefectures": {
+                "type": "travel_trivia",
+                "title": "設置済みは{installed_count}都道府県",
+                "stat": "{installed_count}都道府県",
+                "main": "ポケふた設置済みは{installed_count}都道府県。{empty_status}",
+                "note": "全国に広がりつつも、まだ空白地帯があります。",
+                "share_title": "ポケふた設置済みは{installed_count}都道府県。",
+                "share_lead": "{empty_share_lead}",
+                "share_body": "全国{total}枚の分布を一覧で見ると、まだ出会っていない地域が見つかります。",
+                "image_type": "summary_installed_prefectures",
+                "image_title": "ポケふた設置済み",
+                "image_main_value": "{installed_count}都道府県",
+                "image_subtitle": "未設置は{empty_count}県",
+                "image_footer": "全国{total}枚のポケふた一覧",
+            },
+            "tohoku": {
+                "type": "regional_density",
+                "title": "{tohoku_name}は{tohoku}枚の密集エリア",
+                "stat": "{tohoku}枚",
+                "main": "{tohoku_name}地方には{tohoku}枚のポケふたがあります。全国でも特に密度の高いエリアです。",
+                "note": "福島県、宮城県、岩手県など、巡りがいのある県が並びます。",
+                "share_title": "{tohoku_name}地方にはポケふたが{tohoku}枚。",
+                "share_lead": "福島県・宮城県・岩手県など、旅で巡りやすい密集エリアです。",
+                "share_body": "東北旅行の目的地選びにも使いやすい数字です。",
+                "image_type": "summary_regional_density",
+                "image_title": "{tohoku_name}は密集エリア",
+                "image_main_value": "{tohoku}枚",
+                "image_subtitle": "福島・宮城・岩手に多く分布",
+                "image_footer": "地域別のポケふた分布",
+            },
+            "top-prefectures": {
+                "type": "prefecture_rank",
+                "title": "多い県トップ3",
+                "stat": "TOP3",
+                "main": "ポケふたが多い県トップ3は、{top3}です。",
+                "note": "上位は北日本の存在感が大きめです。",
+                "share_title": "ポケふたが多い都道府県トップ3。",
+                "share_lead": "{top3}が上位です。",
+                "share_body": "数字で見ると、次の旅行先候補がかなり具体的になります。",
+                "image_type": "summary_top_prefectures",
+                "image_title": "多い県トップ3",
+                "image_main_value": "TOP3",
+                "image_subtitle": "{top3}",
+                "image_footer": "ポケふた都道府県別ランキング",
+                "map_label_key": "map_rank",
+            },
+            "fukushima": {
+                "type": "prefecture_rank",
+                "title": "{fukushima_name}は全国2位",
+                "stat": "{fukushima}枚",
+                "main": "{fukushima_name}には{fukushima}枚のポケふたがあります。北海道に次ぐ全国2位です。",
+                "note": "県内を巡るだけでも、かなり濃いポケふた旅になります。",
+                "share_title": "{fukushima_name}のポケふたは{fukushima}枚。",
+                "share_lead": "北海道に次ぐ全国2位です。",
+                "share_body": "1県の中だけでも、しっかり巡る旅が成立する数です。",
+                "image_type": "summary_prefecture_rank",
+                "image_title": "{fukushima_name}は全国2位",
+                "image_main_value": "{fukushima}枚",
+                "image_subtitle": "北海道に次ぐ設置数",
+                "image_footer": "ポケふた都道府県別ランキング",
+                "map_pref": "福島県",
+            },
+            "miyagi-iwate": {
+                "type": "regional_density",
+                "title": "{miyagi_name}と{iwate_name}も強い",
+                "stat": "{miyagi}+{iwate}枚",
+                "main": "{miyagi_name}には{miyagi}枚、{iwate_name}には{iwate}枚。東北はポケふた巡りの有力エリアです。",
+                "note": "東北旅行の目的地選びにも使いやすい数字です。",
+                "share_title": "{miyagi_name}{miyagi}枚、{iwate_name}{iwate}枚。",
+                "share_lead": "東北はポケふた巡りの有力エリアです。",
+                "share_body": "地域をまたいで巡ると、旅程そのものがポケふた探しになります。",
+                "image_type": "summary_regional_pair",
+                "image_title": "{miyagi_name}と{iwate_name}",
+                "image_main_value": "{miyagi}+{iwate}枚",
+                "image_subtitle": "東北旅行で巡りたいエリア",
+                "image_footer": "地域別のポケふた分布",
+                "map_pref": "宮城県",
+            },
+            "mie": {
+                "type": "prefecture_rank",
+                "title": "{mie_name}は{mie}枚",
+                "stat": "{mie}枚",
+                "main": "{mie_name}には{mie}枚のポケふたがあります。近畿・東海エリアでも存在感があります。",
+                "note": "関西・東海方面の旅程にも組み込みやすい地域です。",
+                "share_title": "{mie_name}にはポケふたが{mie}枚。",
+                "share_lead": "近畿・東海エリアでも存在感のある設置数です。",
+                "share_body": "移動ルートに組み込むと、旅の寄り道が少し楽しくなります。",
+                "image_type": "summary_prefecture_rank",
+                "image_title": "{mie_name}は{mie}枚",
+                "image_main_value": "{mie}枚",
+                "image_subtitle": "近畿・東海エリアの注目県",
+                "image_footer": "ポケふた都道府県別ランキング",
+                "map_pref": "三重県",
+            },
+            "empty-prefectures": {
+                "type": "travel_trivia",
+                "title": "まだポケふたがない県",
+                "stat": "{empty_count}県",
+                "main": "{empty_names}には、まだポケふたがありません。",
+                "note": "次にどこへ広がるのかを予想する楽しみもあります。",
+                "share_title": "まだポケふたがない県は{empty_count}県。",
+                "share_lead": "{empty_names}です。",
+                "share_body": "全国{total}枚の一覧を見ると、空白地帯にも地域の個性が見えてきます。",
+                "image_type": "summary_empty_prefectures",
+                "image_title": "まだポケふたがない県",
+                "image_main_value": "{empty_count}県",
+                "image_subtitle": "{empty_names}",
+                "image_footer": "全国{total}枚のポケふた一覧",
+            },
+        },
+    },
+    "en": {
+        "daily": "Today's Pokefuta Trivia",
+        "section": "Pokefuta Trivia",
+        "share": "Share on X",
+        "hashtags": ["#Pokefuta", "#PokemonManhole"],
+        "empty_status": "{empty_count} prefectures still have none.",
+        "empty_share_lead": "{empty_count} prefectures still have no Pokefuta.",
+        "map_all": "View the Japan map",
+        "map_rank": "View rankings",
+        "map_pref": "View {pref} on the map",
+        "facts": {
+            "hokkaido": {
+                "type": "prefecture_rank",
+                "title": "{hokkaido_name} alone has {hokkaido}",
+                "stat": "{hokkaido}",
+                "main": "{hokkaido_name} has {hokkaido} Pokefuta, about {hokkaido_pct}% of the nationwide total of {total}.",
+                "note": "In wide-open Hokkaido, collecting Pokefuta can become a trip in itself.",
+                "share_title": "{hokkaido_name} alone has {hokkaido} Pokefuta.",
+                "share_lead": "That is about {hokkaido_pct}% of Japan's {total} total.",
+                "share_body": "The prefecture counts make travel ideas feel surprisingly concrete.",
+                "image_type": "summary_prefecture_rank",
+                "image_title": "{hokkaido_name} alone",
+                "image_main_value": "{hokkaido}",
+                "image_subtitle": "about {hokkaido_pct}% nationwide",
+                "image_footer": "Pokefuta ranking by prefecture",
+                "map_pref": "北海道",
+            },
+            "installed-prefectures": {
+                "type": "travel_trivia",
+                "title": "{installed_count} prefectures have Pokefuta",
+                "stat": "{installed_count}",
+                "main": "Pokefuta are installed in {installed_count} prefectures. {empty_status}",
+                "note": "They have spread across Japan, while a few blank spots remain.",
+                "share_title": "Pokefuta are in {installed_count} prefectures.",
+                "share_lead": "{empty_share_lead}",
+                "share_body": "A nationwide list makes the next region to explore easier to spot.",
+                "image_type": "summary_installed_prefectures",
+                "image_title": "Prefectures with Pokefuta",
+                "image_main_value": "{installed_count}",
+                "image_subtitle": "{empty_count} still without one",
+                "image_footer": "Nationwide Pokefuta list",
+            },
+            "tohoku": {
+                "type": "regional_density",
+                "title": "{tohoku_name}: {tohoku} in one region",
+                "stat": "{tohoku}",
+                "main": "{tohoku_name} has {tohoku} Pokefuta, one of the densest regions nationwide.",
+                "note": "Fukushima, Miyagi, and Iwate make this area especially rewarding to explore.",
+                "share_title": "{tohoku_name} has {tohoku} Pokefuta.",
+                "share_lead": "Fukushima, Miyagi, and Iwate make it a strong travel area.",
+                "share_body": "It is a useful number when choosing where to go next.",
+                "image_type": "summary_regional_density",
+                "image_title": "{tohoku_name} density",
+                "image_main_value": "{tohoku}",
+                "image_subtitle": "Many in Fukushima, Miyagi, and Iwate",
+                "image_footer": "Regional Pokefuta distribution",
+            },
+            "top-prefectures": {
+                "type": "prefecture_rank",
+                "title": "Top 3 prefectures",
+                "stat": "TOP 3",
+                "main": "The top 3 prefectures by Pokefuta count are {top3}.",
+                "note": "Northern Japan has a strong presence near the top.",
+                "share_title": "Top 3 prefectures by Pokefuta count.",
+                "share_lead": "{top3} lead the ranking.",
+                "share_body": "Numbers like these can turn a map into a travel shortlist.",
+                "image_type": "summary_top_prefectures",
+                "image_title": "Top 3 prefectures",
+                "image_main_value": "TOP 3",
+                "image_subtitle": "{top3}",
+                "image_footer": "Pokefuta ranking by prefecture",
+                "map_label_key": "map_rank",
+            },
+            "fukushima": {
+                "type": "prefecture_rank",
+                "title": "{fukushima_name} ranks #2",
+                "stat": "{fukushima}",
+                "main": "{fukushima_name} has {fukushima} Pokefuta, second only to Hokkaido.",
+                "note": "A trip within the prefecture alone can be rich with discoveries.",
+                "share_title": "{fukushima_name} has {fukushima} Pokefuta.",
+                "share_lead": "That puts it second nationwide after Hokkaido.",
+                "share_body": "It is enough for a full local Pokefuta trip.",
+                "image_type": "summary_prefecture_rank",
+                "image_title": "{fukushima_name} ranks #2",
+                "image_main_value": "{fukushima}",
+                "image_subtitle": "second only to Hokkaido",
+                "image_footer": "Pokefuta ranking by prefecture",
+                "map_pref": "福島県",
+            },
+            "miyagi-iwate": {
+                "type": "regional_density",
+                "title": "{miyagi_name} and {iwate_name} are strong too",
+                "stat": "{miyagi}+{iwate}",
+                "main": "{miyagi_name} has {miyagi}, and {iwate_name} has {iwate}. Tohoku is a major Pokefuta travel area.",
+                "note": "These numbers are useful when planning a Tohoku route.",
+                "share_title": "{miyagi_name}: {miyagi}, {iwate_name}: {iwate}.",
+                "share_lead": "Tohoku is one of the strongest areas for Pokefuta trips.",
+                "share_body": "Crossing prefectures can make the route itself part of the fun.",
+                "image_type": "summary_regional_pair",
+                "image_title": "{miyagi_name} and {iwate_name}",
+                "image_main_value": "{miyagi}+{iwate}",
+                "image_subtitle": "a Tohoku travel route idea",
+                "image_footer": "Regional Pokefuta distribution",
+                "map_pref": "宮城県",
+            },
+            "mie": {
+                "type": "prefecture_rank",
+                "title": "{mie_name} has {mie}",
+                "stat": "{mie}",
+                "main": "{mie_name} has {mie} Pokefuta, giving it a clear presence in the Kinki-Tokai area.",
+                "note": "It is easy to fold into a Kansai or Tokai travel plan.",
+                "share_title": "{mie_name} has {mie} Pokefuta.",
+                "share_lead": "It stands out in the Kinki-Tokai area.",
+                "share_body": "A small detour can become part of the discovery.",
+                "image_type": "summary_prefecture_rank",
+                "image_title": "{mie_name} has {mie}",
+                "image_main_value": "{mie}",
+                "image_subtitle": "Kinki-Tokai area highlight",
+                "image_footer": "Pokefuta ranking by prefecture",
+                "map_pref": "三重県",
+            },
+            "empty-prefectures": {
+                "type": "travel_trivia",
+                "title": "Prefectures still without Pokefuta",
+                "stat": "{empty_count}",
+                "main": "{empty_names} still have no Pokefuta.",
+                "note": "Guessing where the next one may appear is part of the fun.",
+                "share_title": "{empty_count} prefectures still have no Pokefuta.",
+                "share_lead": "They are {empty_names}.",
+                "share_body": "A nationwide list shows both the spread and the remaining blank spots.",
+                "image_type": "summary_empty_prefectures",
+                "image_title": "Still no Pokefuta",
+                "image_main_value": "{empty_count}",
+                "image_subtitle": "{empty_names}",
+                "image_footer": "Nationwide Pokefuta list",
+            },
+        },
+    },
+}
+
+FACT_COPY["zh-CN"] = {
+    **FACT_COPY["en"],
+    "daily": "今日宝可梦井盖小知识",
+    "section": "宝可梦井盖小知识",
+    "share": "分享到 X",
+    "hashtags": ["#Pokefuta", "#PokemonManhole"],
+    "empty_status": "仍有{empty_count}个县尚未设置。",
+    "empty_share_lead": "仍有{empty_count}个县没有宝可梦井盖。",
+    "map_all": "查看全国地图",
+    "map_rank": "查看排行榜",
+    "map_pref": "在地图上查看{pref}",
+}
+FACT_COPY["zh-TW"] = {
+    **FACT_COPY["zh-CN"],
+    "daily": "今日寶可夢人孔蓋小知識",
+    "section": "寶可夢人孔蓋小知識",
+    "empty_status": "仍有{empty_count}個縣尚未設置。",
+    "empty_share_lead": "仍有{empty_count}個縣沒有寶可夢人孔蓋。",
+    "map_all": "查看全國地圖",
+    "map_rank": "查看排行榜",
+    "map_pref": "在地圖上查看{pref}",
+}
+FACT_COPY["ko"] = {
+    **FACT_COPY["en"],
+    "daily": "오늘의 포케후타 상식",
+    "section": "포케후타 상식",
+    "share": "X에 공유",
+    "hashtags": ["#Pokefuta", "#PokemonManhole"],
+    "empty_status": "아직 {empty_count}개 현에는 설치되어 있지 않습니다.",
+    "empty_share_lead": "아직 포케후타가 없는 현은 {empty_count}곳입니다.",
+    "map_all": "전국 지도 보기",
+    "map_rank": "랭킹 보기",
+    "map_pref": "지도에서 {pref} 보기",
+}
+
+FACT_COPY["zh-CN"]["facts"] = {
+    "hokkaido": {
+        "type": "prefecture_rank",
+        "title": "仅{hokkaido_name}就有{hokkaido}个",
+        "stat": "{hokkaido}个",
+        "main": "{hokkaido_name}有{hokkaido}个宝可梦井盖，约占全国{total}个的{hokkaido_pct}%。",
+        "note": "在辽阔的北海道，寻找宝可梦井盖本身就能成为一趟旅行。",
+        "share_title": "{hokkaido_name}一个地区就有{hokkaido}个宝可梦井盖。",
+        "share_lead": "约占全国{total}个的{hokkaido_pct}%。",
+        "share_body": "按都道府县看数量，旅行目的地也会变得更具体。",
+        "image_type": "summary_prefecture_rank",
+        "image_title": "{hokkaido_name}就有{hokkaido}个",
+        "image_main_value": "{hokkaido}个",
+        "image_subtitle": "约占全国{hokkaido_pct}%",
+        "image_footer": "宝可梦井盖都道府县排行榜",
+        "map_pref": "北海道",
+    },
+    "installed-prefectures": {
+        "type": "travel_trivia",
+        "title": "已设置{installed_count}个都道府县",
+        "stat": "{installed_count}个都道府县",
+        "main": "宝可梦井盖已设置于{installed_count}个都道府县。{empty_status}",
+        "note": "虽然已经遍布日本各地，但仍然有空白区域。",
+        "share_title": "宝可梦井盖已设置于{installed_count}个都道府县。",
+        "share_lead": "{empty_share_lead}",
+        "share_body": "查看全国{total}个分布，就能发现还没遇见的地区。",
+        "image_type": "summary_installed_prefectures",
+        "image_title": "已设置宝可梦井盖",
+        "image_main_value": "{installed_count}个都道府县",
+        "image_subtitle": "未设置为{empty_count}县",
+        "image_footer": "全国{total}个宝可梦井盖一览",
+    },
+    "tohoku": {
+        "type": "regional_density",
+        "title": "{tohoku_name}是{tohoku}个的密集区域",
+        "stat": "{tohoku}个",
+        "main": "{tohoku_name}地区有{tohoku}个宝可梦井盖，是全国密度较高的区域之一。",
+        "note": "福岛县、宫城县、岩手县等地都很值得巡游。",
+        "share_title": "{tohoku_name}地区有{tohoku}个宝可梦井盖。",
+        "share_lead": "福岛、宫城、岩手等地，是很适合旅行巡游的密集区域。",
+        "share_body": "规划东北旅行时，这个数字很有参考价值。",
+        "image_type": "summary_regional_density",
+        "image_title": "{tohoku_name}密集区域",
+        "image_main_value": "{tohoku}个",
+        "image_subtitle": "福岛・宫城・岩手分布较多",
+        "image_footer": "宝可梦井盖地区分布",
+    },
+    "top-prefectures": {
+        "type": "prefecture_rank",
+        "title": "数量最多的前三名",
+        "stat": "TOP3",
+        "main": "宝可梦井盖数量最多的前三名是：{top3}。",
+        "note": "北日本地区在上位榜单中存在感很强。",
+        "share_title": "宝可梦井盖数量最多的都道府县TOP3。",
+        "share_lead": "{top3}位居前列。",
+        "share_body": "把地图换成数字来看，下一趟旅行的候选地会更清楚。",
+        "image_type": "summary_top_prefectures",
+        "image_title": "数量最多TOP3",
+        "image_main_value": "TOP3",
+        "image_subtitle": "{top3}",
+        "image_footer": "宝可梦井盖都道府县排行榜",
+        "map_label_key": "map_rank",
+    },
+    "fukushima": {
+        "type": "prefecture_rank",
+        "title": "{fukushima_name}位居全国第2",
+        "stat": "{fukushima}个",
+        "main": "{fukushima_name}有{fukushima}个宝可梦井盖，仅次于北海道，位居全国第2。",
+        "note": "只在县内巡游，也能是一趟内容很丰富的宝可梦井盖之旅。",
+        "share_title": "{fukushima_name}有{fukushima}个宝可梦井盖。",
+        "share_lead": "仅次于北海道，位居全国第2。",
+        "share_body": "这个数量足以支撑一趟县内巡游。",
+        "image_type": "summary_prefecture_rank",
+        "image_title": "{fukushima_name}全国第2",
+        "image_main_value": "{fukushima}个",
+        "image_subtitle": "仅次于北海道",
+        "image_footer": "宝可梦井盖都道府县排行榜",
+        "map_pref": "福島県",
+    },
+    "miyagi-iwate": {
+        "type": "regional_density",
+        "title": "{miyagi_name}和{iwate_name}也很强",
+        "stat": "{miyagi}+{iwate}个",
+        "main": "{miyagi_name}有{miyagi}个，{iwate_name}有{iwate}个。东北是宝可梦井盖巡游的重要区域。",
+        "note": "这些数字也很适合用来规划东北旅行。",
+        "share_title": "{miyagi_name}{miyagi}个，{iwate_name}{iwate}个。",
+        "share_lead": "东北是宝可梦井盖巡游的强势区域。",
+        "share_body": "跨县巡游时，路线本身也会变成旅行的乐趣。",
+        "image_type": "summary_regional_pair",
+        "image_title": "{miyagi_name}和{iwate_name}",
+        "image_main_value": "{miyagi}+{iwate}个",
+        "image_subtitle": "东北旅行巡游候选",
+        "image_footer": "宝可梦井盖地区分布",
+        "map_pref": "宮城県",
+    },
+    "mie": {
+        "type": "prefecture_rank",
+        "title": "{mie_name}有{mie}个",
+        "stat": "{mie}个",
+        "main": "{mie_name}有{mie}个宝可梦井盖，在近畿・东海区域也很有存在感。",
+        "note": "很适合加入关西或东海方向的旅行路线。",
+        "share_title": "{mie_name}有{mie}个宝可梦井盖。",
+        "share_lead": "在近畿・东海区域也很有存在感。",
+        "share_body": "把它作为顺路停靠点，旅行会多一点发现感。",
+        "image_type": "summary_prefecture_rank",
+        "image_title": "{mie_name}有{mie}个",
+        "image_main_value": "{mie}个",
+        "image_subtitle": "近畿・东海区域的注目县",
+        "image_footer": "宝可梦井盖都道府县排行榜",
+        "map_pref": "三重県",
+    },
+    "empty-prefectures": {
+        "type": "travel_trivia",
+        "title": "仍没有宝可梦井盖的县",
+        "stat": "{empty_count}县",
+        "main": "{empty_names}仍然没有宝可梦井盖。",
+        "note": "猜测下一处会设置在哪里，也是乐趣之一。",
+        "share_title": "仍没有宝可梦井盖的县有{empty_count}个。",
+        "share_lead": "分别是{empty_names}。",
+        "share_body": "全国{total}个一览能同时看到扩展范围和空白区域。",
+        "image_type": "summary_empty_prefectures",
+        "image_title": "仍没有宝可梦井盖的县",
+        "image_main_value": "{empty_count}县",
+        "image_subtitle": "{empty_names}",
+        "image_footer": "全国{total}个宝可梦井盖一览",
+    },
+}
+FACT_COPY["zh-TW"]["facts"] = {
+    "hokkaido": {
+        "type": "prefecture_rank",
+        "title": "光是{hokkaido_name}就有{hokkaido}個",
+        "stat": "{hokkaido}個",
+        "main": "{hokkaido_name}有{hokkaido}個寶可夢人孔蓋，約占全國{total}個的{hokkaido_pct}%。",
+        "note": "在幅員遼闊的北海道，尋找寶可夢人孔蓋本身就是一趟旅行。",
+        "share_title": "{hokkaido_name}一地就有{hokkaido}個寶可夢人孔蓋。",
+        "share_lead": "約占全國{total}個的{hokkaido_pct}%。",
+        "share_body": "用都道府縣別數字來看，下一趟旅行的候選地會更具體。",
+        "image_type": "summary_prefecture_rank",
+        "image_title": "{hokkaido_name}就有{hokkaido}個",
+        "image_main_value": "{hokkaido}個",
+        "image_subtitle": "約占全國{hokkaido_pct}%",
+        "image_footer": "寶可夢人孔蓋都道府縣排行榜",
+        "map_pref": "北海道",
+    },
+    "installed-prefectures": {
+        "type": "travel_trivia",
+        "title": "已設置於{installed_count}個都道府縣",
+        "stat": "{installed_count}個都道府縣",
+        "main": "寶可夢人孔蓋已設置於{installed_count}個都道府縣。{empty_status}",
+        "note": "雖然已經遍布日本各地，但仍有尚未設置的空白區域。",
+        "share_title": "寶可夢人孔蓋已設置於{installed_count}個都道府縣。",
+        "share_lead": "{empty_share_lead}",
+        "share_body": "查看全國{total}個分布，就能發現還沒造訪過的地區。",
+        "image_type": "summary_installed_prefectures",
+        "image_title": "已設置寶可夢人孔蓋",
+        "image_main_value": "{installed_count}個都道府縣",
+        "image_subtitle": "未設置為{empty_count}縣",
+        "image_footer": "全國{total}個寶可夢人孔蓋一覽",
+    },
+    "tohoku": {
+        "type": "regional_density",
+        "title": "{tohoku_name}是{tohoku}個的密集區域",
+        "stat": "{tohoku}個",
+        "main": "{tohoku_name}地區有{tohoku}個寶可夢人孔蓋，是全國分布密度較高的區域之一。",
+        "note": "福島縣、宮城縣、岩手縣等地都很值得安排巡訪。",
+        "share_title": "{tohoku_name}地區有{tohoku}個寶可夢人孔蓋。",
+        "share_lead": "福島、宮城、岩手等地，是很適合旅行巡訪的密集區域。",
+        "share_body": "規劃東北旅行時，這個數字很有參考價值。",
+        "image_type": "summary_regional_density",
+        "image_title": "{tohoku_name}密集區域",
+        "image_main_value": "{tohoku}個",
+        "image_subtitle": "福島・宮城・岩手分布較多",
+        "image_footer": "寶可夢人孔蓋地區分布",
+    },
+    "top-prefectures": {
+        "type": "prefecture_rank",
+        "title": "數量最多的前三名",
+        "stat": "TOP3",
+        "main": "寶可夢人孔蓋數量最多的前三名是：{top3}。",
+        "note": "北日本地區在排行榜前段很有存在感。",
+        "share_title": "寶可夢人孔蓋數量最多的都道府縣TOP3。",
+        "share_lead": "{top3}位居前列。",
+        "share_body": "把地圖換成數字來看，下一趟旅行的候選地會更清楚。",
+        "image_type": "summary_top_prefectures",
+        "image_title": "數量最多TOP3",
+        "image_main_value": "TOP3",
+        "image_subtitle": "{top3}",
+        "image_footer": "寶可夢人孔蓋都道府縣排行榜",
+        "map_label_key": "map_rank",
+    },
+    "fukushima": {
+        "type": "prefecture_rank",
+        "title": "{fukushima_name}位居全國第2",
+        "stat": "{fukushima}個",
+        "main": "{fukushima_name}有{fukushima}個寶可夢人孔蓋，僅次於北海道，位居全國第2。",
+        "note": "只在縣內巡訪，也能是一趟內容很豐富的寶可夢人孔蓋之旅。",
+        "share_title": "{fukushima_name}有{fukushima}個寶可夢人孔蓋。",
+        "share_lead": "僅次於北海道，位居全國第2。",
+        "share_body": "這個數量足以規劃一趟縣內巡訪。",
+        "image_type": "summary_prefecture_rank",
+        "image_title": "{fukushima_name}全國第2",
+        "image_main_value": "{fukushima}個",
+        "image_subtitle": "僅次於北海道",
+        "image_footer": "寶可夢人孔蓋都道府縣排行榜",
+        "map_pref": "福島県",
+    },
+    "miyagi-iwate": {
+        "type": "regional_density",
+        "title": "{miyagi_name}和{iwate_name}也很強",
+        "stat": "{miyagi}+{iwate}個",
+        "main": "{miyagi_name}有{miyagi}個，{iwate_name}有{iwate}個。東北是寶可夢人孔蓋巡訪的重要區域。",
+        "note": "這些數字也很適合用來規劃東北旅行。",
+        "share_title": "{miyagi_name}{miyagi}個，{iwate_name}{iwate}個。",
+        "share_lead": "東北是寶可夢人孔蓋巡訪的強勢區域。",
+        "share_body": "跨縣巡訪時，路線本身也會變成旅行的樂趣。",
+        "image_type": "summary_regional_pair",
+        "image_title": "{miyagi_name}和{iwate_name}",
+        "image_main_value": "{miyagi}+{iwate}個",
+        "image_subtitle": "東北旅行巡訪候選",
+        "image_footer": "寶可夢人孔蓋地區分布",
+        "map_pref": "宮城県",
+    },
+    "mie": {
+        "type": "prefecture_rank",
+        "title": "{mie_name}有{mie}個",
+        "stat": "{mie}個",
+        "main": "{mie_name}有{mie}個寶可夢人孔蓋，在近畿・東海區域也很有存在感。",
+        "note": "很適合加入關西或東海方向的旅行路線。",
+        "share_title": "{mie_name}有{mie}個寶可夢人孔蓋。",
+        "share_lead": "在近畿・東海區域也很有存在感。",
+        "share_body": "把它作為順路停靠點，旅行會多一點發現感。",
+        "image_type": "summary_prefecture_rank",
+        "image_title": "{mie_name}有{mie}個",
+        "image_main_value": "{mie}個",
+        "image_subtitle": "近畿・東海區域的注目縣",
+        "image_footer": "寶可夢人孔蓋都道府縣排行榜",
+        "map_pref": "三重県",
+    },
+    "empty-prefectures": {
+        "type": "travel_trivia",
+        "title": "仍沒有寶可夢人孔蓋的縣",
+        "stat": "{empty_count}縣",
+        "main": "{empty_names}仍然沒有寶可夢人孔蓋。",
+        "note": "猜測下一處會設置在哪裡，也是樂趣之一。",
+        "share_title": "仍沒有寶可夢人孔蓋的縣有{empty_count}個。",
+        "share_lead": "分別是{empty_names}。",
+        "share_body": "全國{total}個一覽能同時看到擴展範圍和空白區域。",
+        "image_type": "summary_empty_prefectures",
+        "image_title": "仍沒有寶可夢人孔蓋的縣",
+        "image_main_value": "{empty_count}縣",
+        "image_subtitle": "{empty_names}",
+        "image_footer": "全國{total}個寶可夢人孔蓋一覽",
+    },
+}
+FACT_COPY["ko"]["facts"] = {
+    "hokkaido": {
+        "type": "prefecture_rank",
+        "title": "{hokkaido_name}에만 {hokkaido}개",
+        "stat": "{hokkaido}개",
+        "main": "{hokkaido_name}에는 포케후타가 {hokkaido}개 있습니다. 전국 {total}개 중 약 {hokkaido_pct}%입니다.",
+        "note": "넓은 홋카이도에서는 포케후타 순회 자체가 하나의 여행이 됩니다.",
+        "share_title": "{hokkaido_name}에만 포케후타가 {hokkaido}개.",
+        "share_lead": "전국 {total}개 중 약 {hokkaido_pct}%입니다.",
+        "share_body": "도도부현별 숫자를 보면 여행 후보지도 더 구체적으로 보입니다.",
+        "image_type": "summary_prefecture_rank",
+        "image_title": "{hokkaido_name}에만 {hokkaido}개",
+        "image_main_value": "{hokkaido}개",
+        "image_subtitle": "전국의 약 {hokkaido_pct}%",
+        "image_footer": "포케후타 도도부현별 랭킹",
+        "map_pref": "北海道",
+    },
+    "installed-prefectures": {
+        "type": "travel_trivia",
+        "title": "설치 완료는 {installed_count}개 도도부현",
+        "stat": "{installed_count}개 도도부현",
+        "main": "포케후타 설치 완료 지역은 {installed_count}개 도도부현입니다. {empty_status}",
+        "note": "전국으로 퍼지고 있지만 아직 빈 지역도 남아 있습니다.",
+        "share_title": "포케후타 설치 완료는 {installed_count}개 도도부현.",
+        "share_lead": "{empty_share_lead}",
+        "share_body": "전국 {total}개의 분포를 보면 아직 만나지 못한 지역도 보입니다.",
+        "image_type": "summary_installed_prefectures",
+        "image_title": "포케후타 설치 완료",
+        "image_main_value": "{installed_count}개 도도부현",
+        "image_subtitle": "미설치는 {empty_count}개 현",
+        "image_footer": "전국 {total}개 포케후타 일람",
+    },
+    "tohoku": {
+        "type": "regional_density",
+        "title": "{tohoku_name}는 {tohoku}개의 밀집 지역",
+        "stat": "{tohoku}개",
+        "main": "{tohoku_name} 지방에는 포케후타가 {tohoku}개 있습니다. 전국에서도 특히 밀도가 높은 지역입니다.",
+        "note": "후쿠시마, 미야기, 이와테 등 순회할 만한 현이 이어집니다.",
+        "share_title": "{tohoku_name} 지방에는 포케후타가 {tohoku}개.",
+        "share_lead": "후쿠시마・미야기・이와테 등 여행하며 돌기 좋은 밀집 지역입니다.",
+        "share_body": "도호쿠 여행지를 고를 때도 도움이 되는 숫자입니다.",
+        "image_type": "summary_regional_density",
+        "image_title": "{tohoku_name} 밀집 지역",
+        "image_main_value": "{tohoku}개",
+        "image_subtitle": "후쿠시마・미야기・이와테에 다수 분포",
+        "image_footer": "지역별 포케후타 분포",
+    },
+    "top-prefectures": {
+        "type": "prefecture_rank",
+        "title": "많은 현 TOP3",
+        "stat": "TOP3",
+        "main": "포케후타가 많은 도도부현 TOP3는 {top3}입니다.",
+        "note": "상위권에서는 북일본의 존재감이 큽니다.",
+        "share_title": "포케후타가 많은 도도부현 TOP3.",
+        "share_lead": "{top3}가 상위입니다.",
+        "share_body": "숫자로 보면 다음 여행 후보지가 더 선명해집니다.",
+        "image_type": "summary_top_prefectures",
+        "image_title": "많은 현 TOP3",
+        "image_main_value": "TOP3",
+        "image_subtitle": "{top3}",
+        "image_footer": "포케후타 도도부현별 랭킹",
+        "map_label_key": "map_rank",
+    },
+    "fukushima": {
+        "type": "prefecture_rank",
+        "title": "{fukushima_name}는 전국 2위",
+        "stat": "{fukushima}개",
+        "main": "{fukushima_name}에는 포케후타가 {fukushima}개 있습니다. 홋카이도에 이어 전국 2위입니다.",
+        "note": "현 안에서만 돌아도 충분히 진한 포케후타 여행이 됩니다.",
+        "share_title": "{fukushima_name}에는 포케후타가 {fukushima}개.",
+        "share_lead": "홋카이도에 이어 전국 2위입니다.",
+        "share_body": "한 현 안에서도 충분한 순회 여행이 되는 수입니다.",
+        "image_type": "summary_prefecture_rank",
+        "image_title": "{fukushima_name} 전국 2위",
+        "image_main_value": "{fukushima}개",
+        "image_subtitle": "홋카이도 다음으로 많은 설치 수",
+        "image_footer": "포케후타 도도부현별 랭킹",
+        "map_pref": "福島県",
+    },
+    "miyagi-iwate": {
+        "type": "regional_density",
+        "title": "{miyagi_name}와 {iwate_name}도 강세",
+        "stat": "{miyagi}+{iwate}개",
+        "main": "{miyagi_name}에는 {miyagi}개, {iwate_name}에는 {iwate}개. 도호쿠는 포케후타 순회의 유력 지역입니다.",
+        "note": "도호쿠 여행 목적지를 고를 때도 쓰기 좋은 숫자입니다.",
+        "share_title": "{miyagi_name} {miyagi}개, {iwate_name} {iwate}개.",
+        "share_lead": "도호쿠는 포케후타 순회의 유력 지역입니다.",
+        "share_body": "현을 넘나들며 돌면 경로 자체가 여행의 재미가 됩니다.",
+        "image_type": "summary_regional_pair",
+        "image_title": "{miyagi_name}와 {iwate_name}",
+        "image_main_value": "{miyagi}+{iwate}개",
+        "image_subtitle": "도호쿠 여행 순회 후보",
+        "image_footer": "지역별 포케후타 분포",
+        "map_pref": "宮城県",
+    },
+    "mie": {
+        "type": "prefecture_rank",
+        "title": "{mie_name}는 {mie}개",
+        "stat": "{mie}개",
+        "main": "{mie_name}에는 포케후타가 {mie}개 있습니다. 긴키・도카이 지역에서도 존재감이 있습니다.",
+        "note": "간사이・도카이 방면 여행 일정에도 넣기 좋은 지역입니다.",
+        "share_title": "{mie_name}에는 포케후타가 {mie}개.",
+        "share_lead": "긴키・도카이 지역에서도 존재감 있는 설치 수입니다.",
+        "share_body": "이동 경로에 더하면 작은 발견이 있는 여행이 됩니다.",
+        "image_type": "summary_prefecture_rank",
+        "image_title": "{mie_name}는 {mie}개",
+        "image_main_value": "{mie}개",
+        "image_subtitle": "긴키・도카이 지역의 주목 현",
+        "image_footer": "포케후타 도도부현별 랭킹",
+        "map_pref": "三重県",
+    },
+    "empty-prefectures": {
+        "type": "travel_trivia",
+        "title": "아직 포케후타가 없는 현",
+        "stat": "{empty_count}개 현",
+        "main": "{empty_names}에는 아직 포케후타가 없습니다.",
+        "note": "다음에는 어디로 확장될지 예상하는 재미도 있습니다.",
+        "share_title": "아직 포케후타가 없는 현은 {empty_count}곳.",
+        "share_lead": "{empty_names}입니다.",
+        "share_body": "전국 {total}개의 일람을 보면 확산 지역과 빈 지역이 함께 보입니다.",
+        "image_type": "summary_empty_prefectures",
+        "image_title": "아직 포케후타가 없는 현",
+        "image_main_value": "{empty_count}개 현",
+        "image_subtitle": "{empty_names}",
+        "image_footer": "전국 {total}개 포케후타 일람",
+    },
+}
+
+
+def _localized_fact_copy(lang: str) -> dict:
+    return FACT_COPY.get(lang, FACT_COPY["en"])
+
+
+def _build_facts(s: dict, stats: dict, tr) -> list[dict]:
+    lang = s.get("html_lang", "en")
+    copy = _localized_fact_copy(lang)
     counts = {item["pref"]: item["count"] for item in stats["by_pref"]}
     total = stats["total"]
     hokkaido = counts.get("北海道", 0)
@@ -1109,159 +1817,89 @@ def _build_ja_facts(stats: dict) -> list[dict]:
     installed_count = len(stats["installed"])
     empty_count = len(stats["empty"])
     hokkaido_pct = round((hokkaido / total) * 100) if total else 0
-    top3 = "・".join(item["pref"] for item in stats["ranking"][:3])
-    empty_main = (
-        f"まだ{empty_count}県には設置されていません。"
-        if empty_count
-        else "すべての都道府県に設置されています。"
-    )
-    empty_share = (
-        f"まだ{empty_count}県には設置されていません"
-        if empty_count
-        else "すべての都道府県に設置されています"
-    )
+    top3 = " / ".join(tr(item["pref"]) for item in stats["ranking"][:3])
+    empty_names = " / ".join(tr(item["pref"]) for item in stats["empty"])
+    empty_status = copy["empty_status"].format(empty_count=empty_count)
+    empty_share_lead = copy["empty_share_lead"].format(empty_count=empty_count)
+    region_names = s.get("region_names", {})
+    ctx = {
+        "total": total,
+        "hokkaido": hokkaido,
+        "hokkaido_pct": hokkaido_pct,
+        "hokkaido_name": tr("北海道"),
+        "fukushima": fukushima,
+        "fukushima_name": tr("福島県"),
+        "miyagi": miyagi,
+        "miyagi_name": tr("宮城県"),
+        "iwate": iwate,
+        "iwate_name": tr("岩手県"),
+        "mie": mie,
+        "mie_name": tr("三重県"),
+        "tohoku": tohoku,
+        "tohoku_name": region_names.get("東北", "Tohoku"),
+        "installed_count": installed_count,
+        "empty_count": empty_count,
+        "empty_names": empty_names,
+        "empty_status": empty_status,
+        "empty_share_lead": empty_share_lead,
+        "top3": top3,
+    }
 
-    facts = [
-        {
-            "id": "hokkaido",
-            "title": f"北海道だけで{hokkaido}枚",
-            "stat": f"{hokkaido}枚",
-            "main": f"北海道には{hokkaido}枚のポケふたがあります。全国{total}枚の約{hokkaido_pct}%です。",
-            "note": "広い北海道では、ポケふた巡りも立派な旅になります。",
-            "share_text": (
-                f"北海道だけでポケふたは{hokkaido}枚。\n"
-                f"全国{total}枚の約{hokkaido_pct}%が北海道にあります\n"
-                "ポケふたの都道府県別ランキングを見る\n"
-                "#ポケふた #ポケモンマンホール"
+    facts = []
+    for fact_id, template in copy["facts"].items():
+        if fact_id == "empty-prefectures" and not empty_count:
+            continue
+        fact = {
+            "id": fact_id,
+            "type": template["type"],
+            "share_url": s["canonical"],
+            "hashtags": copy["hashtags"],
+            "map_href": _map_href(s["map_base_href"], template.get("map_pref")),
+            "map_label": (
+                copy[template.get("map_label_key", "map_all")]
+                if "map_pref" not in template
+                else copy["map_pref"].format(pref=tr(template["map_pref"]))
             ),
-            "map_href": _map_href("北海道"),
-            "map_label": "北海道を地図で見る",
-        },
-        {
-            "id": "installed-prefectures",
-            "title": f"設置済みは{installed_count}都道府県",
-            "stat": f"{installed_count}都道府県",
-            "main": f"ポケふた設置済みは{installed_count}都道府県。{empty_main}",
-            "note": "全国に広がりつつも、まだ空白地帯があります。",
-            "share_text": (
-                f"ポケふた設置済みは{installed_count}都道府県。\n"
-                f"{empty_share}\n"
-                "ポケふたの都道府県別ランキングを見る\n"
-                "#ポケふた #ポケモンマンホール"
-            ),
-            "map_href": _map_href(),
-            "map_label": "全国マップを見る",
-        },
-        {
-            "id": "tohoku",
-            "title": f"東北は{tohoku}枚の密集エリア",
-            "stat": f"{tohoku}枚",
-            "main": f"東北地方には{tohoku}枚のポケふたがあります。全国でも特に密度の高いエリアです。",
-            "note": "福島県、宮城県、岩手県など、巡りがいのある県が並びます。",
-            "share_text": (
-                f"東北地方には{tohoku}枚のポケふたがあります。\n"
-                "全国でも特に密度の高いエリアです\n"
-                "ポケふたの都道府県別ランキングを見る\n"
-                "#ポケふた #ポケモンマンホール"
-            ),
-            "map_href": _map_href(),
-            "map_label": "全国マップを見る",
-        },
-        {
-            "id": "top-prefectures",
-            "title": "多い県トップ3",
-            "stat": "TOP3",
-            "main": f"ポケふたが多い県トップ3は、{top3}です。",
-            "note": "上位は北日本の存在感が大きめです。",
-            "share_text": (
-                f"ポケふたが多い県トップ3は、{top3}です。\n"
-                "ポケふたの都道府県別ランキングを見る\n"
-                "#ポケふた #ポケモンマンホール"
-            ),
-            "map_href": _map_href(),
-            "map_label": "ランキングを見る",
-        },
-        {
-            "id": "fukushima",
-            "title": "福島県は全国2位",
-            "stat": f"{fukushima}枚",
-            "main": f"福島県には{fukushima}枚のポケふたがあります。北海道に次ぐ全国2位です。",
-            "note": "県内を巡るだけでも、かなり濃いポケふた旅になります。",
-            "share_text": (
-                f"福島県には{fukushima}枚のポケふたがあります。\n"
-                "北海道に次ぐ全国2位です\n"
-                "ポケふたの都道府県別ランキングを見る\n"
-                "#ポケふた #ポケモンマンホール"
-            ),
-            "map_href": _map_href("福島県"),
-            "map_label": "福島県を地図で見る",
-        },
-        {
-            "id": "miyagi-iwate",
-            "title": "宮城県と岩手県も強い",
-            "stat": f"{miyagi}+{iwate}枚",
-            "main": f"宮城県には{miyagi}枚、岩手県には{iwate}枚。東北はポケふた巡りの有力エリアです。",
-            "note": "東北旅行の目的地選びにも使いやすい数字です。",
-            "share_text": (
-                f"宮城県には{miyagi}枚、岩手県には{iwate}枚。\n"
-                "東北はポケふた巡りの有力エリアです\n"
-                "ポケふたの都道府県別ランキングを見る\n"
-                "#ポケふた #ポケモンマンホール"
-            ),
-            "map_href": _map_href("宮城県"),
-            "map_label": "宮城県を地図で見る",
-        },
-        {
-            "id": "mie",
-            "title": f"三重県は{mie}枚",
-            "stat": f"{mie}枚",
-            "main": f"三重県には{mie}枚のポケふたがあります。近畿・東海エリアでも存在感があります。",
-            "note": "関西・東海方面の旅程にも組み込みやすい地域です。",
-            "share_text": (
-                f"三重県には{mie}枚のポケふたがあります。\n"
-                "近畿・東海エリアでも存在感があります\n"
-                "ポケふたの都道府県別ランキングを見る\n"
-                "#ポケふた #ポケモンマンホール"
-            ),
-            "map_href": _map_href("三重県"),
-            "map_label": "三重県を地図で見る",
-        },
-    ]
+        }
+        for key in (
+            "title", "stat", "main", "note",
+            "share_title", "share_lead", "share_body",
+            "image_type", "image_title", "image_main_value",
+            "image_subtitle", "image_footer",
+        ):
+            fact[key] = template[key].format(**ctx)
+        facts.append(fact)
     if empty_count:
-        facts.append({
-            "id": "empty-prefectures",
-            "title": "まだポケふたがない県",
-            "stat": f"{empty_count}県",
-            "main": f"{empty_names}には、まだポケふたがありません。",
-            "note": "次にどこへ広がるのかを予想する楽しみもあります。",
-            "share_text": (
-                f"未設置県は、{empty_names}です。\n"
-                "次にどこへ広がるのか気になります\n"
-                "ポケふたの都道府県別ランキングを見る\n"
-                "#ポケふた #ポケモンマンホール"
-            ),
-            "map_href": _map_href(),
-            "map_label": "全国マップを見る",
-        })
+        facts[-1]["map_label"] = copy["map_all"]
     return facts
 
 
-def _build_ja_fact_sections(s: dict, stats: dict) -> tuple[str, str]:
-    if s.get("pref_key") != "ja":
-        return "", ""
+def _fact_share_text(fact: dict) -> str:
+    lines = [
+        fact["share_title"],
+        fact["share_lead"],
+        fact["share_body"],
+        " ".join(fact["hashtags"]),
+    ]
+    return "\n".join(line for line in lines if line)
 
-    facts = _build_ja_facts(stats)
+
+def _build_fact_sections(s: dict, stats: dict, tr) -> tuple[str, str]:
+    copy = _localized_fact_copy(s.get("html_lang", "en"))
+    facts = _build_facts(s, stats, tr)
+    if not facts:
+        return "", ""
     daily_fact = facts[0]
 
     def action_links(fact: dict) -> str:
-        share_href = _twitter_intent_url(fact["share_text"])
+        share_href = _twitter_intent_url(_fact_share_text(fact), fact["share_url"])
         map_href = fact["map_href"]
         return (
             '<div class="summary-actions">'
             f'<a class="summary-action" href="{escape(share_href)}" '
             'target="_blank" rel="noopener noreferrer" '
-            f'{_track_attrs("summary_share_x_click", fact, SUMMARY_SHARE_URL)}>'
-            f'{escape(s["share_x_text"])}</a>'
+            f'{_track_attrs("summary_share_x_click", fact, fact["share_url"])}>'
+            f'{escape(copy["share"])}</a>'
             f'<a class="summary-action secondary" href="{escape(map_href)}" '
             f'{_track_attrs("summary_map_click", fact, map_href)}>'
             f'{escape(fact["map_label"])}</a>'
@@ -1271,8 +1909,13 @@ def _build_ja_fact_sections(s: dict, stats: dict) -> tuple[str, str]:
     daily_html = (
         f'\n    <section class="daily-fact-card" aria-labelledby="daily-fact-heading" '
         f'data-fact-id="{escape(daily_fact["id"])}" '
-        f'data-fact-title="{escape(daily_fact["title"])}">'
-        f'\n      <span class="daily-fact-label">{escape(s["daily_fact_heading"])}</span>'
+        f'data-fact-title="{escape(daily_fact["title"])}" '
+        f'data-image-type="{escape(daily_fact["image_type"])}" '
+        f'data-image-title="{escape(daily_fact["image_title"])}" '
+        f'data-image-main-value="{escape(daily_fact["image_main_value"])}" '
+        f'data-image-subtitle="{escape(daily_fact["image_subtitle"])}" '
+        f'data-image-footer="{escape(daily_fact["image_footer"])}">'
+        f'\n      <span class="daily-fact-label">{escape(copy["daily"])}</span>'
         f'\n      <h2 id="daily-fact-heading"><strong>{escape(daily_fact["main"])}</strong></h2>'
         f'\n      <p>{escape(daily_fact["note"])}</p>'
         f'\n      {action_links(daily_fact)}'
@@ -1282,7 +1925,12 @@ def _build_ja_fact_sections(s: dict, stats: dict) -> tuple[str, str]:
     card_items = "\n        ".join(
         f'<li>'
         f'<article class="summary-fact-card" data-fact-id="{escape(fact["id"])}" '
-        f'data-fact-title="{escape(fact["title"])}">'
+        f'data-fact-title="{escape(fact["title"])}" '
+        f'data-image-type="{escape(fact["image_type"])}" '
+        f'data-image-title="{escape(fact["image_title"])}" '
+        f'data-image-main-value="{escape(fact["image_main_value"])}" '
+        f'data-image-subtitle="{escape(fact["image_subtitle"])}" '
+        f'data-image-footer="{escape(fact["image_footer"])}">'
         f'<span class="summary-fact-number">{escape(fact["stat"])}</span>'
         f'<h3>{escape(fact["title"])}</h3>'
         f'<p class="summary-fact-main">{escape(fact["main"])}</p>'
@@ -1294,7 +1942,7 @@ def _build_ja_fact_sections(s: dict, stats: dict) -> tuple[str, str]:
     )
     list_html = (
         f'\n    <section class="summary-section" aria-labelledby="fact-list-heading">'
-        f'\n      <h2 id="fact-list-heading">{escape(s["fact_section_heading"])}</h2>'
+        f'\n      <h2 id="fact-list-heading">{escape(copy["section"])}</h2>'
         f'\n      <ul class="fact-card-grid">\n        {card_items}\n      </ul>'
         f'\n    </section>\n'
     )
@@ -1302,9 +1950,7 @@ def _build_ja_fact_sections(s: dict, stats: dict) -> tuple[str, str]:
     return daily_html, list_html
 
 
-def _build_ja_tracking_script(s: dict) -> str:
-    if s.get("pref_key") != "ja":
-        return ""
+def _build_tracking_script(s: dict) -> str:
     return """\
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-K18NR4GZG2"></script>
   <script>
@@ -1313,7 +1959,7 @@ def _build_ja_tracking_script(s: dict) -> str:
     gtag('js', new Date());
     gtag('config', 'G-K18NR4GZG2', {
       'anonymize_ip': true,
-      'page_path': '/summary'
+      'page_path': window.location.pathname
     });
 
     document.addEventListener('click', function (event) {
@@ -1325,6 +1971,7 @@ def _build_ja_tracking_script(s: dict) -> str:
         window.gtag('event', 'summary_fact_card_click', {
           fact_id: card.dataset.factId || '',
           fact_title: card.dataset.factTitle || '',
+          image_type: card.dataset.imageType || '',
           target_url: window.location.href
         });
       }
@@ -1333,6 +1980,7 @@ def _build_ja_tracking_script(s: dict) -> str:
       window.gtag('event', target.dataset.summaryEvent, {
         fact_id: target.dataset.factId || '',
         fact_title: target.dataset.factTitle || '',
+        image_type: target.dataset.imageType || '',
         target_url: target.dataset.targetUrl || target.href || ''
       });
     });
@@ -1682,9 +2330,9 @@ def render_page(s: dict, stats: dict, pref_names: dict, pokemon_stats: dict, rec
 
     ai_html = _build_ai_summary(s, stats, tr)
     discovery_html = _build_discovery_section(s, stats, tr)
-    daily_fact_html, fact_list_html = _build_ja_fact_sections(s, stats)
+    daily_fact_html, fact_list_html = _build_fact_sections(s, stats, tr)
     regional_html = _build_regional_section(s, stats)
-    tracking_script = _build_ja_tracking_script(s)
+    tracking_script = _build_tracking_script(s)
     search_hub_html = _build_search_hub_section(s)
     popular_pokemon_html = _build_popular_pokemon_section(s, pokemon_stats)
     latest_photos_html = _build_latest_photos_section(s, records_by_id, photos_data)

--- a/apps/scraper/generate_summary_pages.py
+++ b/apps/scraper/generate_summary_pages.py
@@ -1109,6 +1109,12 @@ FACT_COPY: dict[str, dict] = {
         "hashtags": ["#ポケふた", "#ポケモンマンホール"],
         "empty_status": "まだ{empty_count}県には設置されていません。",
         "empty_share_lead": "まだ設置されていない県は{empty_count}県あります。",
+        "empty_image_subtitle": "未設置は{empty_count}県",
+        "all_installed_status": "すべての都道府県に設置されています。",
+        "all_installed_share_lead": "すべての都道府県にポケふたがあります。",
+        "all_installed_image_subtitle": "全都道府県に設置済み",
+        "list_separator": "・",
+        "top3_separator": "・",
         "map_all": "全国マップを見る",
         "map_rank": "ランキングを見る",
         "map_pref": "{pref}を地図で見る",
@@ -1141,7 +1147,7 @@ FACT_COPY: dict[str, dict] = {
                 "image_type": "summary_installed_prefectures",
                 "image_title": "ポケふた設置済み",
                 "image_main_value": "{installed_count}都道府県",
-                "image_subtitle": "未設置は{empty_count}県",
+                "image_subtitle": "{empty_image_subtitle}",
                 "image_footer": "全国{total}枚のポケふた一覧",
             },
             "tohoku": {
@@ -1247,6 +1253,12 @@ FACT_COPY: dict[str, dict] = {
         "hashtags": ["#Pokefuta", "#PokemonManhole"],
         "empty_status": "{empty_count} prefectures still have none.",
         "empty_share_lead": "{empty_count} prefectures still have no Pokefuta.",
+        "empty_image_subtitle": "{empty_count} still without one",
+        "all_installed_status": "Every prefecture now has Pokefuta.",
+        "all_installed_share_lead": "All prefectures now have Pokefuta.",
+        "all_installed_image_subtitle": "all prefectures covered",
+        "list_separator": ", ",
+        "top3_separator": ", ",
         "map_all": "View the Japan map",
         "map_rank": "View rankings",
         "map_pref": "View {pref} on the map",
@@ -1279,7 +1291,7 @@ FACT_COPY: dict[str, dict] = {
                 "image_type": "summary_installed_prefectures",
                 "image_title": "Prefectures with Pokefuta",
                 "image_main_value": "{installed_count}",
-                "image_subtitle": "{empty_count} still without one",
+                "image_subtitle": "{empty_image_subtitle}",
                 "image_footer": "Nationwide Pokefuta list",
             },
             "tohoku": {
@@ -1388,6 +1400,12 @@ FACT_COPY["zh-CN"] = {
     "hashtags": ["#Pokefuta", "#PokemonManhole"],
     "empty_status": "仍有{empty_count}个县尚未设置。",
     "empty_share_lead": "仍有{empty_count}个县没有宝可梦井盖。",
+    "empty_image_subtitle": "未设置为{empty_count}县",
+    "all_installed_status": "所有都道府县都已设置宝可梦井盖。",
+    "all_installed_share_lead": "所有都道府县现在都有宝可梦井盖。",
+    "all_installed_image_subtitle": "所有都道府县均已设置",
+    "list_separator": "、",
+    "top3_separator": "、",
     "map_all": "查看全国地图",
     "map_rank": "查看排行榜",
     "map_pref": "在地图上查看{pref}",
@@ -1398,6 +1416,10 @@ FACT_COPY["zh-TW"] = {
     "section": "寶可夢人孔蓋小知識",
     "empty_status": "仍有{empty_count}個縣尚未設置。",
     "empty_share_lead": "仍有{empty_count}個縣沒有寶可夢人孔蓋。",
+    "empty_image_subtitle": "未設置為{empty_count}縣",
+    "all_installed_status": "所有都道府縣都已設置寶可夢人孔蓋。",
+    "all_installed_share_lead": "所有都道府縣現在都有寶可夢人孔蓋。",
+    "all_installed_image_subtitle": "所有都道府縣均已設置",
     "map_all": "查看全國地圖",
     "map_rank": "查看排行榜",
     "map_pref": "在地圖上查看{pref}",
@@ -1410,6 +1432,12 @@ FACT_COPY["ko"] = {
     "hashtags": ["#Pokefuta", "#PokemonManhole"],
     "empty_status": "아직 {empty_count}개 현에는 설치되어 있지 않습니다.",
     "empty_share_lead": "아직 포케후타가 없는 현은 {empty_count}곳입니다.",
+    "empty_image_subtitle": "미설치는 {empty_count}개 현",
+    "all_installed_status": "모든 도도부현에 포케후타가 설치되어 있습니다.",
+    "all_installed_share_lead": "모든 도도부현에서 포케후타를 만날 수 있습니다.",
+    "all_installed_image_subtitle": "모든 도도부현 설치 완료",
+    "list_separator": "・",
+    "top3_separator": "・",
     "map_all": "전국 지도 보기",
     "map_rank": "랭킹 보기",
     "map_pref": "지도에서 {pref} 보기",
@@ -1444,7 +1472,7 @@ FACT_COPY["zh-CN"]["facts"] = {
         "image_type": "summary_installed_prefectures",
         "image_title": "已设置宝可梦井盖",
         "image_main_value": "{installed_count}个都道府县",
-        "image_subtitle": "未设置为{empty_count}县",
+        "image_subtitle": "{empty_image_subtitle}",
         "image_footer": "全国{total}个宝可梦井盖一览",
     },
     "tohoku": {
@@ -1571,7 +1599,7 @@ FACT_COPY["zh-TW"]["facts"] = {
         "image_type": "summary_installed_prefectures",
         "image_title": "已設置寶可夢人孔蓋",
         "image_main_value": "{installed_count}個都道府縣",
-        "image_subtitle": "未設置為{empty_count}縣",
+        "image_subtitle": "{empty_image_subtitle}",
         "image_footer": "全國{total}個寶可夢人孔蓋一覽",
     },
     "tohoku": {
@@ -1698,7 +1726,7 @@ FACT_COPY["ko"]["facts"] = {
         "image_type": "summary_installed_prefectures",
         "image_title": "포케후타 설치 완료",
         "image_main_value": "{installed_count}개 도도부현",
-        "image_subtitle": "미설치는 {empty_count}개 현",
+        "image_subtitle": "{empty_image_subtitle}",
         "image_footer": "전국 {total}개 포케후타 일람",
     },
     "tohoku": {
@@ -1813,14 +1841,25 @@ def _build_facts(s: dict, stats: dict, tr) -> list[dict]:
     iwate = counts.get("岩手県", 0)
     mie = counts.get("三重県", 0)
     tohoku = stats["regional"].get("東北", 0)
-    empty_names = "・".join(item["pref"] for item in stats["empty"])
     installed_count = len(stats["installed"])
     empty_count = len(stats["empty"])
     hokkaido_pct = round((hokkaido / total) * 100) if total else 0
-    top3 = " / ".join(tr(item["pref"]) for item in stats["ranking"][:3])
-    empty_names = " / ".join(tr(item["pref"]) for item in stats["empty"])
-    empty_status = copy["empty_status"].format(empty_count=empty_count)
-    empty_share_lead = copy["empty_share_lead"].format(empty_count=empty_count)
+    top3 = copy["top3_separator"].join(
+        tr(item["pref"]) for item in stats["ranking"][:3]
+    )
+    empty_names = copy["list_separator"].join(
+        tr(item["pref"]) for item in stats["empty"]
+    )
+    if empty_count:
+        empty_status = copy["empty_status"].format(empty_count=empty_count)
+        empty_share_lead = copy["empty_share_lead"].format(empty_count=empty_count)
+        empty_image_subtitle = copy["empty_image_subtitle"].format(
+            empty_count=empty_count
+        )
+    else:
+        empty_status = copy["all_installed_status"]
+        empty_share_lead = copy["all_installed_share_lead"]
+        empty_image_subtitle = copy["all_installed_image_subtitle"]
     region_names = s.get("region_names", {})
     ctx = {
         "total": total,
@@ -1842,6 +1881,7 @@ def _build_facts(s: dict, stats: dict, tr) -> list[dict]:
         "empty_names": empty_names,
         "empty_status": empty_status,
         "empty_share_lead": empty_share_lead,
+        "empty_image_subtitle": empty_image_subtitle,
         "top3": top3,
     }
 
@@ -1869,8 +1909,6 @@ def _build_facts(s: dict, stats: dict, tr) -> list[dict]:
         ):
             fact[key] = template[key].format(**ctx)
         facts.append(fact)
-    if empty_count:
-        facts[-1]["map_label"] = copy["map_all"]
     return facts
 
 


### PR DESCRIPTION
## Summary
- Rework summary trivia facts into multilingual social-sharing data with separate web, X share, and future image metadata fields
- Add X intent links and GA tracking attributes for each fact card across supported locales
- Keep the summary page as a list/map hub while preserving existing rankings, latest photos, no-photo items, and regional sections

## Test Plan
- python3 -m py_compile apps/scraper/generate_summary_pages.py
- python3 apps/scraper/generate_summary_pages.py
- git diff --check
- Verified generated summary HTML for all 5 locales includes X share links, data-image-type metadata, search hub, and ranking sections
