### PR TITLE
feat: 新タグ3種追加（道の駅・駅から遠い・世界遺産）＋エディタ改善

### DIFF
--- a/.claude/commands/tag-editor.md
+++ b/.claude/commands/tag-editor.md
@@ -1,0 +1,13 @@
+タグ追加ツール（manhole-semantic-editor）を起動する。
+
+```bash
+# Kill anything already on 5177
+_pid=$(lsof -ti:5177 2>/dev/null)
+[ -n "$_pid" ] && kill "$_pid" && echo "[tag-editor] stopped previous server on :5177" || true
+
+# Launch the editor
+cd "$(git rev-parse --show-toplevel)/tools/manhole-semantic-editor"
+npm run dev &
+sleep 1
+echo "[tag-editor] http://localhost:5177"
+```

--- a/apps/scraper/manhole_titles.py
+++ b/apps/scraper/manhole_titles.py
@@ -272,12 +272,27 @@ def compute_titles(manhole: dict, ctx: dict, *, nc50: int, nc100: int) -> list[d
         if t := _entry("seaside"):
             results.append(t)
 
+    # roadside: 道の駅タグ
+    if "roadside" in tags:
+        if t := _entry("roadside"):
+            results.append(t)
+
+    # world_heritage: 世界遺産タグ
+    if "world_heritage" in tags:
+        if t := _entry("world_heritage"):
+            results.append(t)
+
     # station_front / near_station: 駅前・駅近タグ（より具体的な方のみ表示）
     if "station_front" in tags:
         if t := _entry("station_front"):
             results.append(t)
     elif "near_station" in tags:
         if t := _entry("near_station"):
+            results.append(t)
+
+    # far_station: 駅から遠いタグ（駅近系と独立）
+    if "far_station" in tags:
+        if t := _entry("far_station"):
             results.append(t)
 
     # lakeside: check lakes list

--- a/dataset/manhole_titles.json
+++ b/dataset/manhole_titles.json
@@ -131,6 +131,27 @@
       "label": "湖畔のポケふた（{lake}）",
       "hashtag": "#湖畔ポケふた",
       "priority": 38
+    },
+    "roadside": {
+      "enabled": true,
+      "emoji": "🛣",
+      "label": "道の駅のポケふた",
+      "hashtag": "#道の駅ポケふた",
+      "priority": 38
+    },
+    "far_station": {
+      "enabled": true,
+      "emoji": "🚗",
+      "label": "駅から遠いポケふた",
+      "hashtag": "#ポツンとポケふた",
+      "priority": 33
+    },
+    "world_heritage": {
+      "enabled": true,
+      "emoji": "🏛",
+      "label": "世界遺産エリアのポケふた",
+      "hashtag": "#世界遺産ポケふた",
+      "priority": 85
     }
   },
   "islands": [
@@ -658,7 +679,8 @@
     },
     "104": {
       "tags": [
-        "lakeside"
+        "lakeside",
+        "world_heritage"
       ]
     },
     "105": {
@@ -707,6 +729,31 @@
       "building": "絵本の館",
       "verified_at": "2020-11-02"
     },
+    "148": {
+      "tags": [
+        "world_heritage"
+      ]
+    },
+    "149": {
+      "tags": [
+        "world_heritage"
+      ]
+    },
+    "150": {
+      "tags": [
+        "world_heritage"
+      ]
+    },
+    "151": {
+      "tags": [
+        "world_heritage"
+      ]
+    },
+    "152": {
+      "tags": [
+        "world_heritage"
+      ]
+    },
     "153": {
       "tags": [
         "seaside"
@@ -732,14 +779,45 @@
         "seaside"
       ]
     },
+    "159": {
+      "tags": [
+        "world_heritage"
+      ]
+    },
+    "160": {
+      "tags": [
+        "world_heritage"
+      ]
+    },
+    "161": {
+      "tags": [
+        "world_heritage"
+      ]
+    },
+    "162": {
+      "tags": [
+        "world_heritage"
+      ]
+    },
+    "163": {
+      "tags": [
+        "world_heritage"
+      ]
+    },
     "165": {
       "tags": [
         "seaside"
       ]
     },
+    "174": {
+      "tags": [
+        "world_heritage"
+      ]
+    },
     "175": {
       "tags": [
-        "seaside"
+        "seaside",
+        "world_heritage"
       ]
     },
     "187": {
@@ -758,19 +836,27 @@
         "seaside"
       ]
     },
