### PR TITLE
feat: タグ逆引き一覧を件数降順・マップ詳細ページに刷新

### DIFF
--- a/tools/manhole-semantic-editor/src/tasks/tagReverseLookup/TagDetailView.tsx
+++ b/tools/manhole-semantic-editor/src/tasks/tagReverseLookup/TagDetailView.tsx
@@ -1,0 +1,187 @@
+import { useState, useRef, useEffect } from 'react'
+import L from 'leaflet'
+import 'leaflet/dist/leaflet.css'
+import type { PokefutaRecord } from '../../semantic/semanticPatch'
+
+export type TagRow = {
+  key: string
+  emoji: string
+  label: string
+  priority: number
+  count: number
+  editable: boolean
+}
+
+export type ManholeItem = {
+  id: string
+  record: PokefutaRecord | undefined
+  badgeLabel?: string
+}
+
+type Props = {
+  tagRow: TagRow
+  manholeList: ManholeItem[]
+  editable: boolean
+  onBack: () => void
+  onNavigateToEdit: (manholeId: string) => void
+}
+
+function makeIcon(selected: boolean) {
+  const color = selected ? '#ef4444' : '#3b82f6'
+  return L.divIcon({
+    className: '',
+    html: `<div style="width:14px;height:14px;border-radius:50%;background:${color};border:2px solid white;box-shadow:0 1px 4px rgba(0,0,0,0.5)"></div>`,
+    iconSize: [14, 14],
+    iconAnchor: [7, 7],
+    popupAnchor: [0, -10],
+  })
+}
+
+function esc(s: string) {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+}
+
+export function TagDetailView({ tagRow, manholeList, editable, onBack, onNavigateToEdit }: Props) {
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const mapDivRef = useRef<HTMLDivElement>(null)
+  const mapRef = useRef<L.Map | null>(null)
+  const markersRef = useRef<Map<string, L.Marker>>(new Map())
+  const itemRefsRef = useRef<Map<string, HTMLDivElement>>(new Map())
+
+  const plottable = manholeList.filter(i => i.record?.lat != null)
+
+  // Initialize map once
+  useEffect(() => {
+    if (!mapDivRef.current) return
+    const map = L.map(mapDivRef.current).setView([36.5, 136.0], 5)
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+    }).addTo(map)
+    mapRef.current = map
+
+    plottable.forEach(item => {
+      const r = item.record!
+      const popupHtml = [
+        `<b>#${r.id}</b> ${esc(r.prefecture)} ${esc(r.city)}`,
+        `<span style="font-size:11px">${esc(r.address)}</span>`,
+        item.badgeLabel ? `<span style="font-size:11px;color:#7c3aed">${esc(item.badgeLabel)}</span>` : '',
+      ].filter(Boolean).join('<br>')
+
+      const marker = L.marker([r.lat, r.lng], { icon: makeIcon(false) })
+        .addTo(map)
+        .bindPopup(popupHtml)
+        .on('click', () => setSelectedId(cur => cur === r.id ? null : r.id))
+      markersRef.current.set(r.id, marker)
+    })
+
+    if (plottable.length > 1) {
+      const bounds = L.latLngBounds(plottable.map(i => [i.record!.lat, i.record!.lng]))
+      map.fitBounds(bounds, { padding: [30, 30] })
+    } else if (plottable.length === 1) {
+      map.setView([plottable[0].record!.lat, plottable[0].record!.lng], 10)
+    }
+
+    return () => {
+      map.remove()
+      mapRef.current = null
+      markersRef.current.clear()
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // Sync marker color and popup when selection changes
+  useEffect(() => {
+    markersRef.current.forEach((marker, id) => {
+      marker.setIcon(makeIcon(id === selectedId))
+    })
+    if (selectedId) {
+      const marker = markersRef.current.get(selectedId)
+      marker?.openPopup()
+      const item = manholeList.find(i => i.id === selectedId)
+      if (item?.record) mapRef.current?.panTo([item.record.lat, item.record.lng])
+      const el = itemRefsRef.current.get(selectedId)
+      el?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+    }
+  }, [selectedId, manholeList])
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column' }}>
+      {/* Header */}
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 12,
+        padding: '8px 0 12px',
+        borderBottom: '1px solid #e2e8f0',
+        flexShrink: 0,
+        flexWrap: 'wrap',
+      }}>
+        <button
+          onClick={onBack}
+          style={{ padding: '5px 14px', fontSize: 13, background: '#f1f5f9', border: '1px solid #cbd5e1', borderRadius: 6, cursor: 'pointer', whiteSpace: 'nowrap' }}
+        >
+          ← 一覧に戻る
+        </button>
+        <span style={{ fontSize: 22 }}>{tagRow.emoji}</span>
+        <h3 style={{ margin: 0, fontSize: 17 }}>{tagRow.label.replace(/\{[^}]+\}/g, '…')}</h3>
+        <code style={{ fontSize: 12, color: '#64748b', background: '#f1f5f9', padding: '2px 7px', borderRadius: 4 }}>{tagRow.key}</code>
+        <span style={{ fontSize: 14, color: '#6b7280' }}>{manholeList.length}件</span>
+        {!editable && (
+          <span style={{ fontSize: 11, color: '#94a3b8', background: '#f1f5f9', padding: '2px 8px', borderRadius: 4 }}>自動計算・読み取り専用</span>
+        )}
+      </div>
+
+      {/* Body: list (left) + map (right) */}
+      <div style={{ display: 'flex', height: 'calc(100vh - 180px)', marginTop: 12 }}>
+        {/* Left: scrollable manhole list */}
+        <div style={{ width: 320, flexShrink: 0, overflowY: 'auto', borderRight: '1px solid #e2e8f0', paddingRight: 8 }}>
+          {manholeList.length === 0 ? (
+            <div style={{ padding: 24, color: '#9ca3af', textAlign: 'center' }}>マンホールがありません</div>
+          ) : (
+            manholeList.map(item => {
+              const isSelected = item.id === selectedId
+              return (
+                <div
+                  key={item.id}
+                  ref={el => { if (el) itemRefsRef.current.set(item.id, el); else itemRefsRef.current.delete(item.id) }}
+                  onClick={() => setSelectedId(cur => cur === item.id ? null : item.id)}
+                  style={{
+                    padding: '10px 12px',
+                    marginBottom: 2,
+                    borderRadius: 6,
+                    cursor: 'pointer',
+                    background: isSelected ? '#eff6ff' : '#fff',
+                    outline: isSelected ? '2px solid #3b82f6' : '1px solid #f1f5f9',
+                    outlineOffset: '-1px',
+                  }}
+                >
+                  <div style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
+                    <span style={{ fontFamily: 'monospace', fontSize: 12, color: '#94a3b8', flexShrink: 0 }}>#{item.id}</span>
+                    <span style={{ fontSize: 14, fontWeight: 600, color: '#1e293b' }}>
+                      {item.record?.title ?? '—'}
+                    </span>
+                  </div>
+                  <div style={{ fontSize: 12, color: '#64748b', marginTop: 3 }}>
+                    {item.record?.prefecture} {item.record?.city}
+                  </div>
+                  {item.badgeLabel && (
+                    <div style={{ fontSize: 11, color: '#7c3aed', marginTop: 2 }}>{item.badgeLabel}</div>
+                  )}
+                  {editable && (
+                    <button
+                      onClick={e => { e.stopPropagation(); onNavigateToEdit(item.id) }}
+                      style={{ marginTop: 5, padding: '2px 8px', fontSize: 11, borderRadius: 4, border: '1px solid #c4b5d4', background: '#f8f4ff', color: '#7c3aed', cursor: 'pointer' }}
+                    >
+                      タグを編集
+                    </button>
+                  )}
+                </div>
+              )
+            })
+          )}
+        </div>
+
+        {/* Right: Leaflet map */}
+        <div ref={mapDivRef} style={{ flex: 1, borderRadius: '0 0 8px 0' }} />
+      </div>
+    </div>
+  )
+}

