### PR TITLE
fix: summaryページOGP画像URLにキャッシュバスティング用バージョンパラメータを追加

### DIFF
--- a/apps/scraper/generate_summary_pages.py
+++ b/apps/scraper/generate_summary_pages.py
@@ -11,6 +11,7 @@ Outputs:
 
 from __future__ import annotations
 
+import hashlib
 import json
 import sys
 from pathlib import Path
@@ -26,7 +27,9 @@ PHOTOS_JSON = ROOT / "docs" / "latest-manhole-photos.json"
 IMAGE_DIR = ROOT / "dataset" / "manhole" / "image"
 
 BASE_URL = "https://data.pokefuta.com"
-OGP_IMAGE = f"{BASE_URL}/assets/ogp/pokefuta_summary_ogp.png"
+_OGP_PNG = ROOT / "apps" / "web" / "assets" / "ogp" / "pokefuta_summary_ogp.png"
+_ogp_hash = hashlib.md5(_OGP_PNG.read_bytes()).hexdigest()[:8] if _OGP_PNG.exists() else "0"
+OGP_IMAGE = f"{BASE_URL}/assets/ogp/pokefuta_summary_ogp.png?v={_ogp_hash}"
 SUMMARY_SHARE_URL = f"{BASE_URL}/summary"
 
 PREFECTURE_ORDER: list[str] = [


### PR DESCRIPTION
## Summary
- `pokefuta_summary_ogp.png` のMD5ハッシュ先頭8文字を `?v=` として付加するよう変更
- 画像が更新されるたびにURLが変わり、SNS（Twitter/X・Facebook等）のOGPキャッシュが自動的に無効化される
- PNGが存在しない場合は `?v=0` にフォールバック

## Motivation
PR #173 でOGP画像の統計値を修正したが、SNSプラットフォームが古い画像をキャッシュし続ける問題があった。

## Test plan
- [ ] `generate_summary_pages.py` 実行後、生成されたHTMLの `og:image` / `twitter:image` に `?v=XXXXXXXX` が付いていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)