### PR TITLE
feat: ポケモンHubページ強化 — 最新画像・ランキング・タイプ/世代ナビを追加

### DIFF
--- a/apps/scraper/generate_pokemon_index_page.py
+++ b/apps/scraper/generate_pokemon_index_page.py
@@ -422,12 +422,13 @@ def _generation_label(generation: object, strings: dict) -> str:
     if isinstance(generation, int):
         if generation >= 5:
             return strings["generation_later_label"]
-        return strings["generation_label"].format(gen=generation)
+        if 1 <= generation <= 4:
+            return strings["generation_label"].format(gen=generation)
     return strings["unknown_generation"]
 
 
-def _photo_url(mid: str, photo: dict | None, image_dir: Path) -> str:
-    if mid and (image_dir / f"{mid}_latest.jpeg").exists():
+def _photo_url(mid: str, photo: dict | None, available_images: frozenset[str]) -> str:
+    if mid and mid in available_images:
         return f"{BASE_URL}manhole/image/{quote(mid, safe='')}_latest.jpeg"
     if photo and isinstance(photo.get("url"), str):
         return photo["url"]
@@ -437,7 +438,7 @@ def _photo_url(mid: str, photo: dict | None, image_dir: Path) -> str:
 def _select_latest_image(
     manholes: list[dict],
     photos_data: dict,
-    image_dir: Path,
+    available_images: frozenset[str],
     display_name: str,
     translate_pref: Callable[[str], str],
     lang: str,
@@ -453,7 +454,7 @@ def _select_latest_image(
     ]
     for photo in sorted(photo_candidates, key=lambda p: p.get("created_at", ""), reverse=True):
         mid = str(photo.get("manhole_id", "")).strip()
-        url = _photo_url(mid, photo, image_dir)
+        url = _photo_url(mid, photo, available_images)
         if not url:
             continue
         location = _location_text(records_by_id.get(mid, {}), translate_pref, lang)
@@ -468,7 +469,7 @@ def _select_latest_image(
 
     for manhole in sorted(manholes, key=lambda m: str(m.get("id", ""))):
         mid = str(manhole.get("id", "")).strip()
-        url = _photo_url(mid, None, image_dir)
+        url = _photo_url(mid, None, available_images)
         if not url:
             continue
         location = _location_text(manhole, translate_pref, lang)
@@ -493,6 +494,10 @@ def _build_pokemon_cards(
     image_dir: Path,
 ) -> list[dict]:
     url_prefix = lang_config["url_prefix"]
+    available_images = frozenset(
+        p.stem.removesuffix("_latest")
+        for p in image_dir.glob("*_latest.jpeg")
+    ) if image_dir.exists() else frozenset()
     cards = []
     for slug, (meta, manholes) in pokemon_index.items():
         display_name = _get_display_name(meta, lang_config)
@@ -502,7 +507,6 @@ def _build_pokemon_cards(
         card = {
             "slug": slug,
             "href": _pokemon_href(url_prefix, slug),
-            "meta": meta,
             "name": display_name,
             "name_en": meta.get("names", {}).get("en", ""),
             "count": count,
@@ -514,7 +518,7 @@ def _build_pokemon_cards(
             "summary": _region_summary(manholes, count, strings, translate_pref),
         }
         card["latest_image"] = _select_latest_image(
-            manholes, photos_data, image_dir, display_name,
+            manholes, photos_data, available_images, display_name,
             translate_pref, lang, strings,
         )
         cards.append(card)
@@ -552,6 +556,7 @@ def generate_html(
         pokemon_index, lang, lang_config, strings, translate_pref,
         photos_data, image_dir,
     )
+    cards_by_slug = {c["slug"]: c for c in cards}
 
     def image_html(card: dict, class_name: str = "card-photo") -> str:
         image = card.get("latest_image")
@@ -614,7 +619,7 @@ def generate_html(
     for slug in REGIONAL_POKEMON_SLUGS:
         if slug not in pokemon_index:
             continue
-        card = next((c for c in cards if c["slug"] == slug), None)
+        card = cards_by_slug.get(slug)
         if not card:
             continue
         tagline = REGIONAL_TAGLINES.get(slug, {}).get(lang, REGIONAL_TAGLINES.get(slug, {}).get("en", ""))
@@ -657,7 +662,7 @@ def generate_html(
         )
     ranking_html = "\n".join(ranking_items)
 
-    featured_cards = [card for slug in FEATURED_POKEMON_SLUGS for card in cards if card["slug"] == slug]
+    featured_cards = [cards_by_slug[slug] for slug in FEATURED_POKEMON_SLUGS if slug in cards_by_slug]
     featured_html = "".join(card_html(card, "featured-card") for card in featured_cards)
 
     type_groups: dict[str, list[dict]] = defaultdict(list)

--- a/apps/scraper/generate_pokemon_index_page.py
+++ b/apps/scraper/generate_pokemon_index_page.py
@@ -11,6 +11,7 @@ import argparse
 import json
 import logging
 import sys
+from collections import defaultdict
 from collections.abc import Callable
 from pathlib import Path
 from urllib.parse import quote
@@ -35,19 +36,28 @@ logger = logging.getLogger(__name__)
 # UI strings per language for the Pokemon index page.
 LP_INDEX_STRINGS: dict[str, dict] = {
     "ja": {
-        "title": "ポケふたに登場するポケモン一覧 | 全国のポケモンマンホールマップ",
+        "title": "ポケモン別ポケふた一覧｜登場ポケモンから探すポケモンマンホール",
         "description": (
-            "全国各地に設置された「ポケふた（ポケモンマンホール）」に登場するポケモン一覧です。"
-            "北海道のロコンや香川県のヤドン、宮城県のラプラスなど、地域を応援するポケモンとして"
-            "描かれたポケふたも人気があります。気になるポケモンから、全国のポケふたや設置自治体を探せます。"
+            "全国のポケモンマンホール「ポケふた」を登場ポケモン別に探せる一覧ページです。"
+            "ピカチュウ、イーブイ、カビゴンなど、ポケふたに登場するポケモンから設置場所を探せます。"
         ),
-        "og_title": "ポケふたに登場するポケモン一覧",
-        "h1": "ポケふたに登場するポケモン一覧",
+        "og_title": "ポケモン別ポケふた一覧",
+        "h1": "ポケモン別ポケふた一覧",
         "lead": (
-            "全国各地に設置された「ポケふた（ポケモンマンホール）」に登場するポケモン一覧です。"
-            "北海道のロコンや香川県のヤドン、宮城県のラプラスなど、地域を応援するポケモンとして描かれたポケふたも人気があります。"
-            "気になるポケモンから、全国のポケふたや設置自治体を探せます。"
+            "全国に広がるポケモンマンホール「ポケふた」を、登場ポケモン別に探せます。"
+            "好きなポケモンがどの地域のポケふたに登場しているかを見たり、"
+            "旅先で出会えるポケふたを探したりできます。"
         ),
+        "hub_heading": "ポケふたをポケモン別に探す",
+        "hub_name": "ポケモン名で探す",
+        "hub_ranking": "登場数ランキングを見る",
+        "hub_taxonomy": "タイプ・世代から探す",
+        "hub_map": "地図で設置場所を見る",
+        "summary_link": "ポケふた統計・一覧ハブへ戻る",
+        "ranking_heading": "登場数ランキング",
+        "featured_heading": "人気・代表ポケモン",
+        "type_heading": "タイプ別に探す",
+        "generation_heading": "世代別に探す",
         "regional_heading": "地域を応援するポケモン",
         "all_heading": "全ポケモン一覧（{total}体）",
         "map_nav_hint": "都道府県ごとのポケふたは<a href='{map_href}'>全国マップ</a>から地域を選んで確認できます。",
@@ -58,6 +68,15 @@ LP_INDEX_STRINGS: dict[str, dict] = {
         "region_summary_unknown": "所在地不明",
         "region_summary_fmt": "{count}枚 / {region}",
         "region_summary_pref_count": "{n}都道府県",
+        "count_label": "{count}枚",
+        "pref_count_label": "{count}都道府県",
+        "pokemon_count_label": "{count}体",
+        "rank_label": "{rank}位",
+        "type_label": "タイプ",
+        "generation_label": "第{gen}世代",
+        "generation_later_label": "第5世代以降",
+        "unknown_generation": "世代不明",
+        "latest_image_alt": "{name}のポケふた（{location}）",
         "popular_intro": (
             "登場回数が多いポケモンほど、全国各地で出会いやすいポケモンです。"
             "{top3}などは{min_count}枚以上のポケふたに登場しており、"
@@ -67,19 +86,27 @@ LP_INDEX_STRINGS: dict[str, dict] = {
         "jsonld_name": "ポケふたに登場するポケモン一覧",
     },
     "en": {
-        "title": "Pokémon on Pokéfuta — Full List | Pokémon Manhole Map of Japan",
+        "title": "Pokefuta by Pokémon | Find Pokémon Manhole Covers by Featured Pokémon",
         "description": (
-            "Complete list of Pokémon featured on Pokéfuta (Pokémon manhole covers) installed across Japan. "
-            "Includes regional favorites such as Vulpix in Hokkaido, Slowpoke in Kagawa, and Lapras in Miyagi. "
-            "Find Pokéfuta locations and municipalities for any Pokémon you love."
+            "Browse Japan's Pokefuta Pokémon manhole covers by featured Pokémon. "
+            "Find locations for Pikachu, Eevee, Snorlax, and other Pokémon appearing on Pokefuta."
         ),
-        "og_title": "Pokémon on Pokéfuta — Full List",
-        "h1": "Pokémon on Pokéfuta — Full List",
+        "og_title": "Pokefuta by Pokémon",
+        "h1": "Pokefuta by Pokémon",
         "lead": (
-            "Complete list of Pokémon featured on Pokéfuta (Pokémon manhole covers) installed across Japan. "
-            "Includes regional favorites such as Vulpix in Hokkaido, Slowpoke in Kagawa, and Lapras in Miyagi. "
-            "Tap any Pokémon to see installation locations and plan your trip."
+            "Explore Japan's Pokefuta Pokémon manhole covers by the Pokémon featured on them. "
+            "See where your favorite Pokémon appear and find Pokefuta to visit on your trip."
         ),
+        "hub_heading": "Find Pokefuta by Pokémon",
+        "hub_name": "Search by Pokémon",
+        "hub_ranking": "View appearance rankings",
+        "hub_taxonomy": "Browse by type and generation",
+        "hub_map": "View locations on the map",
+        "summary_link": "Back to the Pokefuta summary hub",
+        "ranking_heading": "Appearance Ranking",
+        "featured_heading": "Popular Pokémon",
+        "type_heading": "Browse by Type",
+        "generation_heading": "Browse by Generation",
         "regional_heading": "Regional Pokémon",
         "all_heading": "All Pokémon ({total})",
         "map_nav_hint": "Browse Pokéfuta by prefecture on the <a href='{map_href}'>Japan Map</a>.",
@@ -90,6 +117,15 @@ LP_INDEX_STRINGS: dict[str, dict] = {
         "region_summary_unknown": "Location unknown",
         "region_summary_fmt": "{count} / {region}",
         "region_summary_pref_count": "{n} prefectures",
+        "count_label": "{count} Pokefuta",
+        "pref_count_label": "{count} prefectures",
+        "pokemon_count_label": "{count} Pokémon",
+        "rank_label": "#{rank}",
+        "type_label": "Type",
+        "generation_label": "Gen {gen}",
+        "generation_later_label": "Gen 5+",
+        "unknown_generation": "Generation unknown",
+        "latest_image_alt": "{name} Pokefuta in {location}",
         "popular_intro": (
             "Pokémon that appear on more Pokéfuta are easier to find across Japan. "
             "{top3} and others appear on {min_count}+ Pokéfuta, "
@@ -99,19 +135,27 @@ LP_INDEX_STRINGS: dict[str, dict] = {
         "jsonld_name": "Pokémon on Pokéfuta — Full List",
     },
     "zh-CN": {
-        "title": "宝可夢井盖上的宝可梦一览 | 日本宝可梦井盖地图",
+        "title": "按宝可梦查找宝可梦井盖一览 | 日本宝可梦井盖地图",
         "description": (
-            "日本各地设置的「宝可梦井盖（Pokéfuta）」上登场的宝可梦一览。"
-            "包括北海道的六尾、香川县的呆呆兽、宫城县的拉普拉斯等代表各地区的宝可梦。"
-            "从喜欢的宝可梦查找全国各地的宝可梦井盖和设置市区町村。"
+            "按登场宝可梦查找日本全国的宝可梦井盖（Pokéfuta）。"
+            "可从皮卡丘、伊布、卡比兽等宝可梦查看设置地点。"
         ),
-        "og_title": "宝可梦井盖上的宝可梦一览",
-        "h1": "宝可梦井盖上的宝可梦一览",
+        "og_title": "按宝可梦查找宝可梦井盖",
+        "h1": "按宝可梦查找宝可梦井盖",
         "lead": (
-            "日本各地设置的「宝可梦井盖（Pokéfuta）」上登场的宝可梦一览。"
-            "包括北海道的六尾、香川县的呆呆兽、宫城县的拉普拉斯等代表各地区的宝可梦。"
-            "点击感兴趣的宝可梦，查看设置地点并规划行程。"
+            "日本全国的宝可梦井盖（Pokéfuta）可按登场宝可梦查找。"
+            "看看喜欢的宝可梦出现在哪些地区，也可以为旅行寻找想去看的井盖。"
         ),
+        "hub_heading": "按宝可梦查找井盖",
+        "hub_name": "按宝可梦名称查找",
+        "hub_ranking": "查看登场数排行",
+        "hub_taxonomy": "按属性・世代查找",
+        "hub_map": "在地图上查看地点",
+        "summary_link": "返回宝可梦井盖统计中心",
+        "ranking_heading": "登场数排行",
+        "featured_heading": "热门・代表宝可梦",
+        "type_heading": "按属性查找",
+        "generation_heading": "按世代查找",
         "regional_heading": "代表各地区的宝可梦",
         "all_heading": "全部宝可梦（{total}只）",
         "map_nav_hint": "可从<a href='{map_href}'>全国地图</a>按都道府县查看宝可梦井盖分布。",
@@ -122,6 +166,15 @@ LP_INDEX_STRINGS: dict[str, dict] = {
         "region_summary_unknown": "位置不明",
         "region_summary_fmt": "{count}个 / {region}",
         "region_summary_pref_count": "{n}个都道府县",
+        "count_label": "{count}个",
+        "pref_count_label": "{count}个都道府县",
+        "pokemon_count_label": "{count}只",
+        "rank_label": "第{rank}名",
+        "type_label": "属性",
+        "generation_label": "第{gen}世代",
+        "generation_later_label": "第5世代以后",
+        "unknown_generation": "世代不明",
+        "latest_image_alt": "{location}的{name}宝可梦井盖",
         "popular_intro": (
             "登场次数越多的宝可梦，越容易在全国各地相遇。"
             "{top3}等宝可梦登场的宝可梦井盖达{min_count}个以上，"
@@ -131,19 +184,27 @@ LP_INDEX_STRINGS: dict[str, dict] = {
         "jsonld_name": "宝可梦井盖上的宝可梦一览",
     },
     "zh-TW": {
-        "title": "寶可夢人孔蓋上的寶可夢一覽 | 日本寶可夢人孔蓋地圖",
+        "title": "按寶可夢查找寶可夢人孔蓋一覽 | 日本寶可夢人孔蓋地圖",
         "description": (
-            "日本各地設置的「寶可夢人孔蓋（Pokéfuta）」上登場的寶可夢一覽。"
-            "包括北海道的六尾、香川縣的呆呆獸、宮城縣的拉普拉斯等代表各地區的寶可夢。"
-            "從喜歡的寶可夢查找全國各地的寶可夢人孔蓋和設置市區町村。"
+            "按登場寶可夢查找日本全國的寶可夢人孔蓋（Pokéfuta）。"
+            "可從皮卡丘、伊布、卡比獸等寶可夢查看設置地點。"
         ),
-        "og_title": "寶可夢人孔蓋上的寶可夢一覽",
-        "h1": "寶可夢人孔蓋上的寶可夢一覽",
+        "og_title": "按寶可夢查找寶可夢人孔蓋",
+        "h1": "按寶可夢查找寶可夢人孔蓋",
         "lead": (
-            "日本各地設置的「寶可夢人孔蓋（Pokéfuta）」上登場的寶可夢一覽。"
-            "包括北海道的六尾、香川縣的呆呆獸、宮城縣的拉普拉斯等代表各地區的寶可夢。"
-            "點擊感興趣的寶可夢，查看設置地點並規劃行程。"
+            "日本全國的寶可夢人孔蓋（Pokéfuta）可按登場寶可夢查找。"
+            "看看喜歡的寶可夢出現在哪些地區，也可以為旅行尋找想去看的井蓋。"
         ),
+        "hub_heading": "按寶可夢查找人孔蓋",
+        "hub_name": "按寶可夢名稱查找",
+        "hub_ranking": "查看登場數排行",
+        "hub_taxonomy": "按屬性・世代查找",
+        "hub_map": "在地圖上查看地點",
+        "summary_link": "返回寶可夢人孔蓋統計中心",
+        "ranking_heading": "登場數排行",
+        "featured_heading": "熱門・代表寶可夢",
+        "type_heading": "按屬性查找",
+        "generation_heading": "按世代查找",
         "regional_heading": "代表各地區的寶可夢",
         "all_heading": "全部寶可夢（{total}隻）",
         "map_nav_hint": "可從<a href='{map_href}'>全國地圖</a>按都道府縣查看寶可夢人孔蓋分布。",
@@ -154,6 +215,15 @@ LP_INDEX_STRINGS: dict[str, dict] = {
         "region_summary_unknown": "位置不明",
         "region_summary_fmt": "{count}個 / {region}",
         "region_summary_pref_count": "{n}個都道府縣",
+        "count_label": "{count}個",
+        "pref_count_label": "{count}個都道府縣",
+        "pokemon_count_label": "{count}隻",
+        "rank_label": "第{rank}名",
+        "type_label": "屬性",
+        "generation_label": "第{gen}世代",
+        "generation_later_label": "第5世代以後",
+        "unknown_generation": "世代不明",
+        "latest_image_alt": "{location}的{name}寶可夢人孔蓋",
         "popular_intro": (
             "登場次數越多的寶可夢，越容易在全國各地相遇。"
             "{top3}等寶可夢登場的寶可夢人孔蓋達{min_count}個以上，"
@@ -163,19 +233,27 @@ LP_INDEX_STRINGS: dict[str, dict] = {
         "jsonld_name": "寶可夢人孔蓋上的寶可夢一覽",
     },
     "ko": {
-        "title": "포케후타에 등장하는 포켓몬 목록 | 일본 포켓몬 맨홀 지도",
+        "title": "포켓몬별 포케후타 목록 | 등장 포켓몬으로 찾는 포켓몬 맨홀",
         "description": (
-            "일본 전국에 설치된 「포케후타（포켓몬 맨홀）」에 등장하는 포켓몬 목록입니다. "
-            "홋카이도의 식스테일, 카가와현의 야돈, 미야기현의 라프라스 등 지역을 응원하는 포켓몬도 인기입니다. "
-            "좋아하는 포켓몬으로 전국의 포케후타와 설치 지자체를 찾아보세요."
+            "일본 전국의 포켓몬 맨홀 「포케후타」를 등장 포켓몬별로 찾는 목록 페이지입니다. "
+            "피카츄, 이브이, 잠만보 등 포케후타에 등장하는 포켓몬으로 설치 장소를 찾을 수 있습니다."
         ),
-        "og_title": "포케후타에 등장하는 포켓몬 목록",
-        "h1": "포케후타에 등장하는 포켓몬 목록",
+        "og_title": "포켓몬별 포케후타 목록",
+        "h1": "포켓몬별 포케후타 목록",
         "lead": (
-            "일본 전국에 설치된 「포케후타（포켓몬 맨홀）」에 등장하는 포켓몬 목록입니다. "
-            "홋카이도의 식스테일, 카가와현의 야돈, 미야기현의 라프라스 등 지역을 응원하는 포켓몬도 인기입니다. "
-            "좋아하는 포켓몬을 탭해서 설치 장소와 여행 루트를 확인해 보세요."
+            "일본 전국에 퍼져 있는 포켓몬 맨홀 「포케후타」를 등장 포켓몬별로 찾을 수 있습니다. "
+            "좋아하는 포켓몬이 어느 지역의 포케후타에 등장하는지 보고, 여행지에서 만날 포케후타를 찾아보세요."
         ),
+        "hub_heading": "포켓몬별로 포케후타 찾기",
+        "hub_name": "포켓몬 이름으로 찾기",
+        "hub_ranking": "등장 수 랭킹 보기",
+        "hub_taxonomy": "타입・세대로 찾기",
+        "hub_map": "지도에서 설치 장소 보기",
+        "summary_link": "포케후타 통계 허브로 돌아가기",
+        "ranking_heading": "등장 수 랭킹",
+        "featured_heading": "인기・대표 포켓몬",
+        "type_heading": "타입별로 찾기",
+        "generation_heading": "세대별로 찾기",
         "regional_heading": "지역을 응원하는 포켓몬",
         "all_heading": "모든 포켓몬（{total}마리）",
         "map_nav_hint": "<a href='{map_href}'>전국 지도</a>에서 현별로 포케후타를 확인할 수 있습니다.",
@@ -186,6 +264,15 @@ LP_INDEX_STRINGS: dict[str, dict] = {
         "region_summary_unknown": "위치 불명",
         "region_summary_fmt": "{count}개 / {region}",
         "region_summary_pref_count": "{n}개 현",
+        "count_label": "{count}개",
+        "pref_count_label": "{count}개 현",
+        "pokemon_count_label": "{count}마리",
+        "rank_label": "{rank}위",
+        "type_label": "타입",
+        "generation_label": "{gen}세대",
+        "generation_later_label": "5세대 이후",
+        "unknown_generation": "세대 불명",
+        "latest_image_alt": "{location}의 {name} 포케후타",
         "popular_intro": (
             "등장 횟수가 많은 포켓몬일수록 전국 각지에서 만나기 쉽습니다. "
             "{top3} 등은 {min_count}개 이상의 포케후타에 등장하여 "
@@ -246,6 +333,17 @@ REGIONAL_POKEMON_SLUGS: list[str] = [
     "vulpix", "vulpix-alola", "slowpoke", "lapras", "geodude", "chansey",
 ]
 
+FEATURED_POKEMON_SLUGS: list[str] = [
+    "pikachu", "eevee", "snorlax", "lapras",
+    "vulpix", "magikarp", "slowpoke", "meowth",
+]
+
+TYPE_ORDER_JA: list[str] = [
+    "ノーマル", "ほのお", "みず", "でんき", "くさ", "こおり",
+    "かくとう", "どく", "じめん", "ひこう", "エスパー", "むし",
+    "いわ", "ゴースト", "ドラゴン", "あく", "はがね", "フェアリー",
+]
+
 
 def _region_summary(
     manholes: list[dict],
@@ -264,6 +362,165 @@ def _region_summary(
     return strings["region_summary_fmt"].format(count=count, region=region_text)
 
 
+def load_photos(path: Path) -> dict:
+    """Load latest-manhole-photos.json."""
+    if not path.exists():
+        logger.warning(f"Latest photos file not found: {path}")
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        logger.warning(f"Failed to read latest photos ({exc})")
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _pokemon_href(url_prefix: str, slug: str) -> str:
+    return f"/{url_prefix}pokemon/{quote(slug)}/"
+
+
+def _map_href(url_prefix: str) -> str:
+    return f"/{url_prefix}" if url_prefix else "/"
+
+
+def _summary_href(url_prefix: str) -> str:
+    return f"/{url_prefix}summary/" if url_prefix else "/summary/"
+
+
+def _location_text(manhole: dict, translate_pref: Callable[[str], str], lang: str) -> str:
+    pref = manhole.get("prefecture", "")
+    city = manhole.get("city", "")
+    pref_display = translate_pref(pref) if pref else ""
+    if pref_display and city:
+        return pref_display + city if lang == "ja" else f"{pref_display} {city}"
+    return pref_display or city or manhole.get("title", "")
+
+
+def _type_labels(meta: dict, lang_config: dict) -> list[str]:
+    labels = []
+    for type_data in meta.get("types", []):
+        if not isinstance(type_data, dict):
+            continue
+        if lang_config["name_key"] == "ja":
+            label = type_data.get("ja") or type_data.get("en", "")
+        else:
+            label = type_data.get("en") or type_data.get("ja", "")
+        if label:
+            labels.append(label)
+    return labels
+
+
+def _type_keys(meta: dict) -> list[str]:
+    keys = []
+    for type_data in meta.get("types", []):
+        if isinstance(type_data, dict) and type_data.get("ja"):
+            keys.append(type_data["ja"])
+    return keys
+
+
+def _generation_label(generation: object, strings: dict) -> str:
+    if isinstance(generation, int):
+        if generation >= 5:
+            return strings["generation_later_label"]
+        return strings["generation_label"].format(gen=generation)
+    return strings["unknown_generation"]
+
+
+def _photo_url(mid: str, photo: dict | None, image_dir: Path) -> str:
+    if mid and (image_dir / f"{mid}_latest.jpeg").exists():
+        return f"{BASE_URL}manhole/image/{quote(mid, safe='')}_latest.jpeg"
+    if photo and isinstance(photo.get("url"), str):
+        return photo["url"]
+    return ""
+
+
+def _select_latest_image(
+    manholes: list[dict],
+    photos_data: dict,
+    image_dir: Path,
+    display_name: str,
+    translate_pref: Callable[[str], str],
+    lang: str,
+    strings: dict,
+) -> dict | None:
+    ids = {str(m.get("id", "")).strip() for m in manholes if m.get("id")}
+    photos = photos_data.get("photos", {}) if isinstance(photos_data, dict) else {}
+    records_by_id = {str(m.get("id", "")).strip(): m for m in manholes}
+
+    photo_candidates = [
+        p for p in photos.values()
+        if str(p.get("manhole_id", "")).strip() in ids
+    ]
+    for photo in sorted(photo_candidates, key=lambda p: p.get("created_at", ""), reverse=True):
+        mid = str(photo.get("manhole_id", "")).strip()
+        url = _photo_url(mid, photo, image_dir)
+        if not url:
+            continue
+        location = _location_text(records_by_id.get(mid, {}), translate_pref, lang)
+        return {
+            "url": url,
+            "manhole_id": mid,
+            "location": location,
+            "alt": strings["latest_image_alt"].format(
+                name=display_name, location=location or strings["region_summary_unknown"]
+            ),
+        }
+
+    for manhole in sorted(manholes, key=lambda m: str(m.get("id", ""))):
+        mid = str(manhole.get("id", "")).strip()
+        url = _photo_url(mid, None, image_dir)
+        if not url:
+            continue
+        location = _location_text(manhole, translate_pref, lang)
+        return {
+            "url": url,
+            "manhole_id": mid,
+            "location": location,
+            "alt": strings["latest_image_alt"].format(
+                name=display_name, location=location or strings["region_summary_unknown"]
+            ),
+        }
+    return None
+
+
+def _build_pokemon_cards(
+    pokemon_index: dict[str, tuple[dict, list[dict]]],
+    lang: str,
+    lang_config: dict,
+    strings: dict,
+    translate_pref: Callable[[str], str],
+    photos_data: dict,
+    image_dir: Path,
+) -> list[dict]:
+    url_prefix = lang_config["url_prefix"]
+    cards = []
+    for slug, (meta, manholes) in pokemon_index.items():
+        display_name = _get_display_name(meta, lang_config)
+        count = len(manholes)
+        prefs = {m.get("prefecture") for m in manholes if m.get("prefecture")}
+        generation = meta.get("generation")
+        card = {
+            "slug": slug,
+            "href": _pokemon_href(url_prefix, slug),
+            "meta": meta,
+            "name": display_name,
+            "name_en": meta.get("names", {}).get("en", ""),
+            "count": count,
+            "pref_count": len(prefs),
+            "types": _type_labels(meta, lang_config),
+            "type_keys": _type_keys(meta),
+            "generation": generation,
+            "generation_label": _generation_label(generation, strings),
+            "summary": _region_summary(manholes, count, strings, translate_pref),
+        }
+        card["latest_image"] = _select_latest_image(
+            manholes, photos_data, image_dir, display_name,
+            translate_pref, lang, strings,
+        )
+        cards.append(card)
+    return sorted(cards, key=lambda c: (-c["count"], c["name"]))
+
+
 def _hreflang_links_index() -> str:
     """Generate hreflang <link> tags for all language variants of the Pokemon index."""
     lines = []
@@ -280,70 +537,193 @@ def generate_html(
     lang_config: dict,
     strings: dict,
     translate_pref: Callable[[str], str],
+    photos_data: dict,
+    image_dir: Path,
 ) -> str:
     total_count = len(pokemon_index)
     url_prefix = lang_config["url_prefix"]
-    map_href = f"/{url_prefix}" if url_prefix else "/"
+    map_href = _map_href(url_prefix)
+    summary_href = _summary_href(url_prefix)
     canonical_url = f"{BASE_URL}{url_prefix}pokemon/"
     map_url = f"{BASE_URL}{url_prefix}"
 
     hreflang_html = _hreflang_links_index()
+    cards = _build_pokemon_cards(
+        pokemon_index, lang, lang_config, strings, translate_pref,
+        photos_data, image_dir,
+    )
+
+    def image_html(card: dict, class_name: str = "card-photo") -> str:
+        image = card.get("latest_image")
+        if not image:
+            return ""
+        return (
+            f'<span class="{class_name}">'
+            f'<img src="{escape(image["url"])}" alt="{escape(image["alt"])}" '
+            f'loading="lazy" decoding="async" width="320" height="180">'
+            f"</span>"
+        )
+
+    def meta_html(card: dict) -> str:
+        type_text = " / ".join(card["types"])
+        parts = []
+        if type_text:
+            parts.append(f'{strings["type_label"]}: {type_text}')
+        if card["generation_label"]:
+            parts.append(card["generation_label"])
+        return "".join(f'<span class="poke-chip">{escape(part)}</span>' for part in parts)
+
+    def count_html(card: dict) -> str:
+        return (
+            f'<span>{escape(strings["count_label"].format(count=card["count"]))}</span>'
+            f'<span>{escape(strings["pref_count_label"].format(count=card["pref_count"]))}</span>'
+        )
+
+    def card_html(card: dict, class_name: str = "poke-card") -> str:
+        en_html = (
+            f'<span class="poke-en">{escape(card["name_en"])}</span>'
+            if card["name_en"] and lang != "en" else ""
+        )
+        return (
+            f'<article class="{class_name}">'
+            f'<a href="{escape(card["href"])}">'
+            f'{image_html(card)}'
+            f'<span class="poke-card-body">'
+            f'<span class="poke-name">{escape(card["name"])}</span>'
+            f'{en_html}'
+            f'<span class="poke-counts">{count_html(card)}</span>'
+            f'<span class="poke-meta">{meta_html(card)}</span>'
+            f'<span class="poke-summary">{escape(card["summary"])}</span>'
+            f'</span>'
+            f'</a></article>'
+        )
+
+    def compact_links(section_cards: list[dict], limit: int = 8) -> str:
+        links = []
+        for card in section_cards[:limit]:
+            links.append(
+                f'<a href="{escape(card["href"])}">'
+                f'{escape(card["name"])}'
+                f'<span>{escape(strings["count_label"].format(count=card["count"]))}</span>'
+                f'</a>'
+            )
+        return "".join(links)
 
     # Regional Pokémon section
     regional_items: list[str] = []
     for slug in REGIONAL_POKEMON_SLUGS:
         if slug not in pokemon_index:
             continue
-        meta, manholes = pokemon_index[slug]
-        display_name = _get_display_name(meta, lang_config)
-        name_en = meta.get("names", {}).get("en", "")
-        count = len(manholes)
-        summary = _region_summary(manholes, count, strings, translate_pref)
+        card = next((c for c in cards if c["slug"] == slug), None)
+        if not card:
+            continue
         tagline = REGIONAL_TAGLINES.get(slug, {}).get(lang, REGIONAL_TAGLINES.get(slug, {}).get("en", ""))
-        en_html = f"<span class='poke-en'>{escape(name_en)}</span>" if name_en and lang != "en" else ""
+        en_span = (
+            f"<span class='poke-en'>{escape(card['name_en'])}</span>"
+            if card["name_en"] and lang != "en" else ""
+        )
         regional_items.append(
             f"<li class='regional-item'>"
-            f"<a href='/{url_prefix}pokemon/{quote(slug)}/'>"
-            f"<span class='poke-name'>{escape(display_name)}</span>"
-            f"{en_html}"
+            f"<a href='{escape(card['href'])}'>"
+            f"{image_html(card, 'regional-photo')}"
+            f"<span class='poke-name'>{escape(card['name'])}</span>"
+            f"{en_span}"
             f"<span class='poke-tagline'>{escape(tagline)}</span>"
-            f"<span class='poke-summary'>{escape(summary)}</span>"
+            f"<span class='poke-summary'>{escape(card['summary'])}</span>"
             f"</a></li>"
         )
     regional_items_html = "\n".join(regional_items) + "\n" if regional_items else ""
 
-    # All Pokémon list sorted by manhole count (descending)
-    sorted_slugs = sorted(
-        pokemon_index.keys(),
-        key=lambda s: -len(pokemon_index[s][1]),
-    )
-    items: list[str] = []
-    for slug in sorted_slugs:
-        meta, manholes = pokemon_index[slug]
-        display_name = _get_display_name(meta, lang_config)
-        name_en = meta.get("names", {}).get("en", "")
-        count = len(manholes)
-        summary = _region_summary(manholes, count, strings, translate_pref)
-        en_html = f"<span class='poke-en'>{escape(name_en)}</span>" if name_en and lang != "en" else ""
-        items.append(
-            f"<li class='poke-item'>"
-            f"<a href='/{url_prefix}pokemon/{quote(slug)}/'>"
-            f"<span class='poke-name'>{escape(display_name)}</span>"
-            f"{en_html}"
-            f"<span class='poke-summary'>{escape(summary)}</span>"
-            f"</a></li>"
+    ranking_items = []
+    for rank, card in enumerate(cards[:10], start=1):
+        en_html = (
+            f'<span class="poke-en">{escape(card["name_en"])}</span>'
+            if card["name_en"] and lang != "en" else ""
         )
-    items_html = "".join(items)
+        ranking_image = (
+            image_html(card, "ranking-photo")
+            or '<span class="ranking-photo image-placeholder"></span>'
+        )
+        ranking_items.append(
+            f'<li class="ranking-item">'
+            f'<a href="{escape(card["href"])}">'
+            f'<span class="ranking-rank">{escape(strings["rank_label"].format(rank=rank))}</span>'
+            f'{ranking_image}'
+            f'<span class="ranking-main">'
+            f'<span class="poke-name">{escape(card["name"])}</span>{en_html}'
+            f'<span class="poke-counts">{count_html(card)}</span>'
+            f'</span>'
+            f'</a></li>'
+        )
+    ranking_html = "\n".join(ranking_items)
+
+    featured_cards = [card for slug in FEATURED_POKEMON_SLUGS for card in cards if card["slug"] == slug]
+    featured_html = "".join(card_html(card, "featured-card") for card in featured_cards)
+
+    type_groups: dict[str, list[dict]] = defaultdict(list)
+    type_label_by_key: dict[str, str] = {}
+    for card in cards:
+        for idx, key in enumerate(card["type_keys"]):
+            type_groups[key].append(card)
+            if idx < len(card["types"]) and key not in type_label_by_key:
+                type_label_by_key[key] = card["types"][idx]
+    ordered_type_keys = [key for key in TYPE_ORDER_JA if key in type_groups]
+    ordered_type_keys.extend(sorted(key for key in type_groups if key not in ordered_type_keys))
+    type_sections = []
+    for key in ordered_type_keys:
+        group = sorted(type_groups[key], key=lambda c: (-c["count"], c["name"]))
+        type_sections.append(
+            f'<section class="taxonomy-card" id="type-{quote(key, safe="")}">'
+            f'<h3>{escape(type_label_by_key.get(key, key))}</h3>'
+            f'<p>{escape(strings["pokemon_count_label"].format(count=len(group)))}</p>'
+            f'<div class="taxonomy-links">{compact_links(group)}</div>'
+            f'</section>'
+        )
+    type_html = "\n".join(type_sections)
+
+    generation_groups: dict[str, list[dict]] = defaultdict(list)
+    generation_order = ["1", "2", "3", "4", "5plus", "unknown"]
+    generation_labels = {
+        "1": strings["generation_label"].format(gen=1),
+        "2": strings["generation_label"].format(gen=2),
+        "3": strings["generation_label"].format(gen=3),
+        "4": strings["generation_label"].format(gen=4),
+        "5plus": strings["generation_later_label"],
+        "unknown": strings["unknown_generation"],
+    }
+    for card in cards:
+        gen = card["generation"]
+        if isinstance(gen, int) and 1 <= gen <= 4:
+            key = str(gen)
+        elif isinstance(gen, int) and gen >= 5:
+            key = "5plus"
+        else:
+            key = "unknown"
+        generation_groups[key].append(card)
+    generation_sections = []
+    for key in generation_order:
+        if key not in generation_groups:
+            continue
+        group = sorted(generation_groups[key], key=lambda c: (-c["count"], c["name"]))
+        generation_sections.append(
+            f'<section class="taxonomy-card" id="generation-{key}">'
+            f'<h3>{escape(generation_labels[key])}</h3>'
+            f'<p>{escape(strings["pokemon_count_label"].format(count=len(group)))}</p>'
+            f'<div class="taxonomy-links">{compact_links(group)}</div>'
+            f'</section>'
+        )
+    generation_html = "\n".join(generation_sections)
+
+    items_html = "".join(f"<li>{card_html(card)}</li>" for card in cards)
 
     # Popular intro text
     name_joiner = lang_config.get("pref_joiner", "・")
     top3_names = name_joiner.join(
-        _get_display_name(pokemon_index[s][0], lang_config)
-        for s in sorted_slugs[:3]
+        card["name"] for card in cards[:3]
     )
     top3_min_count = (
-        min(len(pokemon_index[s][1]) for s in sorted_slugs[:3])
-        if sorted_slugs else 0
+        min(card["count"] for card in cards[:3])
+        if cards else 0
     )
     popular_intro = escape(
         strings["popular_intro"].format(top3=top3_names, min_count=top3_min_count)
@@ -377,6 +757,21 @@ def generate_html(
         ],
     }, ensure_ascii=False, indent=2)
 
+    jsonld_item_list = json.dumps({
+        "@context": "https://schema.org",
+        "@type": "ItemList",
+        "name": strings["ranking_heading"],
+        "itemListElement": [
+            {
+                "@type": "ListItem",
+                "position": rank,
+                "name": card["name"],
+                "url": f"{BASE_URL}{url_prefix}pokemon/{quote(card['slug'])}/",
+            }
+            for rank, card in enumerate(cards[:10], start=1)
+        ],
+    }, ensure_ascii=False, indent=2)
+
     return f"""<!doctype html>
 <html lang="{lang_config['html_lang']}">
 <head>
@@ -406,6 +801,9 @@ def generate_html(
   <script type="application/ld+json">
 {jsonld_breadcrumb}
   </script>
+  <script type="application/ld+json">
+{jsonld_item_list}
+  </script>
 
   <!-- Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id={GA_MEASUREMENT_ID}"></script>
@@ -419,19 +817,25 @@ def generate_html(
 
   <style>
     * {{ box-sizing: border-box; margin: 0; padding: 0; }}
+    html, body {{
+      width: 100%;
+      overflow-x: hidden;
+    }}
     body {{
       font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
       line-height: 1.6;
       color: #333;
-      background: #fff8ec;
+      background: #f7f8f3;
       padding: 16px;
+      overflow-wrap: anywhere;
     }}
     .container {{
-      max-width: 800px;
+      width: 100%;
+      max-width: 1080px;
       margin: 0 auto;
       background: white;
-      border-radius: 12px;
-      padding: 20px;
+      border-radius: 8px;
+      padding: 22px;
       box-shadow: 0 4px 16px rgba(0,0,0,0.08);
     }}
     .breadcrumb {{ font-size: 13px; color: #888; margin-bottom: 16px; }}
@@ -440,7 +844,7 @@ def generate_html(
     .breadcrumb a {{ color: #6F55A3; text-decoration: none; }}
     .breadcrumb a:hover {{ text-decoration: underline; }}
     h1 {{
-      font-size: 24px;
+      font-size: 28px;
       font-weight: bold;
       color: #1a1a1a;
       margin-bottom: 8px;
@@ -454,26 +858,47 @@ def generate_html(
       border-bottom: 2px solid #e0e0e0;
     }}
     .lead {{
-      font-size: 14px;
+      font-size: 15px;
       color: #555;
       line-height: 1.75;
-      margin-bottom: 4px;
+      margin-bottom: 14px;
     }}
-    .poke-list, .regional-list {{
+    .hub-grid, .poke-list, .regional-list, .featured-grid, .taxonomy-grid {{
       list-style: none;
       display: grid;
-      gap: 6px;
+      gap: 10px;
+    }}
+    .hub-grid {{
+      grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+      margin: 16px 0 8px;
+    }}
+    .hub-card {{
+      display: block;
+      padding: 14px;
+      background: #f0faf9;
+      border: 1px solid #c9e9e4;
+      border-radius: 8px;
+      color: #176f68;
+      text-decoration: none;
+      font-weight: bold;
+      min-width: 0;
     }}
     .regional-list {{
-      grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
     }}
     .poke-list {{
-      grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+      grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
     }}
-    .poke-item a, .regional-item a {{
+    .featured-grid {{
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }}
+    .taxonomy-grid {{
+      grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+    }}
+    .poke-card a, .featured-card a, .regional-item a, .ranking-item a {{
       display: flex;
       flex-direction: column;
-      padding: 8px 12px;
+      overflow: hidden;
       background: #fafafa;
       border: 1px solid #e8e8e8;
       border-radius: 8px;
@@ -482,13 +907,33 @@ def generate_html(
       transition: border-color 0.15s, box-shadow 0.15s;
       height: 100%;
     }}
-    .poke-item a:hover, .regional-item a:hover {{
+    .poke-card a:hover, .featured-card a:hover, .regional-item a:hover, .ranking-item a:hover, .hub-card:hover {{
       border-color: #6F55A3;
       box-shadow: 0 2px 8px rgba(111,85,163,0.12);
     }}
     .regional-item a {{
       background: #f5f0ff;
       border-color: #d8ccf0;
+      padding: 0 0 12px;
+    }}
+    .card-photo, .regional-photo, .ranking-photo {{
+      display: block;
+      width: 100%;
+      aspect-ratio: 16 / 9;
+      background: #eee;
+      overflow: hidden;
+    }}
+    .card-photo img, .regional-photo img, .ranking-photo img {{
+      display: block;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }}
+    .poke-card-body {{
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      padding: 10px 12px 12px;
     }}
     .poke-name {{
       font-size: 15px;
@@ -500,17 +945,75 @@ def generate_html(
       color: #888;
       margin-top: 1px;
     }}
+    .poke-counts {{
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      font-size: 12px;
+      font-weight: bold;
+      color: #176f68;
+    }}
+    .poke-meta {{
+      display: flex;
+      flex-wrap: wrap;
+      gap: 5px;
+    }}
+    .poke-chip {{
+      display: inline-block;
+      padding: 2px 7px;
+      border-radius: 999px;
+      background: #eef2e6;
+      color: #46563a;
+      font-size: 11px;
+      line-height: 1.4;
+    }}
     .poke-tagline {{
       font-size: 12px;
       color: #6F55A3;
       margin-top: 4px;
       font-weight: bold;
+      padding: 0 12px;
     }}
     .poke-summary {{
       font-size: 12px;
       color: #666;
       margin-top: auto;
       padding-top: 4px;
+    }}
+    .regional-item .poke-name, .regional-item .poke-en, .regional-item .poke-summary {{
+      padding-left: 12px;
+      padding-right: 12px;
+    }}
+    .ranking-list {{
+      list-style: none;
+      display: grid;
+      gap: 8px;
+    }}
+    .ranking-item a {{
+      display: grid;
+      grid-template-columns: 64px 116px minmax(0, 1fr);
+      align-items: center;
+      min-height: 82px;
+      padding: 8px;
+    }}
+    .ranking-rank {{
+      font-weight: bold;
+      color: #6F55A3;
+      text-align: center;
+    }}
+    .ranking-photo {{
+      border-radius: 6px;
+    }}
+    .image-placeholder {{
+      background: linear-gradient(135deg, #eef2e6, #f7f8f3);
+      border: 1px solid #dde4d3;
+    }}
+    .ranking-main {{
+      display: flex;
+      flex-direction: column;
+      gap: 3px;
+      min-width: 0;
+      padding-left: 10px;
     }}
     .popular-intro {{
       font-size: 13px;
@@ -521,6 +1024,42 @@ def generate_html(
       background: #f5f0ff;
       border-left: 3px solid #6F55A3;
       border-radius: 0 6px 6px 0;
+    }}
+    .taxonomy-card {{
+      border: 1px solid #e8e8e8;
+      border-radius: 8px;
+      padding: 12px;
+      background: #fcfcfb;
+    }}
+    .taxonomy-card h3 {{
+      font-size: 15px;
+      margin-bottom: 2px;
+    }}
+    .taxonomy-card p {{
+      font-size: 12px;
+      color: #777;
+      margin-bottom: 8px;
+    }}
+    .taxonomy-links {{
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+    }}
+    .taxonomy-links a {{
+      display: inline-flex;
+      gap: 5px;
+      align-items: center;
+      padding: 4px 8px;
+      background: #f0ebfa;
+      border-radius: 999px;
+      color: #6F55A3;
+      text-decoration: none;
+      font-size: 12px;
+      font-weight: bold;
+    }}
+    .taxonomy-links span {{
+      color: #777;
+      font-weight: normal;
     }}
     .map-nav-hint {{
       font-size: 13px;
@@ -551,6 +1090,19 @@ def generate_html(
       color: #aaa;
     }}
     footer a {{ color: #6F55A3; text-decoration: none; }}
+    @media (max-width: 620px) {{
+      body {{ padding: 10px; }}
+      .container {{
+        width: auto;
+        max-width: calc(100vw - 20px);
+        padding: 16px;
+      }}
+      h1 {{ font-size: 24px; }}
+      .hub-grid {{ grid-template-columns: 1fr; }}
+      .ranking-item a {{
+        grid-template-columns: 50px 84px minmax(0, 1fr);
+      }}
+    }}
   </style>
 </head>
 <body>
@@ -564,12 +1116,50 @@ def generate_html(
 
   <h1>{h1}</h1>
   <p class="lead">{lead}</p>
+  <section aria-labelledby="hub-heading">
+    <h2 id="hub-heading">{escape(strings["hub_heading"])}</h2>
+    <div class="hub-grid">
+      <a class="hub-card" href="#pokemon-list">{escape(strings["hub_name"])}</a>
+      <a class="hub-card" href="#pokemon-ranking">{escape(strings["hub_ranking"])}</a>
+      <a class="hub-card" href="#pokemon-types">{escape(strings["hub_taxonomy"])}</a>
+      <a class="hub-card" href="{escape(map_href)}">{escape(strings["hub_map"])}</a>
+    </div>
+    <p class="map-nav-hint"><a href="{escape(summary_href)}">{escape(strings["summary_link"])}</a></p>
+  </section>
+
+  <section aria-labelledby="pokemon-ranking">
+    <h2 id="pokemon-ranking">{escape(strings["ranking_heading"])}</h2>
+    <ol class="ranking-list">
+{ranking_html}
+    </ol>
+  </section>
+
+  <section aria-labelledby="featured-pokemon">
+    <h2 id="featured-pokemon">{escape(strings["featured_heading"])}</h2>
+    <div class="featured-grid">
+{featured_html}
+    </div>
+  </section>
 
   <h2>{regional_heading}</h2>
   <ul class="regional-list">
 {regional_items_html}  </ul>
 
-  <h2>{all_heading}</h2>
+  <section aria-labelledby="pokemon-types">
+    <h2 id="pokemon-types">{escape(strings["type_heading"])}</h2>
+    <div class="taxonomy-grid">
+{type_html}
+    </div>
+  </section>
+
+  <section aria-labelledby="pokemon-generations">
+    <h2 id="pokemon-generations">{escape(strings["generation_heading"])}</h2>
+    <div class="taxonomy-grid">
+{generation_html}
+    </div>
+  </section>
+
+  <h2 id="pokemon-list">{all_heading}</h2>
   <p class="popular-intro">{popular_intro}</p>
   <ul class="poke-list">
 {items_html}  </ul>
@@ -590,6 +1180,8 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--manholes", default="docs/pokefuta.ndjson")
     parser.add_argument("--pokemon", default="docs/pokemon_metadata.json")
+    parser.add_argument("--photos", default="docs/latest-manhole-photos.json")
+    parser.add_argument("--images", default="dataset/manhole/image")
     parser.add_argument(
         "--output-root", default="dist",
         help="Root output directory (default: dist). Index goes to {output-root}/pokemon/ for ja.",
@@ -615,6 +1207,8 @@ def main() -> int:
         return 1
 
     pref_data = load_prefectures(Path(args.prefectures))
+    photos_data = load_photos(Path(args.photos))
+    image_dir = Path(args.images)
     pokemon_index = build_pokemon_index(manholes, metadata)
     logger.info(f"Pokemon with active pokefuta: {len(pokemon_index)}")
 
@@ -643,7 +1237,10 @@ def main() -> int:
             output_dir = output_root / "pokemon"
 
         output_dir.mkdir(parents=True, exist_ok=True)
-        html = generate_html(pokemon_index, lang, lc, strings, translate_pref)
+        html = generate_html(
+            pokemon_index, lang, lc, strings, translate_pref,
+            photos_data, image_dir,
+        )
         (output_dir / "index.html").write_text(html, encoding="utf-8")
         logger.info(f"[{lang}] Written: {output_dir}/index.html")
 

--- a/apps/scraper/generate_pokemon_pages.py
+++ b/apps/scraper/generate_pokemon_pages.py
@@ -148,6 +148,9 @@ LP_STRINGS: dict[str, dict[str, str]] = {
         "pref_section_heading": "{pref}の{name}のポケふた",
         "pref_map_link": "{pref}の地図で見る →",
         "related_heading": "関連するポケモン",
+        "same_type_heading": "同じタイプのポケモン",
+        "same_generation_heading": "同じ世代のポケモン",
+        "summary_link": "ポケふた統計・一覧ハブ",
         "count_text": "全国に <strong>{count}</strong> 枚の{name}のポケふたがあります。",
         "cta": "地図で全国のポケふたを探す →",
         "breadcrumb_aria": "パンくずリスト",
@@ -170,6 +173,9 @@ LP_STRINGS: dict[str, dict[str, str]] = {
         "pref_section_heading": "{name} Pokéfuta in {pref}",
         "pref_map_link": "View {pref} on map →",
         "related_heading": "Related Pokémon",
+        "same_type_heading": "Same Type",
+        "same_generation_heading": "Same Generation",
+        "summary_link": "Pokefuta Summary Hub",
         "count_text": "There are <strong>{count}</strong> {name} Pokéfuta nationwide.",
         "cta": "Explore all Pokéfuta on the map →",
         "breadcrumb_aria": "Breadcrumb",
@@ -192,6 +198,9 @@ LP_STRINGS: dict[str, dict[str, str]] = {
         "pref_section_heading": "{pref}的{name}宝可梦井盖",
         "pref_map_link": "在地图上查看{pref} →",
         "related_heading": "相关宝可梦",
+        "same_type_heading": "相同属性的宝可梦",
+        "same_generation_heading": "相同世代的宝可梦",
+        "summary_link": "宝可梦井盖统计中心",
         "count_text": "全国共有 <strong>{count}</strong> 个{name}宝可梦井盖。",
         "cta": "在地图上查找全国宝可梦井盖 →",
         "breadcrumb_aria": "面包屑导航",
@@ -214,6 +223,9 @@ LP_STRINGS: dict[str, dict[str, str]] = {
         "pref_section_heading": "{pref}的{name}寶可夢人孔蓋",
         "pref_map_link": "在地圖上查看{pref} →",
         "related_heading": "相關寶可夢",
+        "same_type_heading": "相同屬性的寶可夢",
+        "same_generation_heading": "相同世代的寶可夢",
+        "summary_link": "寶可夢人孔蓋統計中心",
         "count_text": "全國共有 <strong>{count}</strong> 個{name}寶可夢人孔蓋。",
         "cta": "在地圖上查找全國寶可夢人孔蓋 →",
         "breadcrumb_aria": "麵包屑導覽",
@@ -236,6 +248,9 @@ LP_STRINGS: dict[str, dict[str, str]] = {
         "pref_section_heading": "{pref}의 {name} 포케후타",
         "pref_map_link": "{pref} 지도로 보기 →",
         "related_heading": "관련 포켓몬",
+        "same_type_heading": "같은 타입 포켓몬",
+        "same_generation_heading": "같은 세대 포켓몬",
+        "summary_link": "포케후타 통계 허브",
         "count_text": "전국에 <strong>{count}</strong>개의 {name} 포케후타가 있습니다.",
         "cta": "지도에서 전국의 포케후타 찾기 →",
         "breadcrumb_aria": "이동 경로",
@@ -497,6 +512,59 @@ def build_related_map(
     return result
 
 
+def build_taxonomy_related_map(
+    index: dict[str, tuple[dict, list[dict]]],
+) -> dict[str, dict[str, list[tuple[str, dict]]]]:
+    """Return same-type and same-generation related Pokemon for visible LPs."""
+    type_to_slugs: dict[str, list[str]] = defaultdict(list)
+    generation_to_slugs: dict[int, list[str]] = defaultdict(list)
+
+    for slug, (meta, _manholes) in index.items():
+        for type_data in meta.get("types", []):
+            if isinstance(type_data, dict) and type_data.get("ja"):
+                type_to_slugs[type_data["ja"]].append(slug)
+        generation = meta.get("generation")
+        if isinstance(generation, int):
+            generation_to_slugs[generation].append(slug)
+
+    def sort_key(slug: str) -> tuple[int, str]:
+        meta, manholes = index[slug]
+        name = meta.get("names", {}).get("ja", slug)
+        return (-len(manholes), name)
+
+    result: dict[str, dict[str, list[tuple[str, dict]]]] = {}
+    for slug, (meta, _manholes) in index.items():
+        same_type_slugs: list[str] = []
+        seen = {slug}
+        for type_data in meta.get("types", []):
+            type_key = type_data.get("ja") if isinstance(type_data, dict) else ""
+            for related_slug in sorted(type_to_slugs.get(type_key, []), key=sort_key):
+                if related_slug in seen:
+                    continue
+                same_type_slugs.append(related_slug)
+                seen.add(related_slug)
+                if len(same_type_slugs) >= 8:
+                    break
+            if len(same_type_slugs) >= 8:
+                break
+
+        same_generation_slugs: list[str] = []
+        generation = meta.get("generation")
+        if isinstance(generation, int):
+            for related_slug in sorted(generation_to_slugs.get(generation, []), key=sort_key):
+                if related_slug == slug:
+                    continue
+                same_generation_slugs.append(related_slug)
+                if len(same_generation_slugs) >= 8:
+                    break
+
+        result[slug] = {
+            "same_type": [(s, index[s][0]) for s in same_type_slugs],
+            "same_generation": [(s, index[s][0]) for s in same_generation_slugs],
+        }
+    return result
+
+
 def _hreflang_links(slug: str) -> str:
     """Generate hreflang <link> tags for all language variants of a Pokemon page."""
     lines = []
@@ -514,6 +582,7 @@ def generate_html(
     pokemon: dict,
     manholes: list[dict],
     related: list[tuple[str, dict]],
+    taxonomy_related: dict[str, list[tuple[str, dict]]],
     image_dir: Path,
     lang: str,
     lang_config: dict,
@@ -542,6 +611,7 @@ def generate_html(
     map_url = f"{BASE_URL}{url_prefix}"
     pokemon_list_url = f"/{url_prefix}pokemon/" if url_prefix else "/pokemon/"
     map_href = f"/{url_prefix}" if url_prefix else "/"
+    summary_href = f"/{url_prefix}summary/" if url_prefix else "/summary/"
 
     count = len(manholes)
 
@@ -669,18 +739,45 @@ def generate_html(
             f"</section>"
         )
 
-    # Related Pokemon section
-    related_html = ""
-    if related:
-        links = "".join(
+    def related_links_html(related_items: list[tuple[str, dict]]) -> str:
+        return "".join(
             f"<li><a href='/{url_prefix}pokemon/{quote(s)}/'>"
             f"{escape(_get_display_name(meta, lang_config))}</a></li>"
-            for s, meta in related
+            for s, meta in related_items
+        )
+
+    related_blocks: list[str] = []
+    if related:
+        related_blocks.append(
+            f"<section>"
+            f"<h2>{escape(strings['related_heading'])}</h2>"
+            f"<ul class='related-list'>{related_links_html(related)}</ul>"
+            f"</section>"
+        )
+    same_type = taxonomy_related.get("same_type", []) if taxonomy_related else []
+    if same_type:
+        related_blocks.append(
+            f"<section>"
+            f"<h2>{escape(strings['same_type_heading'])}</h2>"
+            f"<ul class='related-list'>{related_links_html(same_type)}</ul>"
+            f"</section>"
+        )
+    same_generation = taxonomy_related.get("same_generation", []) if taxonomy_related else []
+    if same_generation:
+        related_blocks.append(
+            f"<section>"
+            f"<h2>{escape(strings['same_generation_heading'])}</h2>"
+            f"<ul class='related-list'>{related_links_html(same_generation)}</ul>"
+            f"</section>"
+        )
+    related_html = ""
+    if related_blocks:
+        links = "".join(
+            related_blocks
         )
         related_html = (
             f"<div class='section-card related-section'>"
-            f"<h2>{escape(strings['related_heading'])}</h2>"
-            f"<ul class='related-list'>{links}</ul>"
+            f"{links}"
             f"</div>"
         )
 
@@ -906,6 +1003,24 @@ def generate_html(
       font-weight: bold;
     }}
     .related-list a:hover {{ background: #e0d8f5; }}
+    .back-links {{
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 14px;
+    }}
+    .back-links a {{
+      display: inline-block;
+      padding: 6px 12px;
+      border: 1px solid #d8ccf0;
+      border-radius: 999px;
+      color: #6F55A3;
+      text-decoration: none;
+      font-size: 13px;
+      font-weight: bold;
+      background: #fbf9ff;
+    }}
+    .back-links a:hover {{ background: #f0ebfa; }}
     .cta-map {{
       display: block;
       background: #6F55A3;
@@ -951,6 +1066,11 @@ def generate_html(
     {gen_html}
     {seo_desc_html}
     {ai_summary_html}
+    <div class="back-links">
+      <a href="{escape(pokemon_list_url)}">{escape(breadcrumb_pokemon)}</a>
+      <a href="{escape(summary_href)}">{escape(strings["summary_link"])}</a>
+      <a href="{escape(map_href)}">{escape(breadcrumb_home)}</a>
+    </div>
   </div>
 
   <div class="section-card">
@@ -1017,6 +1137,7 @@ def main() -> int:
     logger.info(f"Pokemon with pokefuta: {len(index)}")
 
     related_map = build_related_map(index, metadata)
+    taxonomy_related_map = build_taxonomy_related_map(index)
     image_dir = Path(args.images)
     output_root = Path(args.output_root)
 
@@ -1052,6 +1173,7 @@ def main() -> int:
                 pokemon=pokemon,
                 manholes=poke_manholes,
                 related=related_map.get(slug, []),
+                taxonomy_related=taxonomy_related_map.get(slug, {}),
                 image_dir=image_dir,
                 lang=lang,
                 lang_config=lc,

--- a/apps/scraper/generate_pokemon_pages.py
+++ b/apps/scraper/generate_pokemon_pages.py
@@ -772,12 +772,9 @@ def generate_html(
         )
     related_html = ""
     if related_blocks:
-        links = "".join(
-            related_blocks
-        )
         related_html = (
             f"<div class='section-card related-section'>"
-            f"{links}"
+            f"{''.join(related_blocks)}"
             f"</div>"
         )
 


### PR DESCRIPTION
## 概要

Codexが修正した2ファイルをレビューしてPR化。

### generate_pokemon_index_page.py

- **ハブナビ追加**: ポケモン名検索・ランキング・タイプ/世代・マップへのクイックリンク
- **ランキングセクション**: 登場数上位10体を写真付きリストで表示
- **注目ポケモンセクション**: ピカチュウ・イーブイなど代表ポケモンをカード表示
- **タイプ/世代タクソノミー**: タイプ別・世代別にポケモンを一覧できるセクション
- **最新写真表示**: `latest-manhole-photos.json` + `dataset/manhole/image/` から各カードに写真を表示（`_select_latest_image`）
- **SEO改善**: 5言語のタイトル・説明文・h1を更新、JSON-LD ItemList スキーマ追加
- **CLI引数追加**: `--photos`, `--images`
- **レスポンシブCSS**: コンテナ幅1080px・モバイル対応

### generate_pokemon_pages.py

- **同タイプ関連ポケモン**: `same_type_heading` セクションを追加
- **同世代関連ポケモン**: `same_generation_heading` セクションを追加
- **戻りナビ追加**: ポケモン一覧・サマリーハブ・マップへのリンク（`.back-links`）
- **`build_taxonomy_related_map()` 新設**: タイプ・世代ベースの関連ポケモンマップを構築
- **5言語対応**: `same_type_heading`, `same_generation_heading`, `summary_link` 追加

## テスト計画

- [ ] `generate_pokemon_index_page.py` をローカル実行してHTMLを目視確認
- [ ] 写真なし環境でのフォールバック（placeholder表示）を確認
- [ ] `generate_pokemon_pages.py` で同タイプ/同世代セクションが表示されることを確認
- [ ] CI（pages-deploy.yml）が正常に通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)