--- a/tools/manhole-semantic-editor/src/tasks/tagReverseLookup/TagReverseLookupTask.tsx
+++ b/tools/manhole-semantic-editor/src/tasks/tagReverseLookup/TagReverseLookupTask.tsx
@@ -1,6 +1,8 @@
 import { useState, useMemo } from 'react'
 import type { ManholeTitlesJson, PokefutaRecord } from '../../semantic/semanticPatch'
 import { VALID_TAGS } from '../../semantic/validTags'
+import { TagDetailView } from './TagDetailView'
+import type { TagRow, ManholeItem } from './TagDetailView'
 
 type Props = {
   titles: ManholeTitlesJson
@@ -8,24 +10,8 @@ type Props = {
   onNavigateToEdit: (manholeId: string) => void
 }
 
-type TagRow = {
-  key: string
-  emoji: string
-  label: string
-  priority: number
-  count: number
-  editable: boolean  // VALID_TAGS に含まれる手動タグか否か
-}
-
-type ManholeItem = {
-  id: string
-  record: PokefutaRecord | undefined
-  // manual tag のとき entry.tags から来る; auto title のとき record.titles から来る
-  badgeLabel?: string
-}
-
 export function TagReverseLookupTask({ titles, records, onNavigateToEdit }: Props) {
-  const [selectedTag, setSelectedTag] = useState<string | null>(null)
+  const [detailTag, setDetailTag] = useState<string | null>(null)
 
   const editableKeys = useMemo(() => new Set<string>(VALID_TAGS), [])
 
@@ -62,7 +48,7 @@ export function TagReverseLookupTask({ titles, records, onNavigateToEdit }: Prop
     return result
   }, [titles])
 
-  // 全 vocabulary を TagRow に変換
+  // 全 vocabulary を TagRow に変換 — 件数降順、同数は priority 降順
   const tagRows = useMemo((): TagRow[] => {
     const vocab = titles.vocabulary
     return Object.entries(vocab)
@@ -80,176 +66,104 @@ export function TagReverseLookupTask({ titles, records, onNavigateToEdit }: Prop
           editable,
         }
       })
-      .sort((a, b) => b.priority - a.priority || b.count - a.count)
+      .sort((a, b) => b.count - a.count || b.priority - a.priority)
   }, [titles, editableKeys, manualTagToIds, autoTagToIds])
 
