### PR TITLE
fix: ポップアップのポケモン名クリックをフィルタ→詳細ページ遷移に変更

### DIFF
--- a/apps/web/assets/pokefuta-map.css
+++ b/apps/web/assets/pokefuta-map.css
@@ -855,17 +855,6 @@ body.pokefuta-map-page {
   color: #4a3080;
 }
 
-.pokefuta-map-page button.travel-popup-pokemon--filter {
-  border: none;
-  cursor: pointer;
-}
-
-.pokefuta-map-page button.travel-popup-pokemon--filter:hover,
-.pokefuta-map-page button.travel-popup-pokemon--filter:focus-visible {
-  background: rgba(101, 74, 160, .22);
-  color: #4a3080;
-}
-
 .pokefuta-map-page .travel-popup-actions {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -395,10 +395,6 @@
           <span class="badge-label" style="font-weight:600;">選択中:</span> <span class="badge-value"></span>
           <button type="button" class="badge-clear" aria-label="選択解除" onclick="clearPrefectureSelection()">×</button>
         </div>
-        <div id="selected-pokemon-badge" class="selected-prefecture-badge" style="display:none;">
-          <span class="badge-label" style="font-weight:600;">ポケモン:</span> <span class="badge-value"></span>
-          <button type="button" class="badge-clear" aria-label="ポケモンフィルター解除" onclick="clearPokemonFilter()">×</button>
-        </div>
         <section id="prefecture-spots-panel" class="prefecture-spots-panel" hidden>
           <div class="section-title-row">
             <h4 id="prefecture-spots-heading">県内のポケふた</h4>
@@ -512,7 +508,6 @@
     var cityCounts = {};
     var selectedPrefecture = '';
     var pokemonCounts = {};
-    var selectedPokemons = [];
     var currentTab = 'prefecture';
     var filterRecent = false; // recent 30 days filter
     var showPrefectureCards = true;
@@ -686,8 +681,10 @@
       const pokemons = Array.isArray(d.pokemons) && d.pokemons.length ? d.pokemons : [];
       const pokemonsHtml = pokemons.length
         ? pokemons.map(pokemon => {
-            const safeJs = escapeJs(pokemon);
-            return `<button type="button" class="travel-popup-pokemon travel-popup-pokemon--filter" onclick="filterByPokemon('${safeJs}')">${escapeHtml(pokemon)}</button>`;
+            const url = getPokemonLpUrl(pokemon);
+            return url
+              ? `<a href="${escapeHtml(url)}" class="travel-popup-pokemon" target="_blank" rel="noopener noreferrer">${escapeHtml(pokemon)}</a>`
+              : `<span class="travel-popup-pokemon">${escapeHtml(pokemon)}</span>`;
           }).join('')
         : '<span class="travel-popup-pokemon">ポケモン未設定</span>';
       const imageUrl = getLocalManholeImageUrl(d.id);
@@ -1301,11 +1298,7 @@
         const d = marker.pokefutaData;
         let show = true;
         if (selectedPrefecture) show = show && d.prefecture === selectedPrefecture;
-        if (selectedPokemons.length > 0) {
-          const pList = d.pokemons || [];
-          show = show && selectedPokemons.some(p => pList.includes(p));
-        }
-  if (filterRecent) show = show && isWithinLastDays(d._addedDate, 30);
+        if (filterRecent) show = show && isWithinLastDays(d._addedDate, 30);
         if (show) {
           if (markerLayer && !markerLayer.hasLayer(marker)) markerLayer.addLayer(marker);
           visibleCount++;
@@ -1358,33 +1351,6 @@
       filterByPrefectureFromTable('');
       showSelectedPrefectureBadge();
       renderPrefectureSpots('');
-    }
-
-    function filterByPokemon(name) {
-      if (!name) return;
-      selectedPokemons = selectedPokemons.length === 1 && selectedPokemons[0] === name ? [] : [name];
-      showSelectedPokemonBadge();
-      recomputeVisibility();
-      map.closePopup();
-    }
-
-    function showSelectedPokemonBadge() {
-      const badge = document.getElementById('selected-pokemon-badge');
-      const val = badge?.querySelector('.badge-value');
-      if (!badge || !val) return;
-      if (selectedPokemons.length > 0) {
-        val.textContent = selectedPokemons.join(', ');
-        badge.style.display = 'inline-block';
-      } else {
-        badge.style.display = 'none';
-        val.textContent = '';
-      }
-    }
-
-    function clearPokemonFilter() {
-      selectedPokemons = [];
-      showSelectedPokemonBadge();
-      recomputeVisibility();
     }
 
     function togglePrefectureSelection(prefecture) {


### PR DESCRIPTION
## Summary

- ポップアップのポケモン名クリックで地図フィルタリングしていた動作を廃止
- 既存の `/pokemon/{slug}/` 詳細ページへのリンク（新タブ）に変更
- `getPokemonLpUrl()` を使用。メタデータ未ロード時は `<span>` にフォールバック
- フィルタバッジ (`#selected-pokemon-badge`)・関連 JS 関数 3 件・CSS ボタンスタイルを除去

## Background

PR #176 で実装したフィルタリングは、ユーザーがポケモン名をタップした際の探索意図（そのポケモンについて詳しく知りたい）と乖離しており体験が悪かった。詳細ページへ遷移する方が自然なフローと判断。

## Test plan

- [ ] マーカーをクリック → ポップアップ表示
- [ ] ポケモン名をクリック → `/pokemon/{slug}/` が新タブで開く
- [ ] 地図が絞り込まれないことを確認
- [ ] フィルタバッジが表示されないことを確認
- [ ] 都道府県フィルタなど他のフィルタが正常動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)