### PR TITLE
Update manhole semantic metadata (20260608)

### DIFF
--- a/dataset/manhole_titles.json
+++ b/dataset/manhole_titles.json
@@ -831,10 +831,7 @@
       ]
     },
     "91": {
-      "building": "道の駅なみえ",
-      "tags": [
-        "roadside"
-      ]
+      "building": "道の駅なみえ"
     },
     "92": {
       "building": "道の駅ならは",
@@ -1185,6 +1182,28 @@
     "204": {
       "tags": [
         "seaside"
+      ]
+    },
+    "208": {
+      "building": "東石切公園",
+      "tags": [
+        "park",
+        "rail_access_good"
+      ]
+    },
+    "209": {
+      "building": "花園中央公園",
+      "tags": [
+        "museum",
+        "park",
+        "near_station"
+      ]
+    },
+    "210": {
+      "building": "花園中央公園",
+      "tags": [
+        "park",
+        "near_station"
       ]
     },
     "214": {


### PR DESCRIPTION
## Summary

semantic metadata をセマンティックエディタで更新しました。

## 変更内容

- assign_all_tags: 6件

対象マンホール数（ユニーク）: 3件

## Tasks

- assign_all_tags: 6件

## Guardrails

- docs/pokefuta.ndjson は変更されていません
- dataset/manhole_titles.json のみ変更されています

## Validation

- [x] JSON parse OK
- [x] schema OK
- [x] docs/*.ndjson 汚染なし
- [x] changes.ndjson で操作ログ確認済み

🤖 Generated with Semantic Manhole Metadata Editor