### PR TITLE
Update manhole semantic metadata (20260607)

### DIFF
--- a/dataset/manhole_titles.json
+++ b/dataset/manhole_titles.json
@@ -1117,6 +1117,12 @@
       ],
       "confidence": 3
     },
+    "301": {
+      "tags": [
+        "museum",
+        "park"
+      ]
+    },
     "306": {
       "tags": [
         "seaside"
@@ -1323,6 +1329,36 @@
     "358": {
       "tags": [
         "seaside"
+      ]
+    },
+    "359": {
+      "tags": [
+        "tourism",
+        "park"
+      ]
+    },
+    "360": {
+      "tags": [
+        "tourism"
+      ]
+    },
+    "361": {
+      "tags": [
+        "tourism",
+        "museum"
+      ]
+    },
+    "362": {
+      "tags": [
+        "tourism",
+        "museum",
+        "history",
+        "park"
+      ]
+    },
+    "363": {
+      "tags": [
+        "tourism"
       ]
     },
     "365": {
@@ -1637,10 +1673,10 @@
       ]
     },
     "448": {
-      "prefecture": "東京都",
-      "city": "稲城市",
       "building": "ポケパーク カントー",
-      "address_norm": "東京都稲城市矢野口4015-1 ポケパーク カントー敷地内"
+      "address_norm": "東京都稲城市矢野口4015-1 ポケパーク カントー敷地内",
+      "prefecture": "東京都",
+      "city": "稲城市"
     },
     "450": {
       "tags": [


### PR DESCRIPTION
## Summary

semantic metadata をセマンティックエディタで更新しました。

## 変更内容

- assign_tourism_tags: 6件

対象マンホール数（ユニーク）: 6件

## Tasks

- assign_tourism_tags: 6件

## Guardrails

- docs/pokefuta.ndjson は変更されていません
- dataset/manhole_titles.json のみ変更されています

## Validation

- [x] JSON parse OK
- [x] schema OK
- [x] docs/*.ndjson 汚染なし
- [x] changes.ndjson で操作ログ確認済み

🤖 Generated with Semantic Manhole Metadata Editor