+    "198": {
+      "tags": [
+        "world_heritage"
+      ]
+    },
     "199": {
       "tags": [
-        "seaside"
+        "seaside",
+        "world_heritage"
       ]
     },
     "201": {
       "tags": [
-        "seaside"
+        "seaside",
+        "world_heritage"
       ]
     },
     "202": {
       "tags": [
-        "seaside"
+        "seaside",
+        "world_heritage"
       ]
     },
     "203": {
@@ -793,6 +879,11 @@
       "building": "道の駅あかいがわ敷地内",
       "verified_at": "2021-11-13"
     },
+    "220": {
+      "tags": [
+        "world_heritage"
+      ]
+    },
     "221": {
       "tags": [
         "seaside"
@@ -800,7 +891,8 @@
     },
     "229": {
       "tags": [
-        "seaside"
+        "seaside",
+        "world_heritage"
       ]
     },
     "231": {
@@ -815,7 +907,8 @@
     },
     "233": {
       "tags": [
-        "seaside"
+        "seaside",
+        "world_heritage"
       ]
     },
     "234": {
@@ -940,6 +1033,11 @@
         "station_front"
       ]
     },
+    "267": {
+      "tags": [
+        "world_heritage"
+      ]
+    },
     "271": {
       "building": "愛知県/豊橋市（バクフーン）",
       "address_raw": "愛知県豊橋市",
@@ -1010,22 +1108,26 @@
     },
     "288": {
       "tags": [
-        "seaside"
+        "seaside",
+        "world_heritage"
       ]
     },
     "289": {
       "tags": [
-        "seaside"
+        "seaside",
+        "world_heritage"
       ]
     },
     "290": {
       "tags": [
-        "seaside"
+        "seaside",
+        "world_heritage"
       ]
     },
     "291": {
       "tags": [
-        "seaside"
+        "seaside",
+        "world_heritage"
       ]
     },
     "292": {
@@ -1326,6 +1428,11 @@
         "seaside"
       ]
     },
