### PR TITLE
feat: 離島マンホール28件に remote_island タグを設定

### DIFF
--- a/dataset/manhole_titles.json
+++ b/dataset/manhole_titles.json
@@ -596,22 +596,26 @@
     },
     "35": {
       "tags": [
-        "seaside"
+        "seaside",
+        "remote_island"
       ]
     },
     "36": {
       "tags": [
-        "seaside"
+        "seaside",
+        "remote_island"
       ]
     },
     "37": {
       "tags": [
-        "seaside"
+        "seaside",
+        "remote_island"
       ]
     },
     "39": {
       "tags": [
-        "seaside"
+        "seaside",
+        "remote_island"
       ]
     },
     "44": {
@@ -901,22 +905,26 @@
     },
     "153": {
       "tags": [
-        "seaside"
+        "seaside",
+        "remote_island"
       ]
     },
     "154": {
       "tags": [
-        "seaside"
+        "seaside",
+        "remote_island"
       ]
     },
     "155": {
       "tags": [
-        "seaside"
+        "seaside",
+        "remote_island"
       ]
     },
     "156": {
       "tags": [
-        "seaside"
+        "seaside",
+        "remote_island"
       ]
     },
     "157": {
@@ -956,13 +964,15 @@
     },
     "174": {
       "tags": [
-        "world_heritage"
+        "world_heritage",
+        "remote_island"
       ]
     },
     "175": {
       "tags": [
         "seaside",
-        "world_heritage"
+        "world_heritage",
+        "remote_island"
       ]
     },
     "187": {
@@ -1135,38 +1145,45 @@
     "229": {
       "tags": [
         "seaside",
-        "world_heritage"
+        "world_heritage",
+        "remote_island"
       ]
     },
     "231": {
       "tags": [
-        "seaside"
+        "seaside",
+        "remote_island"
       ]
     },
     "232": {
       "tags": [
-        "seaside"
+        "seaside",
+        "remote_island"
       ]
     },
     "233": {
       "tags": [
         "seaside",
-        "world_heritage"
+        "world_heritage",
+        "remote_island"
       ]
     },
     "234": {
       "tags": [
-        "seaside"
+        "seaside",
+        "remote_island"
       ]
     },
     "235": {
       "tags": [
-        "seaside"
+        "seaside",
+        "remote_island"
       ]
     },
     "236": {
       "tags": [
-        "seaside"
+        "seaside",
+        "remote_island"
       ]
     },
     "240": {
@@ -1732,7 +1749,8 @@
     },
     "358": {
       "tags": [
-        "seaside"
+        "seaside",
+        "remote_island"
       ]
     },
     "359": {
@@ -1798,7 +1816,8 @@
     },
     "381": {
       "tags": [
-        "seaside"
+        "seaside",
+        "remote_island"
       ]
     },
     "383": {
@@ -2006,22 +2025,26 @@
     },
     "422": {
       "tags": [
-        "seaside"
+        "seaside",
+        "remote_island"
       ]
     },
     "423": {
       "tags": [
-        "seaside"
+        "seaside",
+        "remote_island"
       ]
     },
     "424": {
       "tags": [
-        "seaside"
+        "seaside",
+        "remote_island"
       ]
     },
     "425": {
       "tags": [
-        "seaside"
+        "seaside",
+        "remote_island"
       ]
     },
     "427": {
@@ -2031,7 +2054,8 @@
     },
     "428": {
       "tags": [
-        "seaside"
+        "seaside",
+        "remote_island"
       ]
     },
     "429": {
@@ -2135,7 +2159,8 @@
     },
     "446": {
       "tags": [
-        "world_heritage"
+        "world_heritage",
+        "remote_island"
       ]
     },
     "448": {
@@ -2172,6 +2197,21 @@
     "474": {
       "tags": [
         "seaside"
+      ]
+    },
+    "176": {
+      "tags": [
+        "remote_island"
+      ]
+    },
+    "177": {
+      "tags": [
+        "remote_island"
+      ]
+    },
+    "230": {
+      "tags": [
+        "remote_island"
       ]
     }
   },

--- a/dataset/manhole_titles.json
+++ b/dataset/manhole_titles.json
@@ -975,6 +975,16 @@
         "remote_island"
       ]
     },
+    "176": {
+      "tags": [
+        "remote_island"
+      ]
+    },
+    "177": {
+      "tags": [
+        "remote_island"
+      ]
+    },
     "187": {
       "building": "函館公園内旧函館博物館二号前",
       "verified_at": "2021-07-15",
@@ -1146,6 +1156,11 @@
       "tags": [
         "seaside",
         "world_heritage",
+        "remote_island"
+      ]
+    },
+    "230": {
+      "tags": [
         "remote_island"
       ]
     },
@@ -2197,21 +2212,6 @@
     "474": {
       "tags": [
         "seaside"
-      ]
-    },
-    "176": {
-      "tags": [
-        "remote_island"
-      ]
-    },
-    "177": {
-      "tags": [
-        "remote_island"
-      ]
-    },
-    "230": {
-      "tags": [
-        "remote_island"
       ]
     }
   },


### PR DESCRIPTION
## Summary

`dataset/manhole_titles.json` の `islands` リストを参照し、対象マンホールの `tags` フィールドに `remote_island` を追加。

| グループ | 対象 ID |
|---|---|
| 粟島・直島・小豆島（香川） | 35, 36, 37, 39 |
| 小笠原諸島（東京） | 153, 154, 155, 156 |
| 沖縄県全体 | 174–177, 229–236, 422–425, 446 |
| 石垣島（沖縄） | 235（沖縄全体と重複） |
| 五島列島（長崎） | 358 |
| 隠岐の島（島根） | 381 |
| 壱岐島（長崎） | 428 |

合計 **28件**

## Test plan

- [ ] セマンティックエディター「タグ別マンホール一覧」で `remote_island` の件数が 28 になる
- [ ] トップページ「特徴で探す」の 🏝 離島チップで28件が地図に表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)