### PR TITLE
feat: セカンダリタグをpopupにアイコン・詳細ページにバッジ表示

### DIFF
--- a/apps/scraper/generate_manhole_pages.py
+++ b/apps/scraper/generate_manhole_pages.py
@@ -26,6 +26,17 @@ from generate_pokemon_pages import _FORM_PREFIX, _normalize_katakana  # noqa: E4
 BASE_URL = "https://data.pokefuta.com/"
 GA_MEASUREMENT_ID = "G-K18NR4GZG2"
 
+SECONDARY_TAG_LABELS: dict[str, tuple[str, str]] = {
+    'tourism':          ('🗺', '観光スポット'),
+    'park':             ('🌳', '公園'),
+    'museum':           ('🏛', '博物館・展示施設'),
+    'history':          ('🏯', '歴史スポット'),
+    'food':             ('🍜', 'グルメ'),
+    'rail_access_good': ('🚆', '電車でアクセス◎'),
+    'river':            ('🏞', '川・渓谷'),
+    'in_station':       ('🚉', '駅構内'),
+}
+
 
 def build_ja_to_slug(raw_data: list) -> dict[str, str]:
     """Build ja_name → slug map with regional form and katakana normalization."""
@@ -569,6 +580,11 @@ def generate_html(
     for t in titles:
         label = f"{escape(t['emoji'])} {escape(t['label'])}" if t.get("emoji") else escape(t["label"])
         badges.append(f"<span class='hero-badge hero-badge-title'>{label}</span>")
+    # Secondary tag badges (tourism/park/museum/history/food/rail_access_good/river/in_station)
+    for tag in (manhole.get("tags") or []):
+        if tag in SECONDARY_TAG_LABELS:
+            em, lbl = SECONDARY_TAG_LABELS[tag]
+            badges.append(f"<span class='hero-badge hero-badge-secondary'>{escape(em)} {escape(lbl)}</span>")
     # Stats badges with suppression rules (§2.3)
     suppress_pref = title_keys & {"only_in_pref", "unique_pokemon"}
     suppress_nearby = "lone" in title_keys
@@ -1262,6 +1278,12 @@ def generate_html(
       font-weight: 600;
       color: #3a4fc7;
       letter-spacing: 0.01em;
+    }}
+
+    .hero-badge-secondary {{
+      background: #f0f9ff;
+      border-color: #bae6fd;
+      color: #0369a1;
     }}
 
     .hero-actions {{

--- a/apps/web/assets/pokefuta-map.css
+++ b/apps/web/assets/pokefuta-map.css
@@ -934,6 +934,19 @@ body.pokefuta-map-page {
   white-space: nowrap;
 }
 
+.pokefuta-map-page .travel-popup-tag-icons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin: 2px 0 4px;
+}
+
+.pokefuta-map-page .travel-popup-tag-icon {
+  font-size: 15px;
+  line-height: 1;
+  cursor: default;
+}
+
 .pokefuta-map-page .travel-popup-action--share {
   grid-column: 1 / -1;
   background: #fff;

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -566,7 +566,18 @@
       }
     }
 
-    // ==== 単一言語 (日本語) 用 UI ラベル定数 ==== 
+    // ==== セカンダリタグ（バッジ変換なし・popup はアイコンのみ表示） ====
+    const SECONDARY_TAG_EMOJI = Object.freeze({
+      tourism: '🗺', park: '🌳', museum: '🏛', history: '🏯',
+      food: '🍜', rail_access_good: '🚆', river: '🏞', in_station: '🚉',
+    })
+    const SECONDARY_TAG_LABEL = Object.freeze({
+      tourism: '観光スポット', park: '公園', museum: '博物館',
+      history: '歴史スポット', food: 'グルメ', rail_access_good: '電車でアクセス◎',
+      river: '川・渓谷', in_station: '駅構内',
+    })
+
+    // ==== 単一言語 (日本語) 用 UI ラベル定数 ====
     const UI_TEXT = {
       recentLabel: '🆕 直近1ヶ月',
       prefectureFilter: '都道府県で絞り込み',
@@ -705,6 +716,14 @@
             + '</span>').join('')
           + '</div>'
         : '';
+      const secondaryTags = (Array.isArray(d.tags) ? d.tags : []).filter(t => SECONDARY_TAG_EMOJI[t])
+      const secondaryIconsHtml = secondaryTags.length
+        ? '<div class="travel-popup-tag-icons">'
+          + secondaryTags.map(t =>
+              `<span class="travel-popup-tag-icon" title="${escapeHtml(SECONDARY_TAG_LABEL[t] || t)}">${SECONDARY_TAG_EMOJI[t]}</span>`
+            ).join('')
+          + '</div>'
+        : '';
       const photoBlock = imageUrl ? `
         <div class="popup-photo travel-popup-photo" aria-label="マンホール写真">
           <img src="${imageUrl}" alt="${escapeHtml(photoAlt)}" loading="lazy" decoding="async" onerror="handlePopupImageError(this)">
@@ -741,6 +760,7 @@
             ${d.building ? `<p class="travel-popup-building">📍 ${escapeHtml(d.building)}</p>` : ''}
             ${d.place_detail ? `<p class="travel-popup-description">${escapeHtml(d.place_detail)}</p>` : ''}
             ${titleBadgesHtml}
+            ${secondaryIconsHtml}
             ${photoComment ? `<p class="travel-popup-comment">${escapeHtml(photoComment)}</p>` : ''}
             <div class="travel-popup-pokemon-list" aria-label="登場ポケモン">${pokemonsHtml}</div>
             <div class="popup-actions travel-popup-actions travel-popup-actions--single">


### PR DESCRIPTION
## Summary

- `tourism` / `park` / `museum` / `history` / `food` / `rail_access_good` / `river` / `in_station` の8タグを表示に反映
- **地図popup**: emoji アイコン行のみ（マウスオーバーで日本語ラベルのtooltip）
- **詳細ページ**: 水色系の `hero-badge-secondary` バッジ（emoji + フルラベル）
- `roadside` / `seaside` など既存バッジ生成タグとは重複しない設計

## 変更ファイル

| ファイル | 変更 |
|---|---|
| `apps/web/index.html` | `SECONDARY_TAG_EMOJI` / `SECONDARY_TAG_LABEL` 定数追加・popup テンプレートに emoji アイコン行追加 |
| `apps/web/assets/pokefuta-map.css` | `.travel-popup-tag-icons` / `.travel-popup-tag-icon` CSS 追加 |
| `apps/scraper/generate_manhole_pages.py` | `SECONDARY_TAG_LABELS` 定数追加・hero バッジに `hero-badge-secondary` 追加 |

## Test plan

- [ ] 地図で ID 404（名古屋城付近）のポップアップを開き `🍜 🗺 🏯 🌳` アイコン行が出ること
- [ ] アイコンにマウスオーバーで日本語ラベルのtooltipが出ること
- [ ] `/manholes/404/` に水色バッジ（グルメ / 観光スポット / 歴史スポット / 公園）が出ること
- [ ] `roadside` のみ持つマンホールでアイコン行が出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)