+    "357": {
+      "tags": [
+        "world_heritage"
+      ]
+    },
     "358": {
       "tags": [
         "seaside"
@@ -1379,6 +1486,11 @@
     "378": {
       "tags": [
         "seaside"
+      ]
+    },
+    "379": {
+      "tags": [
+        "world_heritage"
       ]
     },
     "380": {
@@ -1670,6 +1782,11 @@
     "445": {
       "tags": [
         "seaside"
+      ]
+    },
+    "446": {
+      "tags": [
+        "world_heritage"
       ]
     },
     "448": {

--- a/dataset/manhole_titles.json
+++ b/dataset/manhole_titles.json
@@ -148,7 +148,7 @@
     },
     "world_heritage": {
       "enabled": true,
-      "emoji": "🏛",
+      "emoji": "🏯",
       "label": "世界遺産エリアのポケふた",
       "hashtag": "#世界遺産ポケふた",
       "priority": 85

--- a/tools/manhole-semantic-editor/src/semantic/semanticPatchValidator.ts
+++ b/tools/manhole-semantic-editor/src/semantic/semanticPatchValidator.ts
@@ -8,9 +8,9 @@ export type ValidationResult = {
 }
 
 const VALID_TAGS = new Set([
-  'seaside', 'beach', 'lakeside', 'river', 'remote_island',
-  'in_station', 'station_front', 'near_station', 'rail_access_good',
-  'tourism', 'park', 'museum', 'history', 'food',
+  'seaside', 'beach', 'lakeside', 'river', 'remote_island', 'roadside',
+  'in_station', 'station_front', 'near_station', 'rail_access_good', 'far_station',
+  'tourism', 'park', 'museum', 'history', 'food', 'world_heritage',
 ])
 
 export function validatePatch(

--- a/tools/manhole-semantic-editor/src/semantic/semanticPatchValidator.ts
+++ b/tools/manhole-semantic-editor/src/semantic/semanticPatchValidator.ts
@@ -1,5 +1,6 @@
 import type { SemanticPatch, ManholeTitlesJson } from './semanticPatch'
 import { normCity } from './semanticPatchApplier'
+import { VALID_TAGS as VALID_TAGS_ARRAY } from './validTags'
 
 export type ValidationResult = {
   valid: boolean
@@ -7,11 +8,7 @@ export type ValidationResult = {
   errors: string[]
 }
 
-const VALID_TAGS = new Set([
-  'seaside', 'beach', 'lakeside', 'river', 'remote_island', 'roadside',
-  'in_station', 'station_front', 'near_station', 'rail_access_good', 'far_station',
-  'tourism', 'park', 'museum', 'history', 'food', 'world_heritage',
-])
+const VALID_TAGS: Set<string> = new Set(VALID_TAGS_ARRAY)
 
 export function validatePatch(
   patch: SemanticPatch,

--- a/tools/manhole-semantic-editor/src/semantic/validTags.ts
+++ b/tools/manhole-semantic-editor/src/semantic/validTags.ts
@@ -1,0 +1,7 @@
+export const VALID_TAGS = [
+  'seaside', 'beach', 'lakeside', 'river', 'remote_island', 'roadside',
+  'in_station', 'station_front', 'near_station', 'rail_access_good', 'far_station',
+  'tourism', 'park', 'museum', 'history', 'food', 'world_heritage',
+] as const
+
+export type ValidTag = (typeof VALID_TAGS)[number]

--- a/tools/manhole-semantic-editor/src/tasks/adminBulkEdit/AdminBulkEditTask.tsx
+++ b/tools/manhole-semantic-editor/src/tasks/adminBulkEdit/AdminBulkEditTask.tsx
@@ -2,12 +2,7 @@ import { useState, useMemo } from 'react'
 import type { PokefutaRecord, ManholeTitlesJson, SemanticPatch, OperationType } from '../../semantic/semanticPatch'
 import { generateConfirmationText } from '../../semantic/semanticPatchApplier'
 import { newPatchId } from '../../util'
-
-const VALID_TAGS = [
-  'seaside', 'beach', 'lakeside', 'river', 'remote_island', 'roadside',
-  'in_station', 'station_front', 'near_station', 'rail_access_good', 'far_station',
-  'tourism', 'park', 'museum', 'history', 'food', 'world_heritage',
-]
+import { VALID_TAGS } from '../../semantic/validTags'
 
 type Props = {
   records: PokefutaRecord[]

--- a/tools/manhole-semantic-editor/src/tasks/adminBulkEdit/AdminBulkEditTask.tsx
+++ b/tools/manhole-semantic-editor/src/tasks/adminBulkEdit/AdminBulkEditTask.tsx
@@ -4,9 +4,9 @@ import { generateConfirmationText } from '../../semantic/semanticPatchApplier'
 import { newPatchId } from '../../util'
 
 const VALID_TAGS = [
-  'seaside', 'beach', 'lakeside', 'river', 'remote_island',
-  'in_station', 'station_front', 'near_station', 'rail_access_good',
-  'tourism', 'park', 'museum', 'history', 'food',
+  'seaside', 'beach', 'lakeside', 'river', 'remote_island', 'roadside',
+  'in_station', 'station_front', 'near_station', 'rail_access_good', 'far_station',
+  'tourism', 'park', 'museum', 'history', 'food', 'world_heritage',
 ]
 
 type Props = {

--- a/tools/manhole-semantic-editor/src/tasks/assignLocationTags/AssignLocationTagsTask.tsx
+++ b/tools/manhole-semantic-editor/src/tasks/assignLocationTags/AssignLocationTagsTask.tsx
@@ -1,7 +1,7 @@
 import type { PokefutaRecord, ManholeTitlesJson, SemanticPatch } from '../../semantic/semanticPatch'
 import { MapTagsTask } from '../shared/MapTagsTask'
 
-const LOCATION_TAGS = ['seaside', 'beach', 'lakeside', 'river', 'remote_island'] as const
+const LOCATION_TAGS = ['seaside', 'beach', 'lakeside', 'river', 'remote_island', 'roadside'] as const
 
 const TAG_LABEL: Record<(typeof LOCATION_TAGS)[number], string> = {
   seaside: '🌊 海沿い',
@@ -9,6 +9,7 @@ const TAG_LABEL: Record<(typeof LOCATION_TAGS)[number], string> = {
   lakeside: '🏞 湖畔',
   river: '🌊 川沿い',
   remote_island: '🏝 離島',
+  roadside: '🛣 道の駅',
 }
 
 type Props = {

--- a/tools/manhole-semantic-editor/src/tasks/assignStationTags/AssignStationTagsTask.tsx
+++ b/tools/manhole-semantic-editor/src/tasks/assignStationTags/AssignStationTagsTask.tsx
@@ -1,13 +1,14 @@
 import type { PokefutaRecord, ManholeTitlesJson, SemanticPatch, ManholeEntry } from '../../semantic/semanticPatch'
 import { MapTagsTask } from '../shared/MapTagsTask'
 
-const STATION_TAGS = ['in_station', 'station_front', 'near_station', 'rail_access_good'] as const
+const STATION_TAGS = ['in_station', 'station_front', 'near_station', 'rail_access_good', 'far_station'] as const
 
 const TAG_LABEL: Record<(typeof STATION_TAGS)[number], string> = {
   in_station: '🚉 駅構内',
   station_front: '🏢 駅前',
   near_station: '🚶 駅近',
   rail_access_good: '🚆 アクセス良',
+  far_station: '🚗 駅から遠い',
 }
 
 function stationHint(r: PokefutaRecord, entry: ManholeEntry | undefined): boolean {

--- a/tools/manhole-semantic-editor/src/tasks/assignTourismTags/AssignTourismTagsTask.tsx
+++ b/tools/manhole-semantic-editor/src/tasks/assignTourismTags/AssignTourismTagsTask.tsx
@@ -9,7 +9,7 @@ const TAG_LABEL: Record<(typeof TOURISM_TAGS)[number], string> = {
   museum: '🏛 博物館',
   history: '🏯 歴史',
   food: '🍜 グルメ',
-  world_heritage: '🏛 世界遺産',
+  world_heritage: '🏯 世界遺産',
 }
 
 type Props = {

--- a/tools/manhole-semantic-editor/src/tasks/assignTourismTags/AssignTourismTagsTask.tsx
+++ b/tools/manhole-semantic-editor/src/tasks/assignTourismTags/AssignTourismTagsTask.tsx
@@ -1,7 +1,7 @@
 import type { PokefutaRecord, ManholeTitlesJson, SemanticPatch } from '../../semantic/semanticPatch'
 import { MapTagsTask } from '../shared/MapTagsTask'
 
-const TOURISM_TAGS = ['tourism', 'park', 'museum', 'history', 'food'] as const
+const TOURISM_TAGS = ['tourism', 'park', 'museum', 'history', 'food', 'world_heritage'] as const
 
 const TAG_LABEL: Record<(typeof TOURISM_TAGS)[number], string> = {
   tourism: '🗺 観光',
@@ -9,6 +9,7 @@ const TAG_LABEL: Record<(typeof TOURISM_TAGS)[number], string> = {
   museum: '🏛 博物館',
   history: '🏯 歴史',
   food: '🍜 グルメ',
+  world_heritage: '🏛 世界遺産',
 }
 
 type Props = {

--- a/tools/manhole-semantic-editor/src/tasks/shared/MapTagsTask.tsx
+++ b/tools/manhole-semantic-editor/src/tasks/shared/MapTagsTask.tsx
@@ -155,7 +155,19 @@ export function MapTagsTask({
       const hasTag = tags.some(t => currentTags.has(t))
       const isSelected = id === selectedId
       marker.setIcon(makeIcon(isSelected ? '#ef4444' : hasTag ? '#22c55e' : '#3b82f6'))
-      if (isSelected) marker.openPopup()
+      if (isSelected) {
+        const r = pageItems.find(p => p.id === id)
+        if (r) {
+          const allTags = [...currentTags].sort()
+          const tagsHtml = allTags.length > 0
+            ? `<div style="margin-top:5px;display:flex;flex-wrap:wrap;gap:3px">${allTags.map(t => `<span style="background:#f3f4f6;border:1px solid #d1d5db;border-radius:4px;padding:1px 6px;font-size:11px;color:#374151">${t}</span>`).join('')}</div>`
+            : `<div style="margin-top:4px;font-size:11px;color:#9ca3af">タグなし</div>`
+          marker.setPopupContent(
+            `<b>#${r.id}</b> ${r.prefecture} ${r.city}<br><span style="font-size:11px">${r.address}</span>${tagsHtml}`
+          )
+        }
+        marker.openPopup()
+      }
     })
 
     if (selectedId) {

--- a/tools/manhole-semantic-editor/src/tasks/shared/MapTagsTask.tsx
+++ b/tools/manhole-semantic-editor/src/tasks/shared/MapTagsTask.tsx
@@ -5,6 +5,10 @@ import type { PokefutaRecord, ManholeTitlesJson, SemanticPatch, ManholeEntry, Ta
 import { validatePatch } from '../../semantic/semanticPatchValidator'
 import { newPatchId } from '../../util'
 
+function esc(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+}
+
 const PAGE_SIZE = 10
 
 const PREF_ORDER = [
@@ -134,7 +138,7 @@ export function MapTagsTask({
     pageItems.forEach(r => {
       const marker = L.marker([r.lat, r.lng], { icon: makeIcon('#3b82f6') })
         .addTo(map)
-        .bindPopup(`<b>#${r.id}</b> ${r.prefecture} ${r.city}<br><span style="font-size:11px">${r.address}</span>`)
+        .bindPopup(`<b>#${r.id}</b> ${esc(r.prefecture)} ${esc(r.city)}<br><span style="font-size:11px">${esc(r.address)}</span>`)
         .on('click', () => setSelectedId(id => id === r.id ? null : r.id))
       markersRef.current.set(r.id, marker)
     })
@@ -160,10 +164,10 @@ export function MapTagsTask({
         if (r) {
           const allTags = [...currentTags].sort()
           const tagsHtml = allTags.length > 0
-            ? `<div style="margin-top:5px;display:flex;flex-wrap:wrap;gap:3px">${allTags.map(t => `<span style="background:#f3f4f6;border:1px solid #d1d5db;border-radius:4px;padding:1px 6px;font-size:11px;color:#374151">${t}</span>`).join('')}</div>`
+            ? `<div style="margin-top:5px;display:flex;flex-wrap:wrap;gap:3px">${allTags.map(t => `<span style="background:#f3f4f6;border:1px solid #d1d5db;border-radius:4px;padding:1px 6px;font-size:11px;color:#374151">${esc(t)}</span>`).join('')}</div>`
             : `<div style="margin-top:4px;font-size:11px;color:#9ca3af">タグなし</div>`
           marker.setPopupContent(
-            `<b>#${r.id}</b> ${r.prefecture} ${r.city}<br><span style="font-size:11px">${r.address}</span>${tagsHtml}`
+            `<b>#${r.id}</b> ${esc(r.prefecture)} ${esc(r.city)}<br><span style="font-size:11px">${esc(r.address)}</span>${tagsHtml}`
           )
         }
         marker.openPopup()


### PR DESCRIPTION
## Summary

- 新タグ vocabulary を3種追加
- 世界遺産10km圏内の28件に `world_heritage` タグを一括付与
- セマンティックエディタのタグ対応と UX 改善

## 新タグ

| タグキー | emoji | label | hashtag | priority |
|---|---|---|---|---|
| `roadside` | 🛣 | 道の駅のポケふた | #道の駅ポケふた | 38 |
| `far_station` | 🚗 | 駅から遠いポケふた | #ポツンとポケふた | 33 |
| `world_heritage` | 🏛 | 世界遺産エリアのポケふた | #世界遺産ポケふた | 85 |

## world_heritage タグ付け対象 (28件)

法隆寺(5件)・古都京都(5件)・琉球王国グスク(4件)・明治産業革命(6件)・平泉・知床・石見銀山・長崎天草 等

選定基準: 各世界遺産代表座標から10km圏内

## セマンティックエディタ変更

- `AssignLocationTagsTask` に `roadside` 追加
- `AssignStationTagsTask` に `far_station` 追加
- `AssignTourismTagsTask` に `world_heritage` 追加
- `semanticPatchValidator.ts` / `AdminBulkEditTask.tsx` の VALID_TAGS を更新
- **マーカークリック時の Leaflet ポップアップに全タグを表示**（pending 変更もリアルタイム反映）
- `/tag-editor` スキルを追加（`.claude/commands/tag-editor.md`）

## Test plan

- [ ] `dataset/manhole_titles.json` に3タグの vocabulary 定義があること
- [ ] 対象28件の `tags` に `world_heritage` が含まれること
- [ ] `/tag-editor` 起動 → 各タスク画面で新タグが表示されること
- [ ] マーカークリック → ポップアップに全タグが表示されること
- [ ] `update_pokefuta.py` 実行後、世界遺産マンホールに「🏛 世界遺産エリアのポケふた」バッジが出ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)