### PR TITLE
fix: タグディレクトリのセカンダリチップが常に表示される問題を修正

### DIFF
--- a/apps/web/assets/pokefuta-map.css
+++ b/apps/web/assets/pokefuta-map.css
@@ -1438,6 +1438,7 @@ body.pokefuta-map-page {
   padding-top: 8px;
   border-top: 1px solid rgba(116, 82, 38, .1);
 }
+.tag-directory-chips[hidden] { display: none; }
 
 .tag-directory-toggle-btn {
   display: block;


### PR DESCRIPTION
## 原因

`.tag-directory-chips { display: flex; }` (author stylesheet) が、ブラウザUAスタイルシートの `[hidden] { display: none; }` を上書きしていた。

`#tag-directory-more` は `.tag-directory-chips` クラスを持つため、`hidden` 属性が付いていても `display: flex` が常に適用され、「もっと見る」の中身が初期から全件表示されていた。

## 修正

```css
.tag-directory-chips[hidden] { display: none; }
```

1行追加。`map.css` の `#sibling-site-banner[hidden] { display:none; }` と同じパターン。

## 影響

- 初期表示: FEATURED_TAGS 5件のみ表示（意図通り）
- 「もっと見る」クリック後: セカンダリチップ展開（変化なし）
- タグフィルタ動作: 変化なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)