### PR TITLE
fix: 特徴タグの初期表示を5件固定（道の駅・離島・駅前・世界遺産・海沿い）

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -541,6 +541,7 @@
     var showTagDirectory = false;
     const TAG_DIRECTORY_MIN_COUNT = 5;  // この件数未満のタグはチップに表示しない
     const TAG_PRIORITY = ['roadside', 'world_heritage', 'remote_island', 'seaside', 'tourism', 'station_front', 'food', 'museum', 'history', 'rail_access_good'];
+    const FEATURED_TAGS = ['roadside', 'remote_island', 'station_front', 'world_heritage', 'seaside'];
 
     const TAG_META = {
       seaside:          { emoji: '🌊', label: '海沿い' },
@@ -1618,8 +1619,10 @@
           if (priB >= 0) return 1;
           return b - a;
         });
-      const primaryTags = sorted.filter(([tag]) => TAG_PRIORITY.includes(tag));
-      const secondaryTags = sorted.filter(([tag]) => !TAG_PRIORITY.includes(tag));
+      const primaryTags = FEATURED_TAGS
+        .filter(tag => tagCounts[tag] >= TAG_DIRECTORY_MIN_COUNT && TAG_META[tag])
+        .map(tag => [tag, tagCounts[tag]]);
+      const secondaryTags = sorted.filter(([tag]) => !FEATURED_TAGS.includes(tag));
       function makeChip(tag, count) {
         const meta = TAG_META[tag];
         return `<button class="tag-chip" data-tag="${tag}" data-count="${count}" aria-pressed="false">${meta.emoji} ${meta.label} <span class="tag-count">${count}枚</span></button>`;


### PR DESCRIPTION
## Summary

「テーマでポケふた巡り」の特徴タグが全件表示されていた問題を修正。

- `FEATURED_TAGS` 定数を追加し、初期表示する5件を固定順で定義
- `renderTagDirectory` の `primaryTags` / `secondaryTags` 分割ロジックを変更

## 初期表示（固定）

| タグ | キー |
|------|------|
| 🛤 道の駅 | `roadside` |
| 🏝 離島 | `remote_island` |
| 🚃 駅前 | `station_front` |
| 🌐 世界遺産 | `world_heritage` |
| 🌊 海沿い | `seaside` |

## 変更内容

- `FEATURED_TAGS = ['roadside', 'remote_island', 'station_front', 'world_heritage', 'seaside']` を追加
- `primaryTags`: FEATURED_TAGS の固定順5件（件数閾値を満たすもの）
- `secondaryTags`: FEATURED_TAGS 以外（TAG_PRIORITY順 → 件数順）
- `TAG_META` 未登録の内部用タグは自動除外

## 影響なし

- 既存の特徴フィルタ機能（`activeTagFilter`）
- GA イベント（`feature_filter_click` / `feature_more_toggle`）
- 「もっと見る」/「閉じる」の展開・折りたたみ動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)