-  const manholeList = useMemo((): ManholeItem[] => {
-    if (!selectedTag) return []
-    const isEditable = editableKeys.has(selectedTag)
+  const detailManholes = useMemo((): ManholeItem[] => {
+    if (!detailTag) return []
+    const isEditable = editableKeys.has(detailTag)
     if (isEditable) {
-      return (manualTagToIds.get(selectedTag) ?? [])
+      return (manualTagToIds.get(detailTag) ?? [])
         .map(id => ({ id, record: recordById.get(id) }))
         .sort((a, b) => Number(a.id) - Number(b.id))
     } else {
-      return (autoTagToIds.get(selectedTag) ?? [])
+      return (autoTagToIds.get(detailTag) ?? [])
         .map(id => {
           const r = recordById.get(id)
-          const badge = r?.titles?.find(t => t.key === selectedTag)
+          const badge = r?.titles?.find(t => t.key === detailTag)
           return { id, record: r, badgeLabel: badge?.label }
         })
         .sort((a, b) => Number(a.id) - Number(b.id))
     }
-  }, [selectedTag, editableKeys, manualTagToIds, autoTagToIds, recordById])
+  }, [detailTag, editableKeys, manualTagToIds, autoTagToIds, recordById])
 
-  const selectedRow = useMemo(
-    () => tagRows.find(r => r.key === selectedTag),
-    [tagRows, selectedTag]
+  const detailRow = useMemo(
+    () => tagRows.find(r => r.key === detailTag) ?? null,
+    [tagRows, detailTag]
   )
 
-  return (
-    <div style={{ display: 'flex', gap: 0, height: '100%' }}>
-      {/* 左ペイン: タグ一覧 */}
-      <div style={{ width: 380, flexShrink: 0, borderRight: '1px solid #e2e8f0', overflowY: 'auto', padding: '16px 12px' }}>
-        <h2 style={{ fontSize: 16, marginBottom: 4 }}>タグ / 称号 一覧</h2>
-        <p style={{ fontSize: 12, color: '#6b7280', marginBottom: 12 }}>
-          クリックするとそのタグ・称号が付いたマンホールを表示します。<br />
-          <span style={{ color: '#7c3aed' }}>●</span> 手動タグ（編集可）　<span style={{ color: '#94a3b8' }}>●</span> 自動計算称号（読み取り専用）
-        </p>
-        <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 12 }}>
-          <thead>
-            <tr style={{ borderBottom: '2px solid #e2e8f0' }}>
-              <th style={{ padding: '4px 4px', color: '#6b7280', fontWeight: 600, textAlign: 'left', width: 8 }}></th>
-              <th style={{ padding: '4px 6px', color: '#6b7280', fontWeight: 600, textAlign: 'left' }}>キー</th>
-              <th style={{ padding: '4px 6px', color: '#6b7280', fontWeight: 600, textAlign: 'left' }}>ラベル</th>
-              <th style={{ padding: '4px 6px', color: '#6b7280', fontWeight: 600, textAlign: 'right', width: 40 }}>件数</th>
-            </tr>
-          </thead>
-          <tbody>
-            {tagRows.map(row => {
-              const isActive = selectedTag === row.key
-              return (
-                <tr
-                  key={row.key}
-                  onClick={() => setSelectedTag(isActive ? null : row.key)}
-                  style={{
-                    borderBottom: '1px solid #f1f5f9',
-                    background: isActive ? '#7c5cbf' : row.count === 0 ? '#f9fafb' : '#fff',
-                    color: isActive ? '#fff' : row.count === 0 ? '#9ca3af' : '#1e293b',
-                    cursor: 'pointer',
-                  }}
-                >
-                  <td style={{ padding: '5px 4px', textAlign: 'center' }}>
-                    <span style={{
-                      display: 'inline-block',
-                      width: 8,
-                      height: 8,
-                      borderRadius: '50%',
-                      background: row.editable
-                        ? (isActive ? '#c4b5d4' : '#7c3aed')
-                        : (isActive ? '#c4b5d4' : '#94a3b8'),
-                    }} />
-                  </td>
-                  <td style={{ padding: '5px 6px', fontFamily: 'monospace', fontSize: 11, whiteSpace: 'nowrap' }}>
-                    {row.key}
-                  </td>
-                  <td style={{ padding: '5px 6px' }}>
-                    {row.emoji} {row.label.replace(/\{[^}]+\}/g, '…')}
-                  </td>
-                  <td style={{
-                    padding: '5px 6px',
-                    textAlign: 'right',
-                    fontWeight: 700,
-                    color: isActive ? '#fff' : row.count === 0 ? '#9ca3af' : '#7c3aed',
-                  }}>
-                    {row.count}
-                  </td>
-                </tr>
-              )
-            })}
-          </tbody>
-        </table>
-      </div>
+  // タグ詳細ページ
+  if (detailTag && detailRow) {
+    return (
+      <TagDetailView
+        tagRow={detailRow}
+        manholeList={detailManholes}
+        editable={editableKeys.has(detailTag)}
+        onBack={() => setDetailTag(null)}
+        onNavigateToEdit={onNavigateToEdit}
+      />
+    )
+  }
 
-      {/* 右ペイン: マンホール一覧 */}
-      <div style={{ flex: 1, overflowY: 'auto', padding: '16px 20px' }}>
-        {!selectedTag ? (
-          <div style={{ color: '#6b7280', marginTop: 40, textAlign: 'center' }}>
-            ← タグ / 称号を選択するとマンホール一覧が表示されます
-          </div>
-        ) : (
-          <>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 12 }}>
-              <h3 style={{ margin: 0, fontSize: 15 }}>
-                {selectedRow?.emoji} {selectedRow?.label.replace(/\{[^}]+\}/g, '…')}
-              </h3>
-              <code style={{ fontSize: 11, color: '#64748b', background: '#f1f5f9', padding: '2px 6px', borderRadius: 4 }}>{selectedTag}</code>
-              <span style={{ fontSize: 13, color: '#6b7280' }}>{manholeList.length}件</span>
-              {!editableKeys.has(selectedTag) && (
-                <span style={{ fontSize: 11, color: '#94a3b8', background: '#f1f5f9', padding: '2px 8px', borderRadius: 4 }}>自動計算・読み取り専用</span>
-              )}
-            </div>
-            {manholeList.length === 0 ? (
-              <p style={{ color: '#9ca3af' }}>このタグ / 称号が付いているマンホールはありません。</p>
-            ) : (
-              <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
-                <thead>
-                  <tr style={{ borderBottom: '2px solid #e2e8f0', textAlign: 'left' }}>
-                    <th style={{ padding: '6px 8px', color: '#6b7280', fontWeight: 600, width: 55 }}>ID</th>
-                    <th style={{ padding: '6px 8px', color: '#6b7280', fontWeight: 600 }}>タイトル</th>
-                    <th style={{ padding: '6px 8px', color: '#6b7280', fontWeight: 600 }}>都道府県</th>
-                    <th style={{ padding: '6px 8px', color: '#6b7280', fontWeight: 600 }}>市区町村</th>
-                    {!editableKeys.has(selectedTag) && (
-                      <th style={{ padding: '6px 8px', color: '#6b7280', fontWeight: 600 }}>称号ラベル</th>
-                    )}
-                    {editableKeys.has(selectedTag) && (
-                      <th style={{ padding: '6px 8px', width: 100 }}></th>
-                    )}
-                  </tr>
-                </thead>
-                <tbody>
-                  {manholeList.map(({ id, record, badgeLabel }) => (
-                    <tr key={id} style={{ borderBottom: '1px solid #f1f5f9' }}>
-                      <td style={{ padding: '6px 8px', color: '#64748b', fontVariantNumeric: 'tabular-nums' }}>{id}</td>
-                      <td style={{ padding: '6px 8px' }}>
-                        {record?.title ?? titles.manholes[id]?.building ?? '—'}
-                      </td>
-                      <td style={{ padding: '6px 8px', color: '#64748b' }}>
-                        {record?.prefecture ?? titles.manholes[id]?.prefecture ?? '—'}
-                      </td>
-                      <td style={{ padding: '6px 8px', color: '#64748b' }}>
-                        {record?.city ?? titles.manholes[id]?.city ?? '—'}
-                      </td>
-                      {!editableKeys.has(selectedTag) && (
-                        <td style={{ padding: '6px 8px', color: '#64748b', fontSize: 12 }}>
-                          {badgeLabel ?? '—'}
-                        </td>
-                      )}
-                      {editableKeys.has(selectedTag) && (
-                        <td style={{ padding: '6px 8px' }}>
-                          <button
-                            onClick={() => onNavigateToEdit(id)}
-                            style={{
-                              padding: '4px 10px',
-                              fontSize: 12,
-                              borderRadius: 6,
-                              border: '1px solid #c4b5d4',
-                              background: '#f8f4ff',
-                              color: '#7c3aed',
-                              cursor: 'pointer',
-                            }}
-                          >
-                            タグを編集
-                          </button>
-                        </td>
-                      )}
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            )}
-          </>
-        )}
-      </div>
+  // タグ一覧ページ
+  return (
+    <div>
+      <h2 style={{ fontSize: 18, marginBottom: 6 }}>タグ / 称号 一覧</h2>
+      <p style={{ fontSize: 13, color: '#6b7280', marginBottom: 16 }}>
+        クリックするとそのタグ・称号が付いたマンホールを地図で確認できます。<br />
+        <span style={{ color: '#7c3aed' }}>●</span> 手動タグ（編集可）　<span style={{ color: '#94a3b8' }}>●</span> 自動計算称号（読み取り専用）
+      </p>
+      <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 14 }}>
+        <thead>
+          <tr style={{ borderBottom: '2px solid #e2e8f0' }}>
+            <th style={{ padding: '6px 6px', color: '#6b7280', fontWeight: 600, textAlign: 'left', width: 12 }}></th>
+            <th style={{ padding: '6px 8px', color: '#6b7280', fontWeight: 600, textAlign: 'left' }}>キー</th>
+            <th style={{ padding: '6px 8px', color: '#6b7280', fontWeight: 600, textAlign: 'left' }}>ラベル</th>
+            <th style={{ padding: '6px 8px', color: '#6b7280', fontWeight: 600, textAlign: 'right', width: 60 }}>件数</th>
+          </tr>
+        </thead>
+        <tbody>
+          {tagRows.map(row => (
+            <tr
+              key={row.key}
+              onClick={() => setDetailTag(row.key)}
+              style={{
+                borderBottom: '1px solid #f1f5f9',
+                background: row.count === 0 ? '#f9fafb' : '#fff',
+                color: row.count === 0 ? '#9ca3af' : '#1e293b',
+                cursor: 'pointer',
+              }}
+              onMouseEnter={e => { (e.currentTarget as HTMLTableRowElement).style.background = '#f0f4ff' }}
+              onMouseLeave={e => { (e.currentTarget as HTMLTableRowElement).style.background = row.count === 0 ? '#f9fafb' : '#fff' }}
+            >
+              <td style={{ padding: '8px 6px', textAlign: 'center' }}>
+                <span style={{
+                  display: 'inline-block',
+                  width: 9,
+                  height: 9,
+                  borderRadius: '50%',
+                  background: row.editable ? '#7c3aed' : '#94a3b8',
+                }} />
+              </td>
+              <td style={{ padding: '8px 8px', fontFamily: 'monospace', fontSize: 12, whiteSpace: 'nowrap', color: '#64748b' }}>
+                {row.key}
+              </td>
+              <td style={{ padding: '8px 8px', fontSize: 15 }}>
+                {row.emoji} {row.label.replace(/\{[^}]+\}/g, '…')}
+              </td>
+              <td style={{
+                padding: '8px 8px',
+                textAlign: 'right',
+                fontWeight: 700,
+                fontSize: 16,
+                color: row.count === 0 ? '#9ca3af' : '#7c3aed',
+              }}>
+                {row.count}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

セマンティックエディターの「タグ別マンホール一覧」を大幅に使いやすく改善。

## 変更内容

- **ソート順**: priority順 → **件数降順**（同数はpriority降順）
- **フォント拡大**: テーブル 12px → 14〜16px、行パディング拡大、ホバーハイライト追加
- **詳細ページ新設** (`TagDetailView.tsx`): タグクリックで遷移
  - 左ペイン: マンホール一覧（スクロール可）
  - 右ペイン: Leaflet マップ（全件マーカー・fitBounds）
  - リストクリック → マーカーが赤に変わり popup 開く・地図 panTo
  - マーカークリック → リスト行にスクロール
  - 「← 一覧に戻る」で元のタグ一覧へ戻る

🤖 Generated with [Claude Code](https://claude.com/claude-code)