### PR TITLE
feat: social-post に道の駅・離島タイプを追加

### DIFF
--- a/.claude/commands/social-post.md
+++ b/.claude/commands/social-post.md
@@ -16,7 +16,8 @@ python3 apps/scraper/generate_social_posts.py
    - 火    → `travel_trivia`
    - 水    → `latest_photo`
    - 木    → `pokemon_rank`
-   - 金    → `rare_area`
+   - 金    → `rare_area` / `michineki` / `remote_island` の3週ローテ
+             （`history.used` を見て、この3タイプの中で最も `used_at` が古いもの、または未使用のタイプを優先する）
    - 土    → `no_photo`
 
    そのタイプの候補の中から、`history.used` にある `id` で `used_at` が30日以内のものを除外した上で最適な1件を選ぶ。

--- a/apps/scraper/generate_social_ogp.py
+++ b/apps/scraper/generate_social_ogp.py
@@ -465,6 +465,205 @@ _TEMPLATE_BUILDERS = {
 
 
 # ---------------------------------------------------------------------------
+# Area map SVG builder (michineki / remote_island)
+# ---------------------------------------------------------------------------
+
+def _build_area_map_svg(
+    headline: str,
+    subline: str,
+    count: int,
+    pref: str,
+    manholes: list[dict],
+    top_pokemons: list[str],
+    special_point: dict | None = None,
+    extra_label: str = "",
+) -> str:
+    """Dark-theme 2-panel SVG for area-based types (no prefecture outline)."""
+    PANEL_X, PANEL_Y, PANEL_W, PANEL_H = 585, 30, 600, 565
+    PAD = 50
+
+    all_lats = [m["lat"] for m in manholes if m.get("lat")]
+    all_lngs = [m["lng"] for m in manholes if m.get("lng")]
+    if special_point:
+        all_lats.append(special_point["lat"])
+        all_lngs.append(special_point["lng"])
+    if not all_lats:
+        all_lats, all_lngs = [35.0], [136.0]
+
+    lat_min, lat_max = min(all_lats), max(all_lats)
+    lng_min, lng_max = min(all_lngs), max(all_lngs)
+    if lat_max - lat_min < 0.05:
+        mid = (lat_min + lat_max) / 2
+        lat_min, lat_max = mid - 0.1, mid + 0.1
+    if lng_max - lng_min < 0.05:
+        mid = (lng_min + lng_max) / 2
+        lng_min, lng_max = mid - 0.2, mid + 0.2
+
+    lat_pad = (lat_max - lat_min) * 0.3
+    lng_pad = (lng_max - lng_min) * 0.3
+    lat_min -= lat_pad; lat_max += lat_pad
+    lng_min -= lng_pad; lng_max += lng_pad
+
+    lng_range = lng_max - lng_min
+    lat_range = lat_max - lat_min
+    avail_w = PANEL_W - 2 * PAD
+    avail_h = PANEL_H - 2 * PAD
+    scale = min(avail_w / lng_range, avail_h / lat_range)
+    map_w = lng_range * scale
+    map_h = lat_range * scale
+    x_off = PANEL_X + PAD + (avail_w - map_w) / 2
+    y_off = PANEL_Y + PAD + (avail_h - map_h) / 2 + map_h
+
+    def to_svg(lat: float, lng: float) -> tuple[float, float]:
+        x = x_off + (lng - lng_min) * scale
+        y = y_off - (lat - lat_min) * scale
+        return round(x, 1), round(y, 1)
+
+    image_ids = {f.stem.replace("_latest", "") for f in IMAGE_DIR.glob("*_latest.jpeg")}
+    photo_candidates = [m for m in manholes if str(m.get("id", "")) in image_ids and m.get("lat") and m.get("lng")]
+    photo_manholes = _pick_spread(photo_candidates, n=5)
+
+    R = 42
+    clips = lines_svg = imgs = lbls = ""
+    placed_centers: list[tuple[float, float]] = []
+    photo_ids: set[str] = set()
+
+    for m in photo_manholes:
+        pid = str(m["id"])
+        lat, lng = m["lat"], m["lng"]
+        mx, my = to_svg(lat, lng)
+        px, py = _find_placement(mx, my, placed_centers, R,
+                                 PANEL_X, PANEL_X + PANEL_W, PANEL_Y, PANEL_Y + PANEL_H)
+        placed_centers.append((px, py))
+        photo_ids.add(pid)
+        b64 = base64.b64encode((IMAGE_DIR / f"{pid}_latest.jpeg").read_bytes()).decode()
+        clips += f'<clipPath id="c{pid}"><circle cx="{px}" cy="{py}" r="{R}"/></clipPath>\n'
+        lines_svg += (f'<line x1="{mx}" y1="{my}" x2="{px}" y2="{py}" '
+                      f'stroke="rgba(255,255,255,0.2)" stroke-width="1.2" stroke-dasharray="4 3"/>\n')
+        imgs += (f'<circle cx="{px}" cy="{py}" r="{R+3.5}" fill="#1a2a4a" '
+                 f'stroke="#F5C842" stroke-width="2" stroke-opacity="0.6"/>\n')
+        imgs += (f'<image href="data:image/jpeg;base64,{b64}" '
+                 f'x="{px-R}" y="{py-R}" width="{R*2}" height="{R*2}" '
+                 f'clip-path="url(#c{pid})" preserveAspectRatio="xMidYMid slice"/>\n')
+        city = m.get("city", "")
+        lbls += (f'<text x="{px}" y="{py+R+14}" class="jp" font-size="12" font-weight="700" '
+                 f'fill="rgba(255,255,255,0.65)" text-anchor="middle">{_xe(city)}</text>\n')
+
+    dots = ""
+    for m in manholes:
+        if not m.get("lat") or not m.get("lng"):
+            continue
+        x, y = to_svg(m["lat"], m["lng"])
+        if str(m.get("id", "")) in photo_ids:
+            dots += f'<circle cx="{x}" cy="{y}" r="4" fill="#FF6B6B" opacity="0.9"/>\n'
+        else:
+            dots += (f'<circle cx="{x}" cy="{y}" r="5" fill="#F5C842" '
+                     f'fill-opacity="0.7" stroke="#FFE566" stroke-width="1"/>\n')
+
+    special_svg = ""
+    if special_point:
+        sx, sy = to_svg(special_point["lat"], special_point["lng"])
+        label = _xe(special_point.get("label", ""))
+        special_svg = (
+            f'<circle cx="{sx}" cy="{sy}" r="12" fill="#00C875" opacity="0.9" stroke="white" stroke-width="2"/>\n'
+            f'<text x="{sx}" y="{sy+5}" font-size="13" text-anchor="middle" fill="white" font-weight="700">★</text>\n'
+            f'<text x="{sx}" y="{sy+28}" class="jp" font-size="11" fill="rgba(0,220,130,0.9)" text-anchor="middle">{label}</text>\n'
+        )
+
+    BAR_W = 430
+    pokemon_chips = ""
+    if top_pokemons:
+        pokemon_chips += '<text x="52" y="415" class="jp" font-size="13" font-weight="700" fill="rgba(255,255,255,0.38)">登場するポケモン</text>\n'
+        cx_p, cy_p = 52, 438
+        for name in top_pokemons[:6]:
+            w = len(name) * 14 + 18
+            if cx_p + w > 530:
+                cx_p, cy_p = 52, cy_p + 28
+            pokemon_chips += (f'<rect x="{cx_p}" y="{cy_p-16}" width="{w}" height="22" rx="11" '
+                              f'fill="rgba(100,160,230,0.12)" stroke="rgba(140,190,255,0.3)" stroke-width="1"/>\n')
+            pokemon_chips += (f'<text x="{cx_p+w//2}" y="{cy_p}" class="jp" font-size="12" '
+                              f'fill="rgba(255,255,255,0.6)" text-anchor="middle">{_xe(name)}</text>\n')
+            cx_p += w + 6
+
+    hl_len = len(headline)
+    hl_size = "44" if hl_len >= 10 else ("52" if hl_len >= 7 else "64")
+
+    return f'''<svg width="1200" height="630" viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
+<defs>
+  <linearGradient id="bg" x1="0" y1="0" x2="1200" y2="630" gradientUnits="userSpaceOnUse">
+    <stop offset="0" stop-color="#0C1B33"/><stop offset="0.55" stop-color="#14103C"/><stop offset="1" stop-color="#0F1E42"/>
+  </linearGradient>
+  <radialGradient id="glow_r" cx="78%" cy="44%" r="42%">
+    <stop offset="0" stop-color="#2E1780" stop-opacity="0.5"/><stop offset="1" stop-color="#0C1B33" stop-opacity="0"/>
+  </radialGradient>
+  <linearGradient id="gold" x1="0" y1="0" x2="0" y2="1">
+    <stop offset="0" stop-color="#FFE566"/><stop offset="1" stop-color="#F5A623"/>
+  </linearGradient>
+  <filter id="nglow" x="-25%" y="-25%" width="150%" height="150%">
+    <feGaussianBlur stdDeviation="5" result="b"/>
+    <feMerge><feMergeNode in="b"/><feMergeNode in="SourceGraphic"/></feMerge>
+  </filter>
+  <style>.jp{{font-family:'Hiragino Sans','Yu Gothic UI','Noto Sans CJK JP',sans-serif;}}.en{{font-family:'Helvetica Neue',Arial,sans-serif;}}</style>
+  {clips}
+</defs>
+<rect width="1200" height="630" fill="url(#bg)"/>
+<rect width="1200" height="630" fill="url(#glow_r)"/>
+<line x1="578" y1="30" x2="578" y2="598" stroke="rgba(255,255,255,0.06)" stroke-width="1"/>
+<!-- LEFT -->
+<rect x="52" y="44" width="228" height="30" rx="15"
+      fill="#F5C842" fill-opacity="0.1" stroke="#F5C842" stroke-opacity="0.45" stroke-width="1.5"/>
+<text x="166" y="64" class="jp" font-size="13" font-weight="700" fill="#F5C842" text-anchor="middle">{_xe(subline)}</text>
+<text x="48" y="{130 + (64 - int(hl_size)) * 2}" class="jp" font-size="{hl_size}" font-weight="900" fill="#FFFFFF" opacity="0.95">{_xe(headline)}</text>
+<text x="48" y="270" class="en" font-size="100" font-weight="900" fill="url(#gold)" filter="url(#nglow)">{count}</text>
+<text x="{48 + len(str(count)) * 60}" y="257" class="jp" font-size="36" font-weight="700" fill="#F5C842">枚</text>
+<text x="52" y="300" class="jp" font-size="16" fill="rgba(255,255,255,0.42)">{_xe(pref)}</text>
+<text x="52" y="324" class="jp" font-size="14" fill="rgba(255,255,255,0.30)">{_xe(extra_label)}</text>
+<rect x="52" y="338" width="{BAR_W}" height="1" fill="#F5C842" opacity="0.22"/>
+{pokemon_chips}
+<!-- RIGHT: map -->
+{lines_svg}{dots}{special_svg}{imgs}{lbls}
+<text x="{PANEL_X + PANEL_W//2}" y="590" class="jp" font-size="11"
+      fill="rgba(255,255,255,0.18)" text-anchor="middle">{_xe(headline)}のポケふた設置マップ</text>
+<!-- FOOTER -->
+<rect x="0" y="601" width="1200" height="29" fill="rgba(0,0,0,0.32)"/>
+<line x1="0" y1="601" x2="1200" y2="601" stroke="#F5C842" stroke-width="1" stroke-opacity="0.15"/>
+<circle cx="68" cy="615" r="7" fill="#F5C842" opacity="0.55"/>
+<circle cx="68" cy="615" r="3.5" fill="#0C1B33"/>
+<text x="83" y="620" class="jp" font-size="15" font-weight="700" fill="rgba(255,255,255,0.72)">ポケふたマップ</text>
+<text x="228" y="620" class="jp" font-size="11" fill="rgba(255,255,255,0.28)">全国ポケモンマンホール情報サイト</text>
+<text x="1142" y="620" class="en" font-size="13" font-weight="600" fill="rgba(255,255,255,0.35)" text-anchor="end">data.pokefuta.com</text>
+</svg>'''
+
+
+def _build_michineki_svg(raw: dict) -> str:
+    all_pokemons = [p for m in raw["manholes"] for p in m.get("pokemons", [])]
+    top_pokemons = [p for p, _ in Counter(all_pokemons).most_common(6)]
+    return _build_area_map_svg(
+        headline=raw["station_name"],
+        subline="道の駅チャレンジ",
+        count=raw["manhole_count"],
+        pref=raw["pref"],
+        manholes=raw["manholes"],
+        top_pokemons=top_pokemons,
+        special_point={"lat": raw["lat"], "lng": raw["lng"], "label": "道の駅"},
+        extra_label=f'半径{raw["radius_km"]}km以内に{raw["manhole_count"]}枚',
+    )
+
+
+def _build_remote_island_svg(raw: dict) -> str:
+    return _build_area_map_svg(
+        headline=raw["island_name"],
+        subline="離島のポケふた",
+        count=raw["manhole_count"],
+        pref=raw["pref"],
+        manholes=raw["manholes"],
+        top_pokemons=raw.get("top_pokemons", []),
+        special_point=None,
+        extra_label=f'{raw["pref"]} {raw["city"]}',
+    )
+
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -488,6 +687,12 @@ def main() -> None:
     if post_type == "prefecture_rank":
         print(f"[generate_social_ogp] {raw['pref']} の地図・写真データを取得中…")
         svg_text = _build_prefecture_rank_svg(raw)
+    elif post_type == "michineki":
+        print(f"[generate_social_ogp] {raw['station_name']} の地図を生成中…")
+        svg_text = _build_michineki_svg(raw)
+    elif post_type == "remote_island":
+        print(f"[generate_social_ogp] {raw['island_name']} の地図を生成中…")
+        svg_text = _build_remote_island_svg(raw)
     elif post_type in _TEMPLATE_BUILDERS:
         template_path = TEMPLATE_DIR / f"{post_type}.svg"
         if not template_path.exists():

--- a/apps/scraper/generate_social_posts.py
+++ b/apps/scraper/generate_social_posts.py
@@ -8,6 +8,7 @@ Body text generation is delegated to Claude (via the /social-post skill).
 from __future__ import annotations
 
 import json
+import math
 from collections import Counter
 from pathlib import Path
 from urllib.parse import quote
@@ -17,6 +18,20 @@ NDJSON = ROOT / "docs" / "pokefuta.ndjson"
 PHOTOS_JSON = ROOT / "docs" / "latest-manhole-photos.json"
 POKEMON_METADATA_JSON = ROOT / "docs" / "pokemon_metadata.json"
 CANDIDATES_JSON = ROOT / "docs" / "social-post-candidates.json"
+MICHINEKI_JSON = ROOT / "dataset" / "michineki.json"
+
+MICHINEKI_RADIUS_KM = 10
+MICHINEKI_MIN_COUNT = 3
+
+ISLAND_CITY_MAP: list[dict] = [
+    {"island_name": "小笠原諸島", "pref": "東京都",  "city": "小笠原"},
+    {"island_name": "小豆島",     "pref": "香川県",  "city": "小豆島"},
+    {"island_name": "直島",       "pref": "香川県",  "city": "直島"},
+    {"island_name": "隠岐諸島",   "pref": "島根県",  "city": "隠岐の島"},
+    {"island_name": "宮古島",     "pref": "沖縄県",  "city": "宮古島"},
+    {"island_name": "久米島",     "pref": "沖縄県",  "city": "久米島"},
+    {"island_name": "五島列島",   "pref": "長崎県",  "city": "新上五島"},
+]
 
 BASE_URL = "https://data.pokefuta.com/"
 
@@ -73,6 +88,24 @@ def _filter_pokemons(pokemons: object) -> list[str]:
 def _pref_slug(pref: str) -> str:
     idx = PREFECTURE_ORDER.index(pref) + 1 if pref in PREFECTURE_ORDER else 0
     return f"pref{idx:02d}"
+
+
+def _haversine(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    R = 6371.0
+    dlat = math.radians(lat2 - lat1)
+    dlon = math.radians(lon2 - lon1)
+    a = (math.sin(dlat / 2) ** 2
+         + math.cos(math.radians(lat1)) * math.cos(math.radians(lat2)) * math.sin(dlon / 2) ** 2)
+    return R * 2 * math.asin(math.sqrt(a))
+
+
+def load_michineki(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    try:
+        return json.loads(path.read_text(encoding="utf-8")).get("@graph", [])
+    except (json.JSONDecodeError, OSError):
+        return []
 
 
 def load_records(path: Path) -> list[dict]:
@@ -450,6 +483,102 @@ def gen_travel_trivia_candidates(stats: dict, pokemon_stats: dict) -> list[dict]
     return candidates
 
 
+def gen_michineki_candidates(records: list[dict], michineki: list[dict]) -> list[dict]:
+    active = [r for r in records if r.get("status") == "active" and r.get("lat") and r.get("lng")]
+    candidates = []
+    for station in michineki:
+        geo = station.get("geo", {})
+        slat, slng = geo.get("latitude"), geo.get("longitude")
+        if not slat or not slng:
+            continue
+        nearby = sorted(
+            [
+                {
+                    "id": r["id"],
+                    "title": r.get("title", ""),
+                    "city": r.get("city", ""),
+                    "pokemons": _filter_pokemons(r.get("pokemons", []))[:2],
+                    "dist_km": round(_haversine(slat, slng, r["lat"], r["lng"]), 2),
+                    "lat": r["lat"],
+                    "lng": r["lng"],
+                }
+                for r in active
+                if _haversine(slat, slng, r["lat"], r["lng"]) <= MICHINEKI_RADIUS_KM
+            ],
+            key=lambda x: x["dist_km"],
+        )
+        if len(nearby) < MICHINEKI_MIN_COUNT:
+            continue
+        pref = station.get("address", {}).get("addressRegion", "")
+        sid = station.get("identifier", "")
+        candidates.append({
+            "id": f"michineki-{sid}",
+            "type": "michineki",
+            "title": f"{station['name']}周辺のポケふた（{len(nearby)}枚）",
+            "url": station.get("url", f"{BASE_URL}summary/"),
+            "hashtags": ["#ポケふた", "#ポケモンマンホール"],
+            "imageType": "michineki",
+            "source": "michineki",
+            "raw_data": {
+                "station_id": sid,
+                "station_name": station["name"],
+                "pref": pref,
+                "lat": slat,
+                "lng": slng,
+                "manhole_count": len(nearby),
+                "radius_km": MICHINEKI_RADIUS_KM,
+                "manholes": nearby,
+            },
+        })
+    return candidates
+
+
+def gen_remote_island_candidates(records: list[dict]) -> list[dict]:
+    by_pref_city: dict[tuple, list] = {}
+    for r in records:
+        if r.get("status") != "active":
+            continue
+        key = (r.get("prefecture", ""), r.get("city", ""))
+        by_pref_city.setdefault(key, []).append(r)
+
+    candidates = []
+    for island in ISLAND_CITY_MAP:
+        manholes = by_pref_city.get((island["pref"], island["city"]), [])
+        if not manholes:
+            continue
+        poke_counter: Counter = Counter()
+        for m in manholes:
+            for p in _filter_pokemons(m.get("pokemons", [])):
+                poke_counter[p] += 1
+        candidates.append({
+            "id": f"island-{island['city']}",
+            "type": "remote_island",
+            "title": f"{island['island_name']}のポケふた（{len(manholes)}枚）",
+            "url": f"{BASE_URL}summary/",
+            "hashtags": ["#ポケふた", "#ポケモンマンホール"],
+            "imageType": "remote_island",
+            "source": "remote_island",
+            "raw_data": {
+                "island_name": island["island_name"],
+                "pref": island["pref"],
+                "city": island["city"],
+                "manhole_count": len(manholes),
+                "manholes": [
+                    {
+                        "id": m["id"],
+                        "title": m.get("title", ""),
+                        "pokemons": _filter_pokemons(m.get("pokemons", []))[:3],
+                        "lat": m.get("lat"),
+                        "lng": m.get("lng"),
+                    }
+                    for m in manholes
+                ],
+                "top_pokemons": [p for p, _ in poke_counter.most_common(3)],
+            },
+        })
+    return candidates
+
+
 def main() -> int:
     if not NDJSON.exists():
         print(f"[ERROR] {NDJSON} not found")
@@ -460,6 +589,7 @@ def main() -> int:
     records_by_id = {str(r.get("id", "")): r for r in active_records}
     pokemon_metadata = load_pokemon_metadata(POKEMON_METADATA_JSON)
     photos_data = load_photos(PHOTOS_JSON)
+    michineki = load_michineki(MICHINEKI_JSON)
 
     stats = build_stats(active_records)
     pokemon_stats = build_pokemon_stats(active_records, pokemon_metadata)
@@ -471,6 +601,8 @@ def main() -> int:
     candidates.extend(gen_latest_photo_candidates(photos_data, records_by_id))
     candidates.extend(gen_no_photo_candidates(records, photos_data))
     candidates.extend(gen_travel_trivia_candidates(stats, pokemon_stats))
+    candidates.extend(gen_michineki_candidates(active_records, michineki))
+    candidates.extend(gen_remote_island_candidates(active_records))
 
     CANDIDATES_JSON.write_text(
         json.dumps(candidates, ensure_ascii=False, indent=2), encoding="utf-8"

--- a/docs/social-post-candidates.json
+++ b/docs/social-post-candidates.json
@@ -516,10 +516,10 @@
     }
   },
   {
-    "id": "photo-190-66931efd",
+    "id": "photo-2-3743c530",
     "type": "latest_photo",
-    "title": "最新写真：北海道/登別市",
-    "url": "https://data.pokefuta.com/manholes/190/",
+    "title": "最新写真：鹿児島県/指宿市",
+    "url": "https://data.pokefuta.com/manholes/2/",
     "hashtags": [
       "#ポケふた",
       "#ポケモンマンホール"
@@ -527,24 +527,240 @@
     "imageType": "latest_photo",
     "source": "photos",
     "raw_data": {
-      "manhole_id": "190",
-      "title": "北海道/登別市",
-      "pref": "北海道",
-      "city": "登別",
-      "pokemon": "キテルグマ",
+      "manhole_id": "2",
+      "title": "鹿児島県/指宿市",
+      "pref": "鹿児島県",
+      "city": "指宿",
+      "pokemon": "シャワーズ",
       "pokemon_list": [
-        "キテルグマ",
+        "シャワーズ"
+      ],
+      "created_at": "2026-06-08T12:44:04.97427+00:00",
+      "image_url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image/photos/original/2026/06/cbc4abfc-c5c0-4a92-9043-0134687eb9b1.jpg"
+    }
+  },
+  {
+    "id": "photo-4-f7170f8e",
+    "type": "latest_photo",
+    "title": "最新写真：鹿児島県/指宿市",
+    "url": "https://data.pokefuta.com/manholes/4/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "latest_photo",
+    "source": "photos",
+    "raw_data": {
+      "manhole_id": "4",
+      "title": "鹿児島県/指宿市",
+      "pref": "鹿児島県",
+      "city": "指宿",
+      "pokemon": "ブースター",
+      "pokemon_list": [
+        "ブースター"
+      ],
+      "created_at": "2026-06-08T12:30:24.811681+00:00",
+      "image_url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image/photos/original/2026/06/a3e1cd70-c3fc-4ea3-898a-cd1a2872fa30.jpg"
+    }
+  },
+  {
+    "id": "photo-5-7e8527e4",
+    "type": "latest_photo",
+    "title": "最新写真：鹿児島県/指宿市",
+    "url": "https://data.pokefuta.com/manholes/5/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "latest_photo",
+    "source": "photos",
+    "raw_data": {
+      "manhole_id": "5",
+      "title": "鹿児島県/指宿市",
+      "pref": "鹿児島県",
+      "city": "指宿",
+      "pokemon": "エーフィ",
+      "pokemon_list": [
+        "エーフィ"
+      ],
+      "created_at": "2026-06-08T12:29:57.344876+00:00",
+      "image_url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image/photos/original/2026/06/2b917d24-b884-4ece-b622-43830b78edda.jpg"
+    }
+  },
+  {
+    "id": "photo-1-6ed18cd0",
+    "type": "latest_photo",
+    "title": "最新写真：鹿児島県/指宿市",
+    "url": "https://data.pokefuta.com/manholes/1/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "latest_photo",
+    "source": "photos",
+    "raw_data": {
+      "manhole_id": "1",
+      "title": "鹿児島県/指宿市",
+      "pref": "鹿児島県",
+      "city": "指宿",
+      "pokemon": "イーブイ",
+      "pokemon_list": [
+        "イーブイ"
+      ],
+      "created_at": "2026-06-08T12:29:36.33282+00:00",
+      "image_url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image/photos/original/2026/06/19a6ab1e-37ad-4a75-8ad5-64e21f916926.jpg"
+    }
+  },
+  {
+    "id": "photo-6-948753b5",
+    "type": "latest_photo",
+    "title": "最新写真：鹿児島県/指宿市",
+    "url": "https://data.pokefuta.com/manholes/6/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "latest_photo",
+    "source": "photos",
+    "raw_data": {
+      "manhole_id": "6",
+      "title": "鹿児島県/指宿市",
+      "pref": "鹿児島県",
+      "city": "指宿",
+      "pokemon": "ブラッキー",
+      "pokemon_list": [
+        "ブラッキー"
+      ],
+      "created_at": "2026-06-08T12:29:21.85972+00:00",
+      "image_url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image/photos/original/2026/06/87875557-3661-4c2d-a351-0521c7b669d5.jpg"
+    }
+  },
+  {
+    "id": "photo-9-7f5ad5d6",
+    "type": "latest_photo",
+    "title": "最新写真：鹿児島県/指宿市",
+    "url": "https://data.pokefuta.com/manholes/9/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "latest_photo",
+    "source": "photos",
+    "raw_data": {
+      "manhole_id": "9",
+      "title": "鹿児島県/指宿市",
+      "pref": "鹿児島県",
+      "city": "指宿",
+      "pokemon": "ニンフィア",
+      "pokemon_list": [
+        "ニンフィア"
+      ],
+      "created_at": "2026-06-08T12:28:58.304891+00:00",
+      "image_url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image/photos/original/2026/06/7cdb6dc0-1e61-4504-8978-4cbfdb4ad0e6.jpg"
+    }
+  },
+  {
+    "id": "photo-8-917148f1",
+    "type": "latest_photo",
+    "title": "最新写真：鹿児島県/指宿市",
+    "url": "https://data.pokefuta.com/manholes/8/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "latest_photo",
+    "source": "photos",
+    "raw_data": {
+      "manhole_id": "8",
+      "title": "鹿児島県/指宿市",
+      "pref": "鹿児島県",
+      "city": "指宿",
+      "pokemon": "グレイシア",
+      "pokemon_list": [
+        "グレイシア"
+      ],
+      "created_at": "2026-06-08T12:28:39.276797+00:00",
+      "image_url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image/photos/original/2026/06/2db39040-51d1-4186-baac-184276609d77.jpg"
+    }
+  },
+  {
+    "id": "photo-3-69fcb47b",
+    "type": "latest_photo",
+    "title": "最新写真：鹿児島県/指宿市",
+    "url": "https://data.pokefuta.com/manholes/3/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "latest_photo",
+    "source": "photos",
+    "raw_data": {
+      "manhole_id": "3",
+      "title": "鹿児島県/指宿市",
+      "pref": "鹿児島県",
+      "city": "指宿",
+      "pokemon": "サンダース",
+      "pokemon_list": [
+        "サンダース"
+      ],
+      "created_at": "2026-06-08T12:27:08.11311+00:00",
+      "image_url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image/photos/original/2026/06/3fc80d82-c14e-4d7b-b48a-a8b98bf96349.jpg"
+    }
+  },
+  {
+    "id": "photo-7-be15815b",
+    "type": "latest_photo",
+    "title": "最新写真：鹿児島県/指宿市",
+    "url": "https://data.pokefuta.com/manholes/7/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "latest_photo",
+    "source": "photos",
+    "raw_data": {
+      "manhole_id": "7",
+      "title": "鹿児島県/指宿市",
+      "pref": "鹿児島県",
+      "city": "指宿",
+      "pokemon": "リーフィア",
+      "pokemon_list": [
+        "リーフィア"
+      ],
+      "created_at": "2026-06-08T12:26:17.591118+00:00",
+      "image_url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image/photos/original/2026/06/2cc7c390-e2b1-4a51-9d2b-2b94746f67a9.jpg"
+    }
+  },
+  {
+    "id": "photo-220-62b9eb76",
+    "type": "latest_photo",
+    "title": "最新写真：北海道/斜里町",
+    "url": "https://data.pokefuta.com/manholes/220/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "latest_photo",
+    "source": "photos",
+    "raw_data": {
+      "manhole_id": "220",
+      "title": "北海道/斜里町",
+      "pref": "北海道",
+      "city": "斜里",
+      "pokemon": "パルキア",
+      "pokemon_list": [
+        "パルキア",
         "ロコン"
       ],
-      "created_at": "2026-05-24T14:35:01.187701+00:00",
-      "image_url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image/photos/original/2026/05/755f79ac-3dcd-4d02-9932-46d49ce35665.jpg"
+      "created_at": "2026-06-03T02:32:14.472542+00:00",
+      "image_url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image/photos/original/2026/06/1f7a16d7-8ee9-4011-8d36-b1517a38a073.jpg"
     }
   },
   {
-    "id": "photo-141-866ab293",
+    "id": "photo-217-f72ceb3e",
     "type": "latest_photo",
-    "title": "最新写真：北海道/三笠市",
-    "url": "https://data.pokefuta.com/manholes/141/",
+    "title": "最新写真：北海道/網走市",
+    "url": "https://data.pokefuta.com/manholes/217/",
     "hashtags": [
       "#ポケふた",
       "#ポケモンマンホール"
@@ -552,269 +768,42 @@
     "imageType": "latest_photo",
     "source": "photos",
     "raw_data": {
-      "manhole_id": "141",
-      "title": "北海道/三笠市",
+      "manhole_id": "217",
+      "title": "北海道/網走市",
       "pref": "北海道",
-      "city": "三笠",
-      "pokemon": "オムナイト",
+      "city": "網走",
+      "pokemon": "アローラロコン",
       "pokemon_list": [
-        "オムナイト",
-        "ズガイドス",
+        "アローラロコン",
+        "マニューラ"
+      ],
+      "created_at": "2026-06-02T07:30:41.996332+00:00",
+      "image_url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image/photos/original/2026/06/735b02d4-8338-4970-b0bd-a29db9e41df7.jpg"
+    }
+  },
+  {
+    "id": "photo-71-ac803346",
+    "type": "latest_photo",
+    "title": "最新写真：北海道/大空町",
+    "url": "https://data.pokefuta.com/manholes/71/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "latest_photo",
+    "source": "photos",
+    "raw_data": {
+      "manhole_id": "71",
+      "title": "北海道/大空町",
+      "pref": "北海道",
+      "city": "大空",
+      "pokemon": "ムクホーク",
+      "pokemon_list": [
+        "ムクホーク",
         "ロコン"
       ],
-      "created_at": "2026-05-24T14:30:56.930694+00:00",
-      "image_url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image/photos/original/2026/05/63295206-f77c-4ab2-a7d1-79faadbded8c.jpg"
-    }
-  },
-  {
-    "id": "photo-272-f0406523",
-    "type": "latest_photo",
-    "title": "最新写真：愛知県/豊橋市",
-    "url": "https://data.pokefuta.com/manholes/272/",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "latest_photo",
-    "source": "photos",
-    "raw_data": {
-      "manhole_id": "272",
-      "title": "愛知県/豊橋市",
-      "pref": "愛知県",
-      "city": "豊橋市",
-      "pokemon": "アゴジムシ",
-      "pokemon_list": [
-        "アゴジムシ",
-        "アブリボン"
-      ],
-      "created_at": "2026-05-24T00:46:17.867307+00:00",
-      "image_url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image/photos/original/2026/05/02167329-16b6-410e-a14f-e7d13e8219fd.jpg"
-    }
-  },
-  {
-    "id": "photo-404-9c19966f",
-    "type": "latest_photo",
-    "title": "最新写真：愛知県/名古屋市",
-    "url": "https://data.pokefuta.com/manholes/404/",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "latest_photo",
-    "source": "photos",
-    "raw_data": {
-      "manhole_id": "404",
-      "title": "愛知県/名古屋市",
-      "pref": "愛知県",
-      "city": "名古屋市中区",
-      "pokemon": "コイキング",
-      "pokemon_list": [
-        "コイキング",
-        "ネッコアラ"
-      ],
-      "created_at": "2026-05-10T16:34:21.982399+00:00",
-      "image_url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image/photos/original/2026/05/7b277c01-81d5-4507-be22-94738e3d752a.jpg"
-    }
-  },
-  {
-    "id": "photo-359-59dd83ea",
-    "type": "latest_photo",
-    "title": "最新写真：岐阜県/各務原市",
-    "url": "https://data.pokefuta.com/manholes/359/",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "latest_photo",
-    "source": "photos",
-    "raw_data": {
-      "manhole_id": "359",
-      "title": "岐阜県/各務原市",
-      "pref": "岐阜県",
-      "city": "各務原",
-      "pokemon": "ドジョッチ",
-      "pokemon_list": [
-        "ドジョッチ",
-        "ナマズン"
-      ],
-      "created_at": "2026-05-10T14:37:18.025776+00:00",
-      "image_url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image/photos/original/2026/05/e0a2fdfb-016f-4b3a-aa7f-6aa3a0cf3c08.jpg"
-    }
-  },
-  {
-    "id": "photo-362-cf7edd1a",
-    "type": "latest_photo",
-    "title": "最新写真：岐阜県/関ケ原町",
-    "url": "https://data.pokefuta.com/manholes/362/",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "latest_photo",
-    "source": "photos",
-    "raw_data": {
-      "manhole_id": "362",
-      "title": "岐阜県/関ケ原町",
-      "pref": "岐阜県",
-      "city": "関ケ原",
-      "pokemon": "コマタナ",
-      "pokemon_list": [
-        "コマタナ",
-        "ドドゲザン"
-      ],
-      "created_at": "2026-05-10T14:36:35.65277+00:00",
-      "image_url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image/photos/original/2026/05/86b7002e-5287-4f9f-89ec-5d6f90cb9279.jpg"
-    }
-  },
-  {
-    "id": "photo-385-7e906a40",
-    "type": "latest_photo",
-    "title": "最新写真：三重県/いなべ市",
-    "url": "https://data.pokefuta.com/manholes/385/",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "latest_photo",
-    "source": "photos",
-    "raw_data": {
-      "manhole_id": "385",
-      "title": "三重県/いなべ市",
-      "pref": "三重県",
-      "city": "いなべ市",
-      "pokemon": "プラスル",
-      "pokemon_list": [
-        "プラスル",
-        "マイナン",
-        "ミジュマル"
-      ],
-      "created_at": "2026-05-10T14:35:58.391514+00:00",
-      "image_url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image/photos/original/2026/05/de485e09-5c17-43d9-aa7f-d82ce1a0bf6a.jpg"
-    }
-  },
-  {
-    "id": "photo-406-78ce48ab",
-    "type": "latest_photo",
-    "title": "最新写真：愛知県/常滑市",
-    "url": "https://data.pokefuta.com/manholes/406/",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "latest_photo",
-    "source": "photos",
-    "raw_data": {
-      "manhole_id": "406",
-      "title": "愛知県/常滑市",
-      "pref": "愛知県",
-      "city": "常滑",
-      "pokemon": "アローラニャース",
-      "pokemon_list": [
-        "アローラニャース",
-        "ピジョット"
-      ],
-      "created_at": "2026-05-10T14:32:40.029181+00:00",
-      "image_url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image/photos/original/2026/05/75a15376-07d7-41aa-9fc8-90e4a32a0e81.jpg"
-    }
-  },
-  {
-    "id": "photo-332-09c55bc3",
-    "type": "latest_photo",
-    "title": "最新写真：三重県/多気町",
-    "url": "https://data.pokefuta.com/manholes/332/",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "latest_photo",
-    "source": "photos",
-    "raw_data": {
-      "manhole_id": "332",
-      "title": "三重県/多気町",
-      "pref": "三重県",
-      "city": "多気郡多気町",
-      "pokemon": "グルトン",
-      "pokemon_list": [
-        "グルトン",
-        "ゴマゾウ",
-        "ミジュマル"
-      ],
-      "created_at": "2026-05-10T14:31:18.472511+00:00",
-      "image_url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image/photos/original/2026/05/527dd838-f8d9-4a18-abed-7214a8b8767e.jpg"
-    }
-  },
-  {
-    "id": "photo-334-61b5c3d9",
-    "type": "latest_photo",
-    "title": "最新写真：三重県/玉城町",
-    "url": "https://data.pokefuta.com/manholes/334/",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "latest_photo",
-    "source": "photos",
-    "raw_data": {
-      "manhole_id": "334",
-      "title": "三重県/玉城町",
-      "pref": "三重県",
-      "city": "度会郡玉城町",
-      "pokemon": "バネブー",
-      "pokemon_list": [
-        "バネブー",
-        "ミジュマル"
-      ],
-      "created_at": "2026-05-10T14:30:01.270535+00:00",
-      "image_url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image/photos/original/2026/05/181baf55-7e6f-45f3-b0ef-8a661ed06551.jpg"
-    }
-  },
-  {
-    "id": "photo-242-99bcd345",
-    "type": "latest_photo",
-    "title": "最新写真：三重県/伊勢市",
-    "url": "https://data.pokefuta.com/manholes/242/",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "latest_photo",
-    "source": "photos",
-    "raw_data": {
-      "manhole_id": "242",
-      "title": "三重県/伊勢市",
-      "pref": "三重県",
-      "city": "伊勢市",
-      "pokemon": "ミジュマル",
-      "pokemon_list": [
-        "ミジュマル",
-        "リーシャン"
-      ],
-      "created_at": "2026-05-10T14:26:40.896826+00:00",
-      "image_url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image/photos/original/2026/05/59ab6fc8-5872-4119-a846-0c557b4a5e09.jpg"
-    }
-  },
-  {
-    "id": "photo-301-f8952706",
-    "type": "latest_photo",
-    "title": "最新写真：石川県/金沢市",
-    "url": "https://data.pokefuta.com/manholes/301/",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "latest_photo",
-    "source": "photos",
-    "raw_data": {
-      "manhole_id": "301",
-      "title": "石川県/金沢市",
-      "pref": "石川県",
-      "city": "金沢",
-      "pokemon": "ミロカロス",
-      "pokemon_list": [
-        "ミロカロス"
-      ],
-      "created_at": "2026-05-10T14:21:18.038551+00:00",
-      "image_url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image/photos/original/2026/05/fc3938bd-90ca-44b9-b4da-58cb53fe9124.jpg"
+      "created_at": "2026-06-02T07:30:12.199062+00:00",
+      "image_url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image/photos/original/2026/06/ac462b6d-b110-4a2c-8f6e-82ffdac20687.jpg"
     }
   },
   {
@@ -1037,6 +1026,3224 @@
         ],
         "total": 470
       }
+    }
+  },
+  {
+    "id": "michineki-04003",
+    "type": "michineki",
+    "title": "道の駅三本木周辺のポケふた（3枚）",
+    "url": "https://it-social.net/roadside_station/?04003",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "04003",
+      "station_name": "道の駅三本木",
+      "pref": "宮城県",
+      "lat": 38.521611,
+      "lng": 140.938388,
+      "manhole_count": 3,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "124",
+          "title": "宮城県/大崎市",
+          "city": "大崎",
+          "pokemons": [
+            "オニスズメ",
+            "ダグトリオ"
+          ],
+          "dist_km": 6.08,
+          "lat": 38.571356,
+          "lng": 140.967465
+        },
+        {
+          "id": "136",
+          "title": "宮城県/色麻町",
+          "city": "色麻",
+          "pokemons": [
+            "ハスブレロ",
+            "ラプラス"
+          ],
+          "dist_km": 6.76,
+          "lat": 38.530136,
+          "lng": 140.86142
+        },
+        {
+          "id": "135",
+          "title": "宮城県/大衡村",
+          "city": "大衡",
+          "pokemons": [
+            "プルリル",
+            "ラブカス"
+          ],
+          "dist_km": 7.16,
+          "lat": 38.46943814,
+          "lng": 140.8902292
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-04006",
+    "type": "michineki",
+    "title": "道の駅おおさと周辺のポケふた（4枚）",
+    "url": "https://it-social.net/roadside_station/?04006",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "04006",
+      "station_name": "道の駅おおさと",
+      "pref": "宮城県",
+      "lat": 38.424053,
+      "lng": 140.992791,
+      "manhole_count": 4,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "134",
+          "title": "宮城県/大郷町",
+          "city": "大郷",
+          "pokemons": [
+            "チュリネ",
+            "ラプラス"
+          ],
+          "dist_km": 0.01,
+          "lat": 38.424016,
+          "lng": 140.992673
+        },
+        {
+          "id": "49",
+          "title": "宮城県/松島町",
+          "city": "松島",
+          "pokemons": [
+            "ラプラス"
+          ],
+          "dist_km": 8.55,
+          "lat": 38.368987,
+          "lng": 141.061207
+        },
+        {
+          "id": "133",
+          "title": "宮城県/大和町",
+          "city": "大和",
+          "pokemons": [
+            "タマゲタケ",
+            "ドダイトス"
+          ],
+          "dist_km": 9.45,
+          "lat": 38.437364,
+          "lng": 140.885648
+        },
+        {
+          "id": "125",
+          "title": "宮城県/富谷市",
+          "city": "富谷",
+          "pokemons": [
+            "ブルー",
+            "ラプラス"
+          ],
+          "dist_km": 9.61,
+          "lat": 38.398336,
+          "lng": 140.8875
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-04012",
+    "type": "michineki",
+    "title": "道の駅村田周辺のポケふた（4枚）",
+    "url": "https://it-social.net/roadside_station/?04012",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "04012",
+      "station_name": "道の駅村田",
+      "pref": "宮城県",
+      "lat": 38.118639,
+      "lng": 140.717279,
+      "manhole_count": 4,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "129",
+          "title": "宮城県/村田町",
+          "city": "村田",
+          "pokemons": [
+            "ベロベルト",
+            "ラプラス"
+          ],
+          "dist_km": 0.07,
+          "lat": 38.119071,
+          "lng": 140.717821
+        },
+        {
+          "id": "130",
+          "title": "宮城県/柴田町",
+          "city": "柴田",
+          "pokemons": [
+            "フラベベ",
+            "ラプラス"
+          ],
+          "dist_km": 7.98,
+          "lat": 38.059143,
+          "lng": 140.768239
+        },
+        {
+          "id": "128",
+          "title": "宮城県/大河原町",
+          "city": "大河原",
+          "pokemons": [
+            "チェリム",
+            "ラプラス"
+          ],
+          "dist_km": 8.01,
+          "lat": 38.0485032,
+          "lng": 140.738089
+        },
+        {
+          "id": "131",
+          "title": "宮城県/川崎町",
+          "city": "川崎",
+          "pokemons": [
+            "ラプラス"
+          ],
+          "dist_km": 9.18,
+          "lat": 38.177534,
+          "lng": 140.643653
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-04015",
+    "type": "michineki",
+    "title": "道の駅かくだ周辺のポケふた（3枚）",
+    "url": "https://it-social.net/roadside_station/?04015",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "04015",
+      "station_name": "道の駅かくだ",
+      "pref": "宮城県",
+      "lat": 37.968556,
+      "lng": 140.807611,
+      "manhole_count": 3,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "121",
+          "title": "宮城県/角田市",
+          "city": "角田",
+          "pokemons": [
+            "ラティアス",
+            "ラプラス"
+          ],
+          "dist_km": 0.05,
+          "lat": 37.968694,
+          "lng": 140.807077
+        },
+        {
+          "id": "132",
+          "title": "宮城県/丸森町",
+          "city": "丸森",
+          "pokemons": [
+            "ニャスパー",
+            "ニャース"
+          ],
+          "dist_km": 7.25,
+          "lat": 37.913873,
+          "lng": 140.762531
+        },
+        {
+          "id": "58",
+          "title": "宮城県/山元町",
+          "city": "山元",
+          "pokemons": [
+            "ラッキー",
+            "ラプラス"
+          ],
+          "dist_km": 9.57,
+          "lat": 37.923988,
+          "lng": 140.900996
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-07010",
+    "type": "michineki",
+    "title": "道の駅会津柳津周辺のポケふた（3枚）",
+    "url": "https://it-social.net/roadside_station/?07010",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "07010",
+      "station_name": "道の駅会津柳津",
+      "pref": "福島県",
+      "lat": 37.527693,
+      "lng": 139.7221754,
+      "manhole_count": 3,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "251",
+          "title": "福島県/柳津町",
+          "city": "柳津",
+          "pokemons": [
+            "ピンプク",
+            "ラッキー"
+          ],
+          "dist_km": 0.07,
+          "lat": 37.528189,
+          "lng": 139.722662
+        },
+        {
+          "id": "369",
+          "title": "福島県/会津坂下町",
+          "city": "会津坂下",
+          "pokemons": [
+            "カイリキー",
+            "ラッキー"
+          ],
+          "dist_km": 9.46,
+          "lat": 37.56046,
+          "lng": 139.821186
+        },
+        {
+          "id": "457",
+          "title": "福島県/西会津町",
+          "city": "西会津",
+          "pokemons": [
+            "ピクシー",
+            "マシェード"
+          ],
+          "dist_km": 9.51,
+          "lat": 37.585568,
+          "lng": 139.642677
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-07014",
+    "type": "michineki",
+    "title": "道の駅たまかわ周辺のポケふた（3枚）",
+    "url": "https://it-social.net/roadside_station/?07014",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "07014",
+      "station_name": "道の駅たまかわ",
+      "pref": "福島県",
+      "lat": 37.2228324,
+      "lng": 140.4181372,
+      "manhole_count": 3,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "370",
+          "title": "福島県/鏡石町",
+          "city": "鏡石",
+          "pokemons": [
+            "ミルタンク",
+            "メリープ"
+          ],
+          "dist_km": 7.03,
+          "lat": 37.251117,
+          "lng": 140.347153
+        },
+        {
+          "id": "285",
+          "title": "福島県/矢吹町",
+          "city": "矢吹",
+          "pokemons": [
+            "ファイアロー",
+            "ラッキー"
+          ],
+          "dist_km": 7.32,
+          "lat": 37.21842,
+          "lng": 140.335635
+        },
+        {
+          "id": "454",
+          "title": "福島県/須賀川市",
+          "city": "須賀川",
+          "pokemons": [
+            "マフォクシー",
+            "ラッキー"
+          ],
+          "dist_km": 8.25,
+          "lat": 37.291536,
+          "lng": 140.382947
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-07023",
+    "type": "michineki",
+    "title": "道の駅季の里天栄周辺のポケふた（3枚）",
+    "url": "https://it-social.net/roadside_station/?07023",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "07023",
+      "station_name": "道の駅季の里天栄",
+      "pref": "福島県",
+      "lat": 37.2436603,
+      "lng": 140.2447857,
+      "manhole_count": 3,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "455",
+          "title": "福島県/天栄村",
+          "city": "天栄",
+          "pokemons": [
+            "イエッサン",
+            "ラッキー"
+          ],
+          "dist_km": 0.1,
+          "lat": 37.243406,
+          "lng": 140.243722
+        },
+        {
+          "id": "285",
+          "title": "福島県/矢吹町",
+          "city": "矢吹",
+          "pokemons": [
+            "ファイアロー",
+            "ラッキー"
+          ],
+          "dist_km": 8.52,
+          "lat": 37.21842,
+          "lng": 140.335635
+        },
+        {
+          "id": "370",
+          "title": "福島県/鏡石町",
+          "city": "鏡石",
+          "pokemons": [
+            "ミルタンク",
+            "メリープ"
+          ],
+          "dist_km": 9.1,
+          "lat": 37.251117,
+          "lng": 140.347153
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-07034",
+    "type": "michineki",
+    "title": "道の駅なみえ周辺のポケふた（3枚）",
+    "url": "https://it-social.net/roadside_station/?07034",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "07034",
+      "station_name": "道の駅なみえ",
+      "pref": "福島県",
+      "lat": 37.496278,
+      "lng": 141.000278,
+      "manhole_count": 3,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "91",
+          "title": "福島県/浪江町",
+          "city": "浪江",
+          "pokemons": [
+            "ラッキー"
+          ],
+          "dist_km": 0.06,
+          "lat": 37.496395,
+          "lng": 141.000919
+        },
+        {
+          "id": "253",
+          "title": "福島県/双葉町",
+          "city": "双葉",
+          "pokemons": [
+            "ヒマナッツ",
+            "ラッキー"
+          ],
+          "dist_km": 4.92,
+          "lat": 37.45745,
+          "lng": 141.02692
+        },
+        {
+          "id": "462",
+          "title": "福島県/大熊町",
+          "city": "大熊",
+          "pokemons": [
+            "キテルグマ",
+            "ヌイコグマ"
+          ],
+          "dist_km": 9.72,
+          "lat": 37.4099576,
+          "lng": 140.983206
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-08008",
+    "type": "michineki",
+    "title": "道の駅いたこ周辺のポケふた（3枚）",
+    "url": "https://it-social.net/roadside_station/?08008",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "08008",
+      "station_name": "道の駅いたこ",
+      "pref": "茨城県",
+      "lat": 35.9461322,
+      "lng": 140.5892448,
+      "manhole_count": 3,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "224",
+          "title": "千葉県/香取市",
+          "city": "香取",
+          "pokemons": [
+            "フラージェス",
+            "ヤヤコマ"
+          ],
+          "dist_km": 6.25,
+          "lat": 35.928206,
+          "lng": 140.523401
+        },
+        {
+          "id": "409",
+          "title": "茨城県/神栖市",
+          "city": "神栖",
+          "pokemons": [
+            "オトシドリ",
+            "マラカッチ"
+          ],
+          "dist_km": 7.65,
+          "lat": 35.897341,
+          "lng": 140.649095
+        },
+        {
+          "id": "225",
+          "title": "千葉県/香取市",
+          "city": "香取",
+          "pokemons": [
+            "タネボー",
+            "ハスボー"
+          ],
+          "dist_km": 9.3,
+          "lat": 35.896204,
+          "lng": 140.506419
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-12021",
+    "type": "michineki",
+    "title": "道の駅水の郷さわら周辺のポケふた（4枚）",
+    "url": "https://it-social.net/roadside_station/?12021",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "12021",
+      "station_name": "道の駅水の郷さわら",
+      "pref": "千葉県",
+      "lat": 35.896313,
+      "lng": 140.505908,
+      "manhole_count": 4,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "225",
+          "title": "千葉県/香取市",
+          "city": "香取",
+          "pokemons": [
+            "タネボー",
+            "ハスボー"
+          ],
+          "dist_km": 0.05,
+          "lat": 35.896204,
+          "lng": 140.506419
+        },
+        {
+          "id": "222",
+          "title": "千葉県/香取市",
+          "city": "香取",
+          "pokemons": [
+            "ガラルカモネギ"
+          ],
+          "dist_km": 1.1,
+          "lat": 35.894417,
+          "lng": 140.493902
+        },
+        {
+          "id": "223",
+          "title": "千葉県/香取市",
+          "city": "香取",
+          "pokemons": [
+            "ココガラ",
+            "タイレーツ"
+          ],
+          "dist_km": 1.16,
+          "lat": 35.888376,
+          "lng": 140.497568
+        },
+        {
+          "id": "224",
+          "title": "千葉県/香取市",
+          "city": "香取",
+          "pokemons": [
+            "フラージェス",
+            "ヤヤコマ"
+          ],
+          "dist_km": 3.88,
+          "lat": 35.928206,
+          "lng": 140.523401
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-15009",
+    "type": "michineki",
+    "title": "道の駅ちぢみの里おぢや周辺のポケふた（4枚）",
+    "url": "https://it-social.net/roadside_station/?15009",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "15009",
+      "station_name": "道の駅ちぢみの里おぢや",
+      "pref": "新潟県",
+      "lat": 37.305143,
+      "lng": 138.822908,
+      "manhole_count": 4,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "145",
+          "title": "新潟県/小千谷市",
+          "city": "小千谷",
+          "pokemons": [
+            "コイキング"
+          ],
+          "dist_km": 1.03,
+          "lat": 37.309883,
+          "lng": 138.812939
+        },
+        {
+          "id": "146",
+          "title": "新潟県/小千谷市",
+          "city": "小千谷",
+          "pokemons": [
+            "コイキング",
+            "ヒンバス"
+          ],
+          "dist_km": 2.5,
+          "lat": 37.311028,
+          "lng": 138.795653
+        },
+        {
+          "id": "144",
+          "title": "新潟県/小千谷市",
+          "city": "小千谷",
+          "pokemons": [
+            "コイキング"
+          ],
+          "dist_km": 2.68,
+          "lat": 37.314216,
+          "lng": 138.794792
+        },
+        {
+          "id": "147",
+          "title": "新潟県/小千谷市",
+          "city": "小千谷",
+          "pokemons": [
+            "コイキング",
+            "ピジョン"
+          ],
+          "dist_km": 3.63,
+          "lat": 37.314301,
+          "lng": 138.7835
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-15032",
+    "type": "michineki",
+    "title": "道の駅越後川口周辺のポケふた（4枚）",
+    "url": "https://it-social.net/roadside_station/?15032",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "15032",
+      "station_name": "道の駅越後川口",
+      "pref": "新潟県",
+      "lat": 37.2608955,
+      "lng": 138.8676387,
+      "manhole_count": 4,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "145",
+          "title": "新潟県/小千谷市",
+          "city": "小千谷",
+          "pokemons": [
+            "コイキング"
+          ],
+          "dist_km": 7.29,
+          "lat": 37.309883,
+          "lng": 138.812939
+        },
+        {
+          "id": "146",
+          "title": "新潟県/小千谷市",
+          "city": "小千谷",
+          "pokemons": [
+            "コイキング",
+            "ヒンバス"
+          ],
+          "dist_km": 8.46,
+          "lat": 37.311028,
+          "lng": 138.795653
+        },
+        {
+          "id": "144",
+          "title": "新潟県/小千谷市",
+          "city": "小千谷",
+          "pokemons": [
+            "コイキング"
+          ],
+          "dist_km": 8.76,
+          "lat": 37.314216,
+          "lng": 138.794792
+        },
+        {
+          "id": "147",
+          "title": "新潟県/小千谷市",
+          "city": "小千谷",
+          "pokemons": [
+            "コイキング",
+            "ピジョン"
+          ],
+          "dist_km": 9.52,
+          "lat": 37.314301,
+          "lng": 138.7835
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-18016",
+    "type": "michineki",
+    "title": "道の駅恐竜渓谷かつやま周辺のポケふた（3枚）",
+    "url": "https://it-social.net/roadside_station/?18016",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "18016",
+      "station_name": "道の駅恐竜渓谷かつやま",
+      "pref": "福井県",
+      "lat": 36.072056,
+      "lng": 136.47875,
+      "manhole_count": 3,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "336",
+          "title": "福井県/勝山市",
+          "city": "勝山",
+          "pokemons": [
+            "アーケン",
+            "カイリュー"
+          ],
+          "dist_km": 2.07,
+          "lat": 36.056787,
+          "lng": 136.492007
+        },
+        {
+          "id": "339",
+          "title": "福井県/永平寺町",
+          "city": "永平寺",
+          "pokemons": [
+            "カイリュー",
+            "ダクマ"
+          ],
+          "dist_km": 7.19,
+          "lat": 36.079891,
+          "lng": 136.399312
+        },
+        {
+          "id": "364",
+          "title": "福井県/大野市",
+          "city": "大野",
+          "pokemons": [
+            "カイリュー"
+          ],
+          "dist_km": 9.76,
+          "lat": 35.9845016,
+          "lng": 136.4859314
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-18019",
+    "type": "michineki",
+    "title": "道の駅越前たけふ周辺のポケふた（3枚）",
+    "url": "https://it-social.net/roadside_station/?18019",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "18019",
+      "station_name": "道の駅越前たけふ",
+      "pref": "福井県",
+      "lat": 35.895139,
+      "lng": 136.198111,
+      "manhole_count": 3,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "338",
+          "title": "福井県/越前市",
+          "city": "越前",
+          "pokemons": [
+            "エレズン",
+            "カイリュー"
+          ],
+          "dist_km": 0.06,
+          "lat": 35.895286,
+          "lng": 136.198727
+        },
+        {
+          "id": "419",
+          "title": "福井県/鯖江市",
+          "city": "鯖江",
+          "pokemons": [
+            "カイリュー",
+            "サッチムシ"
+          ],
+          "dist_km": 6.3,
+          "lat": 35.950098,
+          "lng": 136.181116
+        },
+        {
+          "id": "366",
+          "title": "福井県/南越前町",
+          "city": "南越前",
+          "pokemons": [
+            "カイリュー",
+            "バタフリー"
+          ],
+          "dist_km": 7.09,
+          "lat": 35.831454,
+          "lng": 136.201365
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-23017",
+    "type": "michineki",
+    "title": "道の駅とよはし周辺のポケふた（4枚）",
+    "url": "https://it-social.net/roadside_station/?23017",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "23017",
+      "station_name": "道の駅とよはし",
+      "pref": "愛知県",
+      "lat": 34.696222,
+      "lng": 137.414833,
+      "manhole_count": 4,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "273",
+          "title": "愛知県/豊橋市",
+          "city": "豊橋市",
+          "pokemons": [
+            "スターミー",
+            "デンヂムシ"
+          ],
+          "dist_km": 0.09,
+          "lat": 34.695901,
+          "lng": 137.413953
+        },
+        {
+          "id": "274",
+          "title": "愛知県/豊橋市",
+          "city": "豊橋市",
+          "pokemons": [
+            "カブト",
+            "クワガノン"
+          ],
+          "dist_km": 3.06,
+          "lat": 34.72096,
+          "lng": 137.429448
+        },
+        {
+          "id": "272",
+          "title": "愛知県/豊橋市",
+          "city": "豊橋市",
+          "pokemons": [
+            "アゴジムシ",
+            "アブリボン"
+          ],
+          "dist_km": 7.93,
+          "lat": 34.762599,
+          "lng": 137.382958
+        },
+        {
+          "id": "271",
+          "title": "愛知県/豊橋市",
+          "city": "豊橋市",
+          "pokemons": [
+            "バクフーン"
+          ],
+          "dist_km": 8.3,
+          "lat": 34.768863,
+          "lng": 137.393843
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-24014",
+    "type": "michineki",
+    "title": "道の駅あやま周辺のポケふた（3枚）",
+    "url": "https://it-social.net/roadside_station/?24014",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "24014",
+      "station_name": "道の駅あやま",
+      "pref": "三重県",
+      "lat": 34.8445672,
+      "lng": 136.1709955,
+      "manhole_count": 3,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "239",
+          "title": "滋賀県/甲賀市",
+          "city": "甲賀",
+          "pokemons": [
+            "ゲコガシラ",
+            "ゲッコウガ"
+          ],
+          "dist_km": 8.18,
+          "lat": 34.900437,
+          "lng": 136.229399
+        },
+        {
+          "id": "237",
+          "title": "滋賀県/甲賀市",
+          "city": "甲賀",
+          "pokemons": [
+            "ゲッコウガ"
+          ],
+          "dist_km": 8.34,
+          "lat": 34.919591,
+          "lng": 136.170196
+        },
+        {
+          "id": "246",
+          "title": "三重県/伊賀市",
+          "city": "伊賀市",
+          "pokemons": [
+            "アギルダー",
+            "ミジュマル"
+          ],
+          "dist_km": 9.34,
+          "lat": 34.767543,
+          "lng": 136.130081
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-24016",
+    "type": "michineki",
+    "title": "道の駅津かわげ周辺のポケふた（4枚）",
+    "url": "https://it-social.net/roadside_station/?24016",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "24016",
+      "station_name": "道の駅津かわげ",
+      "pref": "三重県",
+      "lat": 34.7967069,
+      "lng": 136.5179906,
+      "manhole_count": 4,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "415",
+          "title": "三重県/鈴鹿市",
+          "city": "鈴鹿",
+          "pokemons": [
+            "ミジュマル"
+          ],
+          "dist_km": 6.46,
+          "lat": 34.852227,
+          "lng": 136.538663
+        },
+        {
+          "id": "330",
+          "title": "三重県/鈴鹿市",
+          "city": "鈴鹿市",
+          "pokemons": [
+            "ミジュマル",
+            "モトトカゲ"
+          ],
+          "dist_km": 6.75,
+          "lat": 34.823065,
+          "lng": 136.584609
+        },
+        {
+          "id": "240",
+          "title": "三重県/津市",
+          "city": "津市",
+          "pokemons": [
+            "ミジュマル"
+          ],
+          "dist_km": 8.72,
+          "lat": 34.718493,
+          "lng": 136.5108
+        },
+        {
+          "id": "292",
+          "title": "三重県/亀山市",
+          "city": "亀山市",
+          "pokemons": [
+            "ドダイトス",
+            "ミジュマル"
+          ],
+          "dist_km": 9.49,
+          "lat": 34.8594415,
+          "lng": 136.4474608
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-28016",
+    "type": "michineki",
+    "title": "道の駅うずしお周辺のポケふた（3枚）",
+    "url": "https://it-social.net/roadside_station/?28016",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "28016",
+      "station_name": "道の駅うずしお",
+      "pref": "兵庫県",
+      "lat": 34.2420275,
+      "lng": 134.6597796,
+      "manhole_count": 3,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "327",
+          "title": "徳島県/鳴門市",
+          "city": "鳴門",
+          "pokemons": [
+            "スイクン"
+          ],
+          "dist_km": 2.94,
+          "lat": 34.224106,
+          "lng": 134.636196
+        },
+        {
+          "id": "328",
+          "title": "徳島県/鳴門市",
+          "city": "鳴門",
+          "pokemons": [
+            "キングドラ",
+            "シードラ"
+          ],
+          "dist_km": 8.55,
+          "lat": 34.181955,
+          "lng": 134.601709
+        },
+        {
+          "id": "329",
+          "title": "徳島県/鳴門市",
+          "city": "鳴門",
+          "pokemons": [
+            "ディグダ",
+            "ニョロゾ"
+          ],
+          "dist_km": 9.14,
+          "lat": 34.168084,
+          "lng": 134.616371
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-29005",
+    "type": "michineki",
+    "title": "道の駅ふたかみパーク當麻周辺のポケふた（4枚）",
+    "url": "https://it-social.net/roadside_station/?29005",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "29005",
+      "station_name": "道の駅ふたかみパーク當麻",
+      "pref": "奈良県",
+      "lat": 34.5265079,
+      "lng": 135.6932765,
+      "manhole_count": 4,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "148",
+          "title": "奈良県/斑鳩町",
+          "city": "斑鳩",
+          "pokemons": [
+            "ドータクン",
+            "バオッキー"
+          ],
+          "dist_km": 9.38,
+          "lat": 34.60189,
+          "lng": 135.73917
+        },
+        {
+          "id": "149",
+          "title": "奈良県/斑鳩町",
+          "city": "斑鳩",
+          "pokemons": [
+            "ガーディ",
+            "マダツボミ"
+          ],
+          "dist_km": 9.6,
+          "lat": 34.60474,
+          "lng": 135.7376
+        },
+        {
+          "id": "151",
+          "title": "奈良県/斑鳩町",
+          "city": "斑鳩",
+          "pokemons": [
+            "シキジカ",
+            "ヒノヤコマ"
+          ],
+          "dist_km": 9.95,
+          "lat": 34.60826,
+          "lng": 135.73755
+        },
+        {
+          "id": "150",
+          "title": "奈良県/斑鳩町",
+          "city": "斑鳩",
+          "pokemons": [
+            "チリーン",
+            "ブビィ"
+          ],
+          "dist_km": 9.96,
+          "lat": 34.60827,
+          "lng": 135.73769
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-29010",
+    "type": "michineki",
+    "title": "道の駅大和路へぐり周辺のポケふた（9枚）",
+    "url": "https://it-social.net/roadside_station/?29010",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "29010",
+      "station_name": "道の駅大和路へぐり",
+      "pref": "奈良県",
+      "lat": 34.6235384,
+      "lng": 135.7062481,
+      "manhole_count": 9,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "152",
+          "title": "奈良県/斑鳩町",
+          "city": "斑鳩",
+          "pokemons": [
+            "エンテイ"
+          ],
+          "dist_km": 3.06,
+          "lat": 34.60983,
+          "lng": 135.73529
+        },
+        {
+          "id": "151",
+          "title": "奈良県/斑鳩町",
+          "city": "斑鳩",
+          "pokemons": [
+            "シキジカ",
+            "ヒノヤコマ"
+          ],
+          "dist_km": 3.33,
+          "lat": 34.60826,
+          "lng": 135.73755
+        },
+        {
+          "id": "150",
+          "title": "奈良県/斑鳩町",
+          "city": "斑鳩",
+          "pokemons": [
+            "チリーン",
+            "ブビィ"
+          ],
+          "dist_km": 3.34,
+          "lat": 34.60827,
+          "lng": 135.73769
+        },
+        {
+          "id": "149",
+          "title": "奈良県/斑鳩町",
+          "city": "斑鳩",
+          "pokemons": [
+            "ガーディ",
+            "マダツボミ"
+          ],
+          "dist_km": 3.55,
+          "lat": 34.60474,
+          "lng": 135.7376
+        },
+        {
+          "id": "148",
+          "title": "奈良県/斑鳩町",
+          "city": "斑鳩",
+          "pokemons": [
+            "ドータクン",
+            "バオッキー"
+          ],
+          "dist_km": 3.86,
+          "lat": 34.60189,
+          "lng": 135.73917
+        },
+        {
+          "id": "207",
+          "title": "大阪府/東大阪市",
+          "city": "東大阪",
+          "pokemons": [
+            "ギアル",
+            "ギギアル"
+          ],
+          "dist_km": 7.81,
+          "lat": 34.66771,
+          "lng": 135.63989
+        },
+        {
+          "id": "208",
+          "title": "大阪府/東大阪市",
+          "city": "東大阪",
+          "pokemons": [
+            "エレキッド",
+            "クチート"
+          ],
+          "dist_km": 8.13,
+          "lat": 34.680678,
+          "lng": 135.650788
+        },
+        {
+          "id": "210",
+          "title": "大阪府/東大阪市",
+          "city": "東大阪",
+          "pokemons": [
+            "トゲデマル",
+            "ワンパチ"
+          ],
+          "dist_km": 8.6,
+          "lat": 34.669486,
+          "lng": 135.630586
+        },
+        {
+          "id": "209",
+          "title": "大阪府/東大阪市",
+          "city": "東大阪",
+          "pokemons": [
+            "ライコウ"
+          ],
+          "dist_km": 8.81,
+          "lat": 34.667678,
+          "lng": 135.626309
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-29014",
+    "type": "michineki",
+    "title": "道の駅レスティ 唐古・鍵周辺のポケふた（5枚）",
+    "url": "https://it-social.net/roadside_station/?29014",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "29014",
+      "station_name": "道の駅レスティ 唐古・鍵",
+      "pref": "奈良県",
+      "lat": 34.571407,
+      "lng": 135.797418,
+      "manhole_count": 5,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "148",
+          "title": "奈良県/斑鳩町",
+          "city": "斑鳩",
+          "pokemons": [
+            "ドータクン",
+            "バオッキー"
+          ],
+          "dist_km": 6.32,
+          "lat": 34.60189,
+          "lng": 135.73917
+        },
+        {
+          "id": "149",
+          "title": "奈良県/斑鳩町",
+          "city": "斑鳩",
+          "pokemons": [
+            "ガーディ",
+            "マダツボミ"
+          ],
+          "dist_km": 6.61,
+          "lat": 34.60474,
+          "lng": 135.7376
+        },
+        {
+          "id": "150",
+          "title": "奈良県/斑鳩町",
+          "city": "斑鳩",
+          "pokemons": [
+            "チリーン",
+            "ブビィ"
+          ],
+          "dist_km": 6.83,
+          "lat": 34.60827,
+          "lng": 135.73769
+        },
+        {
+          "id": "151",
+          "title": "奈良県/斑鳩町",
+          "city": "斑鳩",
+          "pokemons": [
+            "シキジカ",
+            "ヒノヤコマ"
+          ],
+          "dist_km": 6.84,
+          "lat": 34.60826,
+          "lng": 135.73755
+        },
+        {
+          "id": "152",
+          "title": "奈良県/斑鳩町",
+          "city": "斑鳩",
+          "pokemons": [
+            "エンテイ"
+          ],
+          "dist_km": 7.11,
+          "lat": 34.60983,
+          "lng": 135.73529
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-31001",
+    "type": "michineki",
+    "title": "道の駅大栄周辺のポケふた（3枚）",
+    "url": "https://it-social.net/roadside_station/?31001",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "31001",
+      "station_name": "道の駅大栄",
+      "pref": "鳥取県",
+      "lat": 35.4987404,
+      "lng": 133.7617796,
+      "manhole_count": 3,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "108",
+          "title": "鳥取県/北栄町",
+          "city": "北栄",
+          "pokemons": [
+            "アローラサンド",
+            "サンド"
+          ],
+          "dist_km": 5.08,
+          "lat": 35.49924,
+          "lng": 133.81794
+        },
+        {
+          "id": "82",
+          "title": "鳥取県/琴浦町",
+          "city": "琴浦",
+          "pokemons": [
+            "アローラサンド",
+            "サンド"
+          ],
+          "dist_km": 9.11,
+          "lat": 35.506942,
+          "lng": 133.661612
+        },
+        {
+          "id": "76",
+          "title": "鳥取県/倉吉市",
+          "city": "倉吉",
+          "pokemons": [
+            "アローラサンド",
+            "サンド"
+          ],
+          "dist_km": 9.4,
+          "lat": 35.454272,
+          "lng": 133.850116
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-31003",
+    "type": "michineki",
+    "title": "道の駅北条公園周辺のポケふた（3枚）",
+    "url": "https://it-social.net/roadside_station/?31003",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "31003",
+      "station_name": "道の駅北条公園",
+      "pref": "鳥取県",
+      "lat": 35.4981997,
+      "lng": 133.8199605,
+      "manhole_count": 3,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "108",
+          "title": "鳥取県/北栄町",
+          "city": "北栄",
+          "pokemons": [
+            "アローラサンド",
+            "サンド"
+          ],
+          "dist_km": 0.22,
+          "lat": 35.49924,
+          "lng": 133.81794
+        },
+        {
+          "id": "76",
+          "title": "鳥取県/倉吉市",
+          "city": "倉吉",
+          "pokemons": [
+            "アローラサンド",
+            "サンド"
+          ],
+          "dist_km": 5.6,
+          "lat": 35.454272,
+          "lng": 133.850116
+        },
+        {
+          "id": "81",
+          "title": "鳥取県/湯梨浜町",
+          "city": "湯梨浜",
+          "pokemons": [
+            "サンド",
+            "シェルダー"
+          ],
+          "dist_km": 6.21,
+          "lat": 35.478166,
+          "lng": 133.88401
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-31007",
+    "type": "michineki",
+    "title": "道の駅はわい周辺のポケふた（4枚）",
+    "url": "https://it-social.net/roadside_station/?31007",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "31007",
+      "station_name": "道の駅はわい",
+      "pref": "鳥取県",
+      "lat": 35.4942979,
+      "lng": 133.8904755,
+      "manhole_count": 4,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "81",
+          "title": "鳥取県/湯梨浜町",
+          "city": "湯梨浜",
+          "pokemons": [
+            "サンド",
+            "シェルダー"
+          ],
+          "dist_km": 1.89,
+          "lat": 35.478166,
+          "lng": 133.88401
+        },
+        {
+          "id": "76",
+          "title": "鳥取県/倉吉市",
+          "city": "倉吉",
+          "pokemons": [
+            "アローラサンド",
+            "サンド"
+          ],
+          "dist_km": 5.76,
+          "lat": 35.454272,
+          "lng": 133.850116
+        },
+        {
+          "id": "108",
+          "title": "鳥取県/北栄町",
+          "city": "北栄",
+          "pokemons": [
+            "アローラサンド",
+            "サンド"
+          ],
+          "dist_km": 6.59,
+          "lat": 35.49924,
+          "lng": 133.81794
+        },
+        {
+          "id": "80",
+          "title": "鳥取県/三朝町",
+          "city": "三朝",
+          "pokemons": [
+            "アローラサンド",
+            "ケロマツ"
+          ],
+          "dist_km": 9.46,
+          "lat": 35.409324,
+          "lng": 133.894397
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-31012",
+    "type": "michineki",
+    "title": "燕趙園周辺のポケふた（4枚）",
+    "url": "https://it-social.net/roadside_station/?31012",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "31012",
+      "station_name": "燕趙園",
+      "pref": "鳥取県",
+      "lat": 35.4646909,
+      "lng": 133.8926402,
+      "manhole_count": 4,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "81",
+          "title": "鳥取県/湯梨浜町",
+          "city": "湯梨浜",
+          "pokemons": [
+            "サンド",
+            "シェルダー"
+          ],
+          "dist_km": 1.69,
+          "lat": 35.478166,
+          "lng": 133.88401
+        },
+        {
+          "id": "76",
+          "title": "鳥取県/倉吉市",
+          "city": "倉吉",
+          "pokemons": [
+            "アローラサンド",
+            "サンド"
+          ],
+          "dist_km": 4.02,
+          "lat": 35.454272,
+          "lng": 133.850116
+        },
+        {
+          "id": "80",
+          "title": "鳥取県/三朝町",
+          "city": "三朝",
+          "pokemons": [
+            "アローラサンド",
+            "ケロマツ"
+          ],
+          "dist_km": 6.16,
+          "lat": 35.409324,
+          "lng": 133.894397
+        },
+        {
+          "id": "108",
+          "title": "鳥取県/北栄町",
+          "city": "北栄",
+          "pokemons": [
+            "アローラサンド",
+            "サンド"
+          ],
+          "dist_km": 7.78,
+          "lat": 35.49924,
+          "lng": 133.81794
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-31013",
+    "type": "michineki",
+    "title": "道の駅きなんせ岩美周辺のポケふた（3枚）",
+    "url": "https://it-social.net/roadside_station/?31013",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "31013",
+      "station_name": "道の駅きなんせ岩美",
+      "pref": "鳥取県",
+      "lat": 35.56741079,
+      "lng": 134.3259855,
+      "manhole_count": 3,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "78",
+          "title": "鳥取県/岩美町",
+          "city": "岩美",
+          "pokemons": [
+            "サンド",
+            "ネイティオ"
+          ],
+          "dist_km": 2.65,
+          "lat": 35.590938,
+          "lng": 134.321556
+        },
+        {
+          "id": "74",
+          "title": "鳥取県/鳥取市",
+          "city": "鳥取",
+          "pokemons": [
+            "アローラサンド",
+            "サンド"
+          ],
+          "dist_km": 8.6,
+          "lat": 35.539668,
+          "lng": 134.237266
+        },
+        {
+          "id": "300",
+          "title": "鳥取県/鳥取市",
+          "city": "鳥取",
+          "pokemons": [
+            "アローラサンド",
+            "サンド"
+          ],
+          "dist_km": 9.91,
+          "lat": 35.53395,
+          "lng": 134.224478
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-31014",
+    "type": "michineki",
+    "title": "道の駅奥大山周辺のポケふた（4枚）",
+    "url": "https://it-social.net/roadside_station/?31014",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "31014",
+      "station_name": "道の駅奥大山",
+      "pref": "鳥取県",
+      "lat": 35.2961102,
+      "lng": 133.4740758,
+      "manhole_count": 4,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "110",
+          "title": "鳥取県/江府町",
+          "city": "江府",
+          "pokemons": [
+            "アローラサンド",
+            "サンド"
+          ],
+          "dist_km": 0.03,
+          "lat": 35.295841,
+          "lng": 133.474089
+        },
+        {
+          "id": "87",
+          "title": "鳥取県/日野町",
+          "city": "日野",
+          "pokemons": [
+            "アローラサンド",
+            "サンド"
+          ],
+          "dist_km": 6.73,
+          "lat": 35.24192,
+          "lng": 133.441049
+        },
+        {
+          "id": "84",
+          "title": "鳥取県/南部町",
+          "city": "南部",
+          "pokemons": [
+            "アローラサンド",
+            "サンド"
+          ],
+          "dist_km": 7.33,
+          "lat": 35.347474,
+          "lng": 133.423398
+        },
+        {
+          "id": "85",
+          "title": "鳥取県/伯耆町",
+          "city": "伯耆",
+          "pokemons": [
+            "アローラサンド",
+            "オニゴーリ"
+          ],
+          "dist_km": 9.81,
+          "lat": 35.383395,
+          "lng": 133.458512
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-32027",
+    "type": "michineki",
+    "title": "道の駅あらエッサ周辺のポケふた（3枚）",
+    "url": "https://it-social.net/roadside_station/?32027",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "32027",
+      "station_name": "道の駅あらエッサ",
+      "pref": "島根県",
+      "lat": 35.4095485,
+      "lng": 133.3124056,
+      "manhole_count": 3,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "380",
+          "title": "島根県/安来市",
+          "city": "安来",
+          "pokemons": [
+            "ドジョッチ",
+            "バリヤード"
+          ],
+          "dist_km": 5.27,
+          "lat": 35.428407,
+          "lng": 133.259012
+        },
+        {
+          "id": "75",
+          "title": "鳥取県/米子市",
+          "city": "米子",
+          "pokemons": [
+            "カモネギ",
+            "サンド"
+          ],
+          "dist_km": 6.84,
+          "lat": 35.456258,
+          "lng": 133.361525
+        },
+        {
+          "id": "109",
+          "title": "鳥取県/日吉津村",
+          "city": "日吉津",
+          "pokemons": [
+            "サンド",
+            "メタモン"
+          ],
+          "dist_km": 7.03,
+          "lat": 35.441126,
+          "lng": 133.379578
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-36018",
+    "type": "michineki",
+    "title": "道の駅くるくる なると周辺のポケふた（3枚）",
+    "url": "https://it-social.net/roadside_station/?36018",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "36018",
+      "station_name": "道の駅くるくる なると",
+      "pref": "徳島県",
+      "lat": 34.158139,
+      "lng": 134.579889,
+      "manhole_count": 3,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "328",
+          "title": "徳島県/鳴門市",
+          "city": "鳴門",
+          "pokemons": [
+            "キングドラ",
+            "シードラ"
+          ],
+          "dist_km": 3.32,
+          "lat": 34.181955,
+          "lng": 134.601709
+        },
+        {
+          "id": "329",
+          "title": "徳島県/鳴門市",
+          "city": "鳴門",
+          "pokemons": [
+            "ディグダ",
+            "ニョロゾ"
+          ],
+          "dist_km": 3.53,
+          "lat": 34.168084,
+          "lng": 134.616371
+        },
+        {
+          "id": "327",
+          "title": "徳島県/鳴門市",
+          "city": "鳴門",
+          "pokemons": [
+            "スイクン"
+          ],
+          "dist_km": 8.98,
+          "lat": 34.224106,
+          "lng": 134.636196
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-37001",
+    "type": "michineki",
+    "title": "道の駅瀬戸大橋記念公園周辺のポケふた（4枚）",
+    "url": "https://it-social.net/roadside_station/?37001",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "37001",
+      "station_name": "道の駅瀬戸大橋記念公園",
+      "pref": "香川県",
+      "lat": 34.3526893,
+      "lng": 133.8261282,
+      "manhole_count": 4,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "97",
+          "title": "香川県/宇多津町",
+          "city": "宇多津",
+          "pokemons": [
+            "ガラルヤドン",
+            "ヌオー"
+          ],
+          "dist_km": 4.69,
+          "lat": 34.3134259,
+          "lng": 133.8075257
+        },
+        {
+          "id": "30",
+          "title": "香川県/坂出市",
+          "city": "坂出",
+          "pokemons": [
+            "ヤドン"
+          ],
+          "dist_km": 5.21,
+          "lat": 34.312992,
+          "lng": 133.856292
+        },
+        {
+          "id": "29",
+          "title": "香川県/丸亀市",
+          "city": "丸亀",
+          "pokemons": [
+            "ヤドン"
+          ],
+          "dist_km": 7.37,
+          "lat": 34.292014,
+          "lng": 133.793951
+        },
+        {
+          "id": "194",
+          "title": "岡山県/倉敷市",
+          "city": "倉敷",
+          "pokemons": [
+            "ルカリオ"
+          ],
+          "dist_km": 9.14,
+          "lat": 34.43427,
+          "lng": 133.81388
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-37004",
+    "type": "michineki",
+    "title": "道の駅ふれあいパークみの周辺のポケふた（5枚）",
+    "url": "https://it-social.net/roadside_station/?37004",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "37004",
+      "station_name": "道の駅ふれあいパークみの",
+      "pref": "香川県",
+      "lat": 34.2263483,
+      "lng": 133.7228554,
+      "manhole_count": 5,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "31",
+          "title": "香川県/善通寺市",
+          "city": "善通寺",
+          "pokemons": [
+            "ヤドラン",
+            "ヤドン"
+          ],
+          "dist_km": 5.01,
+          "lat": 34.22531,
+          "lng": 133.7773
+        },
+        {
+          "id": "42",
+          "title": "香川県/多度津町",
+          "city": "多度津",
+          "pokemons": [
+            "ヤドン"
+          ],
+          "dist_km": 6.01,
+          "lat": 34.272282,
+          "lng": 133.757247
+        },
+        {
+          "id": "35",
+          "title": "香川県/三豊市",
+          "city": "三豊",
+          "pokemons": [
+            "シェルダー",
+            "ヤドン"
+          ],
+          "dist_km": 9.57,
+          "lat": 34.2687992,
+          "lng": 133.6322219
+        },
+        {
+          "id": "29",
+          "title": "香川県/丸亀市",
+          "city": "丸亀",
+          "pokemons": [
+            "ヤドン"
+          ],
+          "dist_km": 9.8,
+          "lat": 34.292014,
+          "lng": 133.793951
+        },
+        {
+          "id": "41",
+          "title": "香川県/琴平町",
+          "city": "琴平",
+          "pokemons": [
+            "ヤドン"
+          ],
+          "dist_km": 9.9,
+          "lat": 34.187735,
+          "lng": 133.819896
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-37007",
+    "type": "michineki",
+    "title": "道の駅空の夢もみの木パーク周辺のポケふた（3枚）",
+    "url": "https://it-social.net/roadside_station/?37007",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "37007",
+      "station_name": "道の駅空の夢もみの木パーク",
+      "pref": "香川県",
+      "lat": 34.1548496,
+      "lng": 133.8215512,
+      "manhole_count": 3,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "41",
+          "title": "香川県/琴平町",
+          "city": "琴平",
+          "pokemons": [
+            "ヤドン"
+          ],
+          "dist_km": 3.66,
+          "lat": 34.187735,
+          "lng": 133.819896
+        },
+        {
+          "id": "43",
+          "title": "香川県/まんのう町",
+          "city": "まんのう",
+          "pokemons": [
+            "ヤドン"
+          ],
+          "dist_km": 5.03,
+          "lat": 34.173339,
+          "lng": 133.871387
+        },
+        {
+          "id": "31",
+          "title": "香川県/善通寺市",
+          "city": "善通寺",
+          "pokemons": [
+            "ヤドラン",
+            "ヤドン"
+          ],
+          "dist_km": 8.83,
+          "lat": 34.22531,
+          "lng": 133.7773
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-37008",
+    "type": "michineki",
+    "title": "道の駅みろく周辺のポケふた（3枚）",
+    "url": "https://it-social.net/roadside_station/?37008",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "37008",
+      "station_name": "道の駅みろく",
+      "pref": "香川県",
+      "lat": 34.25819,
+      "lng": 134.2424659,
+      "manhole_count": 3,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "34",
+          "title": "香川県/東かがわ市",
+          "city": "東かがわ",
+          "pokemons": [
+            "ヤドン"
+          ],
+          "dist_km": 8.4,
+          "lat": 34.251174,
+          "lng": 134.333457
+        },
+        {
+          "id": "33",
+          "title": "香川県/さぬき市",
+          "city": "さぬき",
+          "pokemons": [
+            "ピッピ",
+            "ヤドン"
+          ],
+          "dist_km": 9.47,
+          "lat": 34.321305,
+          "lng": 134.173241
+        },
+        {
+          "id": "38",
+          "title": "香川県/三木町",
+          "city": "三木",
+          "pokemons": [
+            "ヤドン"
+          ],
+          "dist_km": 9.98,
+          "lat": 34.268586,
+          "lng": 134.134567
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-37010",
+    "type": "michineki",
+    "title": "道の駅滝宮周辺のポケふた（4枚）",
+    "url": "https://it-social.net/roadside_station/?37010",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "37010",
+      "station_name": "道の駅滝宮",
+      "pref": "香川県",
+      "lat": 34.2497767902,
+      "lng": 133.917359488,
+      "manhole_count": 4,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "40",
+          "title": "香川県/綾川町",
+          "city": "綾川",
+          "pokemons": [
+            "ヤドン"
+          ],
+          "dist_km": 0.07,
+          "lat": 34.250399,
+          "lng": 133.917073
+        },
+        {
+          "id": "298",
+          "title": "香川県/綾川町",
+          "city": "綾川",
+          "pokemons": [
+            "ガラルヤドン",
+            "シェルダー"
+          ],
+          "dist_km": 1.44,
+          "lat": 34.247395,
+          "lng": 133.9327735
+        },
+        {
+          "id": "30",
+          "title": "香川県/坂出市",
+          "city": "坂出",
+          "pokemons": [
+            "ヤドン"
+          ],
+          "dist_km": 8.99,
+          "lat": 34.312992,
+          "lng": 133.856292
+        },
+        {
+          "id": "43",
+          "title": "香川県/まんのう町",
+          "city": "まんのう",
+          "pokemons": [
+            "ヤドン"
+          ],
+          "dist_km": 9.49,
+          "lat": 34.173339,
+          "lng": 133.871387
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-37012",
+    "type": "michineki",
+    "title": "道の駅恋人の聖地 うたづ臨海公園周辺のポケふた（4枚）",
+    "url": "https://it-social.net/roadside_station/?37012",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "37012",
+      "station_name": "道の駅恋人の聖地 うたづ臨海公園",
+      "pref": "香川県",
+      "lat": 34.31338818,
+      "lng": 133.807966,
+      "manhole_count": 4,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "97",
+          "title": "香川県/宇多津町",
+          "city": "宇多津",
+          "pokemons": [
+            "ガラルヤドン",
+            "ヌオー"
+          ],
+          "dist_km": 0.04,
+          "lat": 34.3134259,
+          "lng": 133.8075257
+        },
+        {
+          "id": "29",
+          "title": "香川県/丸亀市",
+          "city": "丸亀",
+          "pokemons": [
+            "ヤドン"
+          ],
+          "dist_km": 2.7,
+          "lat": 34.292014,
+          "lng": 133.793951
+        },
+        {
+          "id": "30",
+          "title": "香川県/坂出市",
+          "city": "坂出",
+          "pokemons": [
+            "ヤドン"
+          ],
+          "dist_km": 4.44,
+          "lat": 34.312992,
+          "lng": 133.856292
+        },
+        {
+          "id": "42",
+          "title": "香川県/多度津町",
+          "city": "多度津",
+          "pokemons": [
+            "ヤドン"
+          ],
+          "dist_km": 6.53,
+          "lat": 34.272282,
+          "lng": 133.757247
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-37018",
+    "type": "michineki",
+    "title": "道の駅源平の里むれ周辺のポケふた（3枚）",
+    "url": "https://it-social.net/roadside_station/?37018",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "37018",
+      "station_name": "道の駅源平の里むれ",
+      "pref": "香川県",
+      "lat": 34.3337252,
+      "lng": 134.1574969,
+      "manhole_count": 3,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "33",
+          "title": "香川県/さぬき市",
+          "city": "さぬき",
+          "pokemons": [
+            "ピッピ",
+            "ヤドン"
+          ],
+          "dist_km": 2.0,
+          "lat": 34.321305,
+          "lng": 134.173241
+        },
+        {
+          "id": "38",
+          "title": "香川県/三木町",
+          "city": "三木",
+          "pokemons": [
+            "ヤドン"
+          ],
+          "dist_km": 7.54,
+          "lat": 34.268586,
+          "lng": 134.134567
+        },
+        {
+          "id": "28",
+          "title": "香川県/高松市",
+          "city": "高松",
+          "pokemons": [
+            "ヤドン"
+          ],
+          "dist_km": 9.97,
+          "lat": 34.338888,
+          "lng": 134.049052
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-39012",
+    "type": "michineki",
+    "title": "道の駅大山周辺のポケふた（3枚）",
+    "url": "https://it-social.net/roadside_station/?39012",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "39012",
+      "station_name": "道の駅大山",
+      "pref": "高知県",
+      "lat": 33.47009977,
+      "lng": 133.9440693,
+      "manhole_count": 3,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "433",
+          "title": "高知県/安芸市",
+          "city": "安芸",
+          "pokemons": [
+            "ヌオー",
+            "ホーホー"
+          ],
+          "dist_km": 5.16,
+          "lat": 33.5043207,
+          "lng": 133.9065445
+        },
+        {
+          "id": "451",
+          "title": "高知県/安田町",
+          "city": "安田",
+          "pokemons": [
+            "ヌオー",
+            "メタモン"
+          ],
+          "dist_km": 5.28,
+          "lat": 33.47986,
+          "lng": 133.99983
+        },
+        {
+          "id": "391",
+          "title": "高知県/奈半利町",
+          "city": "奈半利",
+          "pokemons": [
+            "サニーゴ",
+            "ヌオー"
+          ],
+          "dist_km": 8.46,
+          "lat": 33.425249,
+          "lng": 134.017781
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-45013",
+    "type": "michineki",
+    "title": "道の駅高千穂周辺のポケふた（3枚）",
+    "url": "https://it-social.net/roadside_station/?45013",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "45013",
+      "station_name": "道の駅高千穂",
+      "pref": "宮崎県",
+      "lat": 32.7084429,
+      "lng": 131.3004346,
+      "manhole_count": 3,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "184",
+          "title": "宮崎県/高千穂町",
+          "city": "高千穂",
+          "pokemons": [
+            "ナッシー",
+            "レジギガス"
+          ],
+          "dist_km": 0.52,
+          "lat": 32.707748,
+          "lng": 131.305889
+        },
+        {
+          "id": "186",
+          "title": "宮崎県/五ヶ瀬町",
+          "city": "五ヶ瀬",
+          "pokemons": [
+            "ナッシー",
+            "レジアイス"
+          ],
+          "dist_km": 9.07,
+          "lat": 32.679051,
+          "lng": 131.210041
+        },
+        {
+          "id": "185",
+          "title": "宮崎県/日之影町",
+          "city": "日之影",
+          "pokemons": [
+            "ナッシー",
+            "レジスチル"
+          ],
+          "dist_km": 9.82,
+          "lat": 32.660643,
+          "lng": 131.388639
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-46015",
+    "type": "michineki",
+    "title": "道の駅いぶすき周辺のポケふた（7枚）",
+    "url": "https://it-social.net/roadside_station/?46015",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "46015",
+      "station_name": "道の駅いぶすき",
+      "pref": "鹿児島県",
+      "lat": 31.3022146,
+      "lng": 130.5900439,
+      "manhole_count": 7,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "3",
+          "title": "鹿児島県/指宿市",
+          "city": "指宿",
+          "pokemons": [
+            "サンダース"
+          ],
+          "dist_km": 7.56,
+          "lat": 31.255278,
+          "lng": 130.647639
+        },
+        {
+          "id": "7",
+          "title": "鹿児島県/指宿市",
+          "city": "指宿",
+          "pokemons": [
+            "リーフィア"
+          ],
+          "dist_km": 8.13,
+          "lat": 31.263889,
+          "lng": 130.662917
+        },
+        {
+          "id": "1",
+          "title": "鹿児島県/指宿市",
+          "city": "指宿",
+          "pokemons": [
+            "イーブイ"
+          ],
+          "dist_km": 8.8,
+          "lat": 31.237194,
+          "lng": 130.642861
+        },
+        {
+          "id": "6",
+          "title": "鹿児島県/指宿市",
+          "city": "指宿",
+          "pokemons": [
+            "ブラッキー"
+          ],
+          "dist_km": 8.8,
+          "lat": 31.236833,
+          "lng": 130.642188
+        },
+        {
+          "id": "5",
+          "title": "鹿児島県/指宿市",
+          "city": "指宿",
+          "pokemons": [
+            "エーフィ"
+          ],
+          "dist_km": 8.82,
+          "lat": 31.238278,
+          "lng": 130.645
+        },
+        {
+          "id": "9",
+          "title": "鹿児島県/指宿市",
+          "city": "指宿",
+          "pokemons": [
+            "ニンフィア"
+          ],
+          "dist_km": 8.88,
+          "lat": 31.235444,
+          "lng": 130.641389
+        },
+        {
+          "id": "8",
+          "title": "鹿児島県/指宿市",
+          "city": "指宿",
+          "pokemons": [
+            "グレイシア"
+          ],
+          "dist_km": 9.46,
+          "lat": 31.231056,
+          "lng": 130.644611
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-46019",
+    "type": "michineki",
+    "title": "道の駅山川港活お海道周辺のポケふた（9枚）",
+    "url": "https://it-social.net/roadside_station/?46019",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "46019",
+      "station_name": "道の駅山川港活お海道",
+      "pref": "鹿児島県",
+      "lat": 31.2030165,
+      "lng": 130.6349136,
+      "manhole_count": 9,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "8",
+          "title": "鹿児島県/指宿市",
+          "city": "指宿",
+          "pokemons": [
+            "グレイシア"
+          ],
+          "dist_km": 3.25,
+          "lat": 31.231056,
+          "lng": 130.644611
+        },
+        {
+          "id": "2",
+          "title": "鹿児島県/指宿市",
+          "city": "指宿",
+          "pokemons": [
+            "シャワーズ"
+          ],
+          "dist_km": 3.27,
+          "lat": 31.228,
+          "lng": 130.653028
+        },
+        {
+          "id": "4",
+          "title": "鹿児島県/指宿市",
+          "city": "指宿",
+          "pokemons": [
+            "ブースター"
+          ],
+          "dist_km": 3.35,
+          "lat": 31.229417,
+          "lng": 130.651972
+        },
+        {
+          "id": "9",
+          "title": "鹿児島県/指宿市",
+          "city": "指宿",
+          "pokemons": [
+            "ニンフィア"
+          ],
+          "dist_km": 3.66,
+          "lat": 31.235444,
+          "lng": 130.641389
+        },
+        {
+          "id": "6",
+          "title": "鹿児島県/指宿市",
+          "city": "指宿",
+          "pokemons": [
+            "ブラッキー"
+          ],
+          "dist_km": 3.82,
+          "lat": 31.236833,
+          "lng": 130.642188
+        },
+        {
+          "id": "1",
+          "title": "鹿児島県/指宿市",
+          "city": "指宿",
+          "pokemons": [
+            "イーブイ"
+          ],
+          "dist_km": 3.87,
+          "lat": 31.237194,
+          "lng": 130.642861
+        },
+        {
+          "id": "5",
+          "title": "鹿児島県/指宿市",
+          "city": "指宿",
+          "pokemons": [
+            "エーフィ"
+          ],
+          "dist_km": 4.04,
+          "lat": 31.238278,
+          "lng": 130.645
+        },
+        {
+          "id": "3",
+          "title": "鹿児島県/指宿市",
+          "city": "指宿",
+          "pokemons": [
+            "サンダース"
+          ],
+          "dist_km": 5.94,
+          "lat": 31.255278,
+          "lng": 130.647639
+        },
+        {
+          "id": "7",
+          "title": "鹿児島県/指宿市",
+          "city": "指宿",
+          "pokemons": [
+            "リーフィア"
+          ],
+          "dist_km": 7.27,
+          "lat": 31.263889,
+          "lng": 130.662917
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-47004",
+    "type": "michineki",
+    "title": "道の駅かでな周辺のポケふた（3枚）",
+    "url": "https://it-social.net/roadside_station/?47004",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "47004",
+      "station_name": "道の駅かでな",
+      "pref": "沖縄県",
+      "lat": 26.3681116,
+      "lng": 127.7741485,
+      "manhole_count": 3,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "176",
+          "title": "沖縄県/沖縄市",
+          "city": "沖縄",
+          "pokemons": [
+            "バチンキー",
+            "ラランテス"
+          ],
+          "dist_km": 5.34,
+          "lat": 26.32766,
+          "lng": 127.803001
+        },
+        {
+          "id": "422",
+          "title": "沖縄県/北谷町",
+          "city": "北谷",
+          "pokemons": [
+            "ガーディ"
+          ],
+          "dist_km": 6.17,
+          "lat": 26.315733,
+          "lng": 127.753613
+        },
+        {
+          "id": "177",
+          "title": "沖縄県/うるま市",
+          "city": "うるま",
+          "pokemons": [
+            "ケンタロス"
+          ],
+          "dist_km": 9.17,
+          "lat": 26.436181,
+          "lng": 127.826113
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-47005",
+    "type": "michineki",
+    "title": "道の駅喜名番所周辺のポケふた（3枚）",
+    "url": "https://it-social.net/roadside_station/?47005",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "47005",
+      "station_name": "道の駅喜名番所",
+      "pref": "沖縄県",
+      "lat": 26.3993416,
+      "lng": 127.758204,
+      "manhole_count": 3,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "177",
+          "title": "沖縄県/うるま市",
+          "city": "うるま",
+          "pokemons": [
+            "ケンタロス"
+          ],
+          "dist_km": 7.91,
+          "lat": 26.436181,
+          "lng": 127.826113
+        },
+        {
+          "id": "176",
+          "title": "沖縄県/沖縄市",
+          "city": "沖縄",
+          "pokemons": [
+            "バチンキー",
+            "ラランテス"
+          ],
+          "dist_km": 9.14,
+          "lat": 26.32766,
+          "lng": 127.803001
+        },
+        {
+          "id": "422",
+          "title": "沖縄県/北谷町",
+          "city": "北谷",
+          "pokemons": [
+            "ガーディ"
+          ],
+          "dist_km": 9.31,
+          "lat": 26.315733,
+          "lng": 127.753613
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-47006",
+    "type": "michineki",
+    "title": "道の駅豊崎周辺のポケふた（4枚）",
+    "url": "https://it-social.net/roadside_station/?47006",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "47006",
+      "station_name": "道の駅豊崎",
+      "pref": "沖縄県",
+      "lat": 26.1576946,
+      "lng": 127.6553335,
+      "manhole_count": 4,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "233",
+          "title": "沖縄県/豊見城市",
+          "city": "豊見城",
+          "pokemons": [
+            "キバゴ",
+            "ジャラコ"
+          ],
+          "dist_km": 0.08,
+          "lat": 26.15755646,
+          "lng": 127.656121
+        },
+        {
+          "id": "231",
+          "title": "沖縄県/糸満市",
+          "city": "糸満",
+          "pokemons": [
+            "カメール",
+            "スナバァ"
+          ],
+          "dist_km": 2.24,
+          "lat": 26.13828,
+          "lng": 127.661336
+        },
+        {
+          "id": "174",
+          "title": "沖縄県/那覇市",
+          "city": "那覇",
+          "pokemons": [
+            "ウインディ"
+          ],
+          "dist_km": 7.36,
+          "lat": 26.21641,
+          "lng": 127.68942
+        },
+        {
+          "id": "446",
+          "title": "沖縄県/那覇市",
+          "city": "那覇",
+          "pokemons": [
+            "ガーディ"
+          ],
+          "dist_km": 9.24,
+          "lat": 26.22005,
+          "lng": 127.71657
+        }
+      ]
+    }
+  },
+  {
+    "id": "michineki-47007",
+    "type": "michineki",
+    "title": "道の駅いとまん周辺のポケふた（3枚）",
+    "url": "https://it-social.net/roadside_station/?47007",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "michineki",
+    "source": "michineki",
+    "raw_data": {
+      "station_id": "47007",
+      "station_name": "道の駅いとまん",
+      "pref": "沖縄県",
+      "lat": 26.1384965,
+      "lng": 127.661156,
+      "manhole_count": 3,
+      "radius_km": 10,
+      "manholes": [
+        {
+          "id": "231",
+          "title": "沖縄県/糸満市",
+          "city": "糸満",
+          "pokemons": [
+            "カメール",
+            "スナバァ"
+          ],
+          "dist_km": 0.03,
+          "lat": 26.13828,
+          "lng": 127.661336
+        },
+        {
+          "id": "233",
+          "title": "沖縄県/豊見城市",
+          "city": "豊見城",
+          "pokemons": [
+            "キバゴ",
+            "ジャラコ"
+          ],
+          "dist_km": 2.18,
+          "lat": 26.15755646,
+          "lng": 127.656121
+        },
+        {
+          "id": "174",
+          "title": "沖縄県/那覇市",
+          "city": "那覇",
+          "pokemons": [
+            "ウインディ"
+          ],
+          "dist_km": 9.11,
+          "lat": 26.21641,
+          "lng": 127.68942
+        }
+      ]
+    }
+  },
+  {
+    "id": "island-小笠原",
+    "type": "remote_island",
+    "title": "小笠原諸島のポケふた（4枚）",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "remote_island",
+    "source": "remote_island",
+    "raw_data": {
+      "island_name": "小笠原諸島",
+      "pref": "東京都",
+      "city": "小笠原",
+      "manhole_count": 4,
+      "manholes": [
+        {
+          "id": "153",
+          "title": "東京都/小笠原村",
+          "pokemons": [
+            "フシギバナ"
+          ],
+          "lat": 27.094863,
+          "lng": 142.194033
+        },
+        {
+          "id": "154",
+          "title": "東京都/小笠原村",
+          "pokemons": [
+            "リザードン"
+          ],
+          "lat": 27.094708,
+          "lng": 142.193279
+        },
+        {
+          "id": "155",
+          "title": "東京都/小笠原村",
+          "pokemons": [
+            "カメックス"
+          ],
+          "lat": 27.094596,
+          "lng": 142.192781
+        },
+        {
+          "id": "156",
+          "title": "東京都/小笠原村",
+          "pokemons": [
+            "ミュウ"
+          ],
+          "lat": 27.09448,
+          "lng": 142.19235
+        }
+      ],
+      "top_pokemons": [
+        "フシギバナ",
+        "リザードン",
+        "カメックス"
+      ]
+    }
+  },
+  {
+    "id": "island-小豆島",
+    "type": "remote_island",
+    "title": "小豆島のポケふた（1枚）",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "remote_island",
+    "source": "remote_island",
+    "raw_data": {
+      "island_name": "小豆島",
+      "pref": "香川県",
+      "city": "小豆島",
+      "manhole_count": 1,
+      "manholes": [
+        {
+          "id": "37",
+          "title": "香川県/小豆島町",
+          "pokemons": [
+            "ヤドン"
+          ],
+          "lat": 34.4708542,
+          "lng": 134.2358695
+        }
+      ],
+      "top_pokemons": [
+        "ヤドン"
+      ]
+    }
+  },
+  {
+    "id": "island-直島",
+    "type": "remote_island",
+    "title": "直島のポケふた（1枚）",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "remote_island",
+    "source": "remote_island",
+    "raw_data": {
+      "island_name": "直島",
+      "pref": "香川県",
+      "city": "直島",
+      "manhole_count": 1,
+      "manholes": [
+        {
+          "id": "39",
+          "title": "香川県/直島町",
+          "pokemons": [
+            "コイキング",
+            "ヤドン"
+          ],
+          "lat": 34.455827,
+          "lng": 133.975492
+        }
+      ],
+      "top_pokemons": [
+        "コイキング",
+        "ヤドン"
+      ]
+    }
+  },
+  {
+    "id": "island-隠岐の島",
+    "type": "remote_island",
+    "title": "隠岐諸島のポケふた（1枚）",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "remote_island",
+    "source": "remote_island",
+    "raw_data": {
+      "island_name": "隠岐諸島",
+      "pref": "島根県",
+      "city": "隠岐の島",
+      "manhole_count": 1,
+      "manholes": [
+        {
+          "id": "381",
+          "title": "島根県/隠岐の島町",
+          "pokemons": [
+            "デデンネ",
+            "ミミロップ"
+          ],
+          "lat": 36.17725248,
+          "lng": 133.3302467
+        }
+      ],
+      "top_pokemons": [
+        "デデンネ",
+        "ミミロップ"
+      ]
+    }
+  },
+  {
+    "id": "island-宮古島",
+    "type": "remote_island",
+    "title": "宮古島のポケふた（1枚）",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "remote_island",
+    "source": "remote_island",
+    "raw_data": {
+      "island_name": "宮古島",
+      "pref": "沖縄県",
+      "city": "宮古島",
+      "manhole_count": 1,
+      "manholes": [
+        {
+          "id": "236",
+          "title": "沖縄県/宮古島市",
+          "pokemons": [
+            "カイオーガ"
+          ],
+          "lat": 24.734962,
+          "lng": 125.263088
+        }
+      ],
+      "top_pokemons": [
+        "カイオーガ"
+      ]
+    }
+  },
+  {
+    "id": "island-久米島",
+    "type": "remote_island",
+    "title": "久米島のポケふた（1枚）",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "remote_island",
+    "source": "remote_island",
+    "raw_data": {
+      "island_name": "久米島",
+      "pref": "沖縄県",
+      "city": "久米島",
+      "manhole_count": 1,
+      "manholes": [
+        {
+          "id": "425",
+          "title": "沖縄県/久米島町",
+          "pokemons": [
+            "ウデッポウ",
+            "ガーディ"
+          ],
+          "lat": 26.373985,
+          "lng": 126.788928
+        }
+      ],
+      "top_pokemons": [
+        "ウデッポウ",
+        "ガーディ"
+      ]
+    }
+  },
+  {
+    "id": "island-新上五島",
+    "type": "remote_island",
+    "title": "五島列島のポケふた（1枚）",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "remote_island",
+    "source": "remote_island",
+    "raw_data": {
+      "island_name": "五島列島",
+      "pref": "長崎県",
+      "city": "新上五島",
+      "manhole_count": 1,
+      "manholes": [
+        {
+          "id": "358",
+          "title": "長崎県/新上五島町",
+          "pokemons": [
+            "イルカマン",
+            "デンリュウ"
+          ],
+          "lat": 32.986402,
+          "lng": 129.112745
+        }
+      ],
+      "top_pokemons": [
+        "イルカマン",
+        "デンリュウ"
+      ]
     }
   }
 ]


### PR DESCRIPTION
## Summary

- `michineki` タイプ追加：半径10km以内にポケふた3枚以上の道の駅を候補化（44件）
- `remote_island` タイプ追加：小笠原・小豆島・直島・隠岐・宮古島・久米島・五島列島（7件）
- OGP画像：`_build_area_map_svg()` で地図ドットマップSVGをプログラム生成（道の駅は緑の★マーカー付き）
- 金曜投稿スケジュール：`rare_area` → `michineki` → `remote_island` の3週ローテに変更

## Test plan
- [ ] `python3 apps/scraper/generate_social_posts.py` → michineki: 44, remote_island: 7 が出力される
- [ ] `/social-post` で金曜日に michineki または remote_island タイプが選択される
- [ ] `generate_social_ogp.py` で両タイプのSVGが正常生成される

🤖 Generated with [Claude Code](https://claude.com/claude-code)