### PR TITLE
feat: ポップアップのポケモン名クリックで地図をフィルタリング

### DIFF
--- a/apps/web/assets/pokefuta-map.css
+++ b/apps/web/assets/pokefuta-map.css
@@ -855,6 +855,17 @@ body.pokefuta-map-page {
   color: #4a3080;
 }
 
+.pokefuta-map-page button.travel-popup-pokemon--filter {
+  border: none;
+  cursor: pointer;
+}
+
+.pokefuta-map-page button.travel-popup-pokemon--filter:hover,
+.pokefuta-map-page button.travel-popup-pokemon--filter:focus-visible {
+  background: rgba(101, 74, 160, .22);
+  color: #4a3080;
+}
+
 .pokefuta-map-page .travel-popup-actions {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/apps/web/gmanhole_map.html
+++ b/apps/web/gmanhole_map.html
@@ -152,6 +152,9 @@
   </div>
   <div id="map"></div>
   <footer class="data-links" role="contentinfo" style="margin:16px auto 0; max-width:960px; text-align:center; font-size:0.9rem; color:#444;">
+    <p style="margin:0 0 4px;">
+      <a href="https://x.com/pokemonmanhole" target="_blank" rel="noopener noreferrer" style="color:#888; font-size:0.82rem; text-decoration:none;">𝕏 @pokemonmanhole — 公式更新情報</a>
+    </p>
     <p style="margin:0;">
       <a href="./">ポケふたマップ</a>
       /

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -395,6 +395,10 @@
           <span class="badge-label" style="font-weight:600;">選択中:</span> <span class="badge-value"></span>
           <button type="button" class="badge-clear" aria-label="選択解除" onclick="clearPrefectureSelection()">×</button>
         </div>
+        <div id="selected-pokemon-badge" class="selected-prefecture-badge" style="display:none;">
+          <span class="badge-label" style="font-weight:600;">ポケモン:</span> <span class="badge-value"></span>
+          <button type="button" class="badge-clear" aria-label="ポケモンフィルター解除" onclick="clearPokemonFilter()">×</button>
+        </div>
         <section id="prefecture-spots-panel" class="prefecture-spots-panel" hidden>
           <div class="section-title-row">
             <h4 id="prefecture-spots-heading">県内のポケふた</h4>
@@ -682,10 +686,8 @@
       const pokemons = Array.isArray(d.pokemons) && d.pokemons.length ? d.pokemons : [];
       const pokemonsHtml = pokemons.length
         ? pokemons.map(pokemon => {
-            const url = getPokemonLpUrl(pokemon);
-            return url
-              ? `<a href="${escapeHtml(url)}" class="travel-popup-pokemon" target="_blank" rel="noopener noreferrer">${escapeHtml(pokemon)}</a>`
-              : `<span class="travel-popup-pokemon">${escapeHtml(pokemon)}</span>`;
+            const safeJs = escapeJs(pokemon);
+            return `<button type="button" class="travel-popup-pokemon travel-popup-pokemon--filter" onclick="filterByPokemon('${safeJs}')">${escapeHtml(pokemon)}</button>`;
           }).join('')
         : '<span class="travel-popup-pokemon">ポケモン未設定</span>';
       const imageUrl = getLocalManholeImageUrl(d.id);
@@ -1356,6 +1358,33 @@
       filterByPrefectureFromTable('');
       showSelectedPrefectureBadge();
       renderPrefectureSpots('');
+    }
+
+    function filterByPokemon(name) {
+      if (!name) return;
+      selectedPokemons = selectedPokemons.length === 1 && selectedPokemons[0] === name ? [] : [name];
+      showSelectedPokemonBadge();
+      recomputeVisibility();
+      map.closePopup();
+    }
+
+    function showSelectedPokemonBadge() {
+      const badge = document.getElementById('selected-pokemon-badge');
+      const val = badge?.querySelector('.badge-value');
+      if (!badge || !val) return;
+      if (selectedPokemons.length > 0) {
+        val.textContent = selectedPokemons.join(', ');
+        badge.style.display = 'inline-block';
+      } else {
+        badge.style.display = 'none';
+        val.textContent = '';
+      }
+    }
+
+    function clearPokemonFilter() {
+      selectedPokemons = [];
+      showSelectedPokemonBadge();
+      recomputeVisibility();
     }
 
     function togglePrefectureSelection(prefecture) {

--- a/apps/web/index.template.html
+++ b/apps/web/index.template.html
@@ -433,6 +433,9 @@
   </nav>
 
   <footer class="data-links" role="contentinfo" style="margin:16px auto 0; max-width:960px; text-align:center; font-size:0.9rem; color:#444;">
+    <p style="margin:0 0 4px;">
+      <a href="https://x.com/pokemonmanhole" target="_blank" rel="noopener noreferrer" style="color:#888; font-size:0.82rem; text-decoration:none;">𝕏 @pokemonmanhole — 公式更新情報</a>
+    </p>
     <p style="margin:0;">
       %%FOOTER_EXPORT%%
       <a href="%%BASE_PATH%%pokefuta.ndjson" target="_blank" rel="noopener">NDJSON</a>


### PR DESCRIPTION
## Summary

- ポップアップ内のポケモン名タグをクリック可能なボタンに変更（旧: slug ありは外部リンク、なしはプレーンテキスト）
- クリックすると地図をそのポケモンに絞り込み、ポップアップを閉じる
- 同じポケモンを再クリックでトグル解除、右パネルの「ポケモン: ○○ ×」バッジからも解除可能

## Test plan

- [ ] マーカーをクリックしてポップアップを開き、ポケモン名ボタンをクリック → 地図が絞り込まれることを確認
- [ ] バッジ「ポケモン: ○○ ×」が右パネルに表示されることを確認
- [ ] × ボタンでフィルター解除、全マーカーが復元されることを確認
- [ ] 同じポケモンを再クリックでもフィルター解除されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)