### PR TITLE
feat: GA4マップページにpage_type・prefectureパラメータを追加

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -37,6 +37,20 @@
       '佐賀県': '41', '長崎県': '42', '熊本県': '43', '大分県': '44', '宮崎県': '45',
       '鹿児島県': '46', '沖縄県': '47'
     });
+    window.PREFECTURE_SLUG_MAP = Object.freeze({
+      '北海道': 'hokkaido',  '青森県': 'aomori',    '岩手県': 'iwate',     '宮城県': 'miyagi',
+      '秋田県': 'akita',     '山形県': 'yamagata',  '福島県': 'fukushima', '茨城県': 'ibaraki',
+      '栃木県': 'tochigi',   '群馬県': 'gunma',     '埼玉県': 'saitama',   '千葉県': 'chiba',
+      '東京都': 'tokyo',     '神奈川県': 'kanagawa','新潟県': 'niigata',   '富山県': 'toyama',
+      '石川県': 'ishikawa',  '福井県': 'fukui',     '山梨県': 'yamanashi', '長野県': 'nagano',
+      '岐阜県': 'gifu',      '静岡県': 'shizuoka',  '愛知県': 'aichi',     '三重県': 'mie',
+      '滋賀県': 'shiga',     '京都府': 'kyoto',     '大阪府': 'osaka',     '兵庫県': 'hyogo',
+      '奈良県': 'nara',      '和歌山県': 'wakayama','鳥取県': 'tottori',   '島根県': 'shimane',
+      '岡山県': 'okayama',   '広島県': 'hiroshima', '山口県': 'yamaguchi', '徳島県': 'tokushima',
+      '香川県': 'kagawa',    '愛媛県': 'ehime',     '高知県': 'kochi',     '福岡県': 'fukuoka',
+      '佐賀県': 'saga',      '長崎県': 'nagasaki',  '熊本県': 'kumamoto',  '大分県': 'oita',
+      '宮崎県': 'miyazaki',  '鹿児島県': 'kagoshima','沖縄県': 'okinawa'
+    });
     window.SITE_BASE_URL = 'https://data.pokefuta.com/';
 
     window.resolvePrefectureParam = function(prefParam) {
@@ -303,9 +317,23 @@
       pagePath = `/tracker_pref/${encodeURIComponent(prefParam)}`;
     }
 
+    let mapGA4Params = {};
+    if (!manholeParam) {
+      const resolvedPref = prefParam ? window.resolvePrefectureParam(prefParam) : '';
+      if (resolvedPref) {
+        mapGA4Params = {
+          page_type: 'map_prefecture',
+          prefecture: window.PREFECTURE_SLUG_MAP[resolvedPref] || resolvedPref,
+        };
+      } else {
+        mapGA4Params = { page_type: 'map_index' };
+      }
+    }
+
     gtag('config', 'G-K18NR4GZG2', {
-      'anonymize_ip': true,
-      'page_path': pagePath
+      anonymize_ip: true,
+      page_path: pagePath,
+      ...mapGA4Params,
     });
 
     // Event tracking helper function
@@ -594,7 +622,9 @@
         // Send page_view for SPA navigation (skip initial page load)
         if (window.gtag && !isInitialPageLoad) {
           gtag('event', 'page_view', {
-            'page_path': `/tracker_pref/${encodeURIComponent(prefecture)}`
+            page_path: `/tracker_pref/${encodeURIComponent(prefecture)}`,
+            page_type: 'map_prefecture',
+            prefecture: window.PREFECTURE_SLUG_MAP[prefecture] || prefecture,
           });
         }
       } else {
@@ -604,7 +634,8 @@
         // Send page_view for SPA navigation back to top (skip initial page load)
         if (window.gtag && !isInitialPageLoad) {
           gtag('event', 'page_view', {
-            'page_path': '/tracker_top'
+            page_path: '/tracker_top',
+            page_type: 'map_index',
           });
         }
       }

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -310,16 +310,16 @@
     const params = new URLSearchParams(window.location.search);
     const manholeParam = params.get('manhole');
     const prefParam = params.get('pref');
+    const resolvedPref = prefParam ? window.resolvePrefectureParam(prefParam) : '';
     let pagePath = '/tracker_top';
     if (manholeParam) {
       pagePath = `/tracker_manhole/${manholeParam}`;
-    } else if (prefParam) {
-      pagePath = `/tracker_pref/${encodeURIComponent(prefParam)}`;
+    } else if (resolvedPref) {
+      pagePath = `/tracker_pref/${encodeURIComponent(resolvedPref)}`;
     }
 
     let mapGA4Params = {};
     if (!manholeParam) {
-      const resolvedPref = prefParam ? window.resolvePrefectureParam(prefParam) : '';
       if (resolvedPref) {
         mapGA4Params = {
           page_type: 'map_prefecture',

--- a/apps/web/index.template.html
+++ b/apps/web/index.template.html
@@ -322,16 +322,16 @@
     const params = new URLSearchParams(window.location.search);
     const manholeParam = params.get('manhole');
     const prefParam = params.get('pref');
+    const resolvedPref = prefParam ? window.resolvePrefectureParam(prefParam) : '';
     let pagePath = '/tracker_top';
     if (manholeParam) {
       pagePath = `/tracker_manhole/${manholeParam}`;
-    } else if (prefParam) {
-      pagePath = `/tracker_pref/${encodeURIComponent(prefParam)}`;
+    } else if (resolvedPref) {
+      pagePath = `/tracker_pref/${encodeURIComponent(resolvedPref)}`;
     }
 
     let mapGA4Params = {};
     if (!manholeParam) {
-      const resolvedPref = prefParam ? window.resolvePrefectureParam(prefParam) : '';
       if (resolvedPref) {
         mapGA4Params = {
           page_type: 'map_prefecture',

--- a/apps/web/index.template.html
+++ b/apps/web/index.template.html
@@ -46,6 +46,20 @@
       '佐賀県': '41', '長崎県': '42', '熊本県': '43', '大分県': '44', '宮崎県': '45',
       '鹿児島県': '46', '沖縄県': '47'
     });
+    window.PREFECTURE_SLUG_MAP = Object.freeze({
+      '北海道': 'hokkaido',  '青森県': 'aomori',    '岩手県': 'iwate',     '宮城県': 'miyagi',
+      '秋田県': 'akita',     '山形県': 'yamagata',  '福島県': 'fukushima', '茨城県': 'ibaraki',
+      '栃木県': 'tochigi',   '群馬県': 'gunma',     '埼玉県': 'saitama',   '千葉県': 'chiba',
+      '東京都': 'tokyo',     '神奈川県': 'kanagawa','新潟県': 'niigata',   '富山県': 'toyama',
+      '石川県': 'ishikawa',  '福井県': 'fukui',     '山梨県': 'yamanashi', '長野県': 'nagano',
+      '岐阜県': 'gifu',      '静岡県': 'shizuoka',  '愛知県': 'aichi',     '三重県': 'mie',
+      '滋賀県': 'shiga',     '京都府': 'kyoto',     '大阪府': 'osaka',     '兵庫県': 'hyogo',
+      '奈良県': 'nara',      '和歌山県': 'wakayama','鳥取県': 'tottori',   '島根県': 'shimane',
+      '岡山県': 'okayama',   '広島県': 'hiroshima', '山口県': 'yamaguchi', '徳島県': 'tokushima',
+      '香川県': 'kagawa',    '愛媛県': 'ehime',     '高知県': 'kochi',     '福岡県': 'fukuoka',
+      '佐賀県': 'saga',      '長崎県': 'nagasaki',  '熊本県': 'kumamoto',  '大分県': 'oita',
+      '宮崎県': 'miyazaki',  '鹿児島県': 'kagoshima','沖縄県': 'okinawa'
+    });
     window.SITE_BASE_URL = 'https://data.pokefuta.com/';
 
     window.resolvePrefectureParam = function(prefParam) {
@@ -315,9 +329,23 @@
       pagePath = `/tracker_pref/${encodeURIComponent(prefParam)}`;
     }
 
+    let mapGA4Params = {};
+    if (!manholeParam) {
+      const resolvedPref = prefParam ? window.resolvePrefectureParam(prefParam) : '';
+      if (resolvedPref) {
+        mapGA4Params = {
+          page_type: 'map_prefecture',
+          prefecture: window.PREFECTURE_SLUG_MAP[resolvedPref] || resolvedPref,
+        };
+      } else {
+        mapGA4Params = { page_type: 'map_index' };
+      }
+    }
+
     gtag('config', 'G-K18NR4GZG2', {
-      'anonymize_ip': true,
-      'page_path': pagePath
+      anonymize_ip: true,
+      page_path: pagePath,
+      ...mapGA4Params,
     });
 
     // Event tracking helper function
@@ -605,7 +633,9 @@
         // Send page_view for SPA navigation (skip initial page load)
         if (window.gtag && !isInitialPageLoad) {
           gtag('event', 'page_view', {
-            'page_path': `/tracker_pref/${encodeURIComponent(prefecture)}`
+            page_path: `/tracker_pref/${encodeURIComponent(prefecture)}`,
+            page_type: 'map_prefecture',
+            prefecture: window.PREFECTURE_SLUG_MAP[prefecture] || prefecture,
           });
         }
       } else {
@@ -615,7 +645,8 @@
         // Send page_view for SPA navigation back to top (skip initial page load)
         if (window.gtag && !isInitialPageLoad) {
           gtag('event', 'page_view', {
-            'page_path': '/tracker_top'
+            page_path: '/tracker_top',
+            page_type: 'map_index',
           });
         }
       }


### PR DESCRIPTION
## Summary

- `PREFECTURE_SLUG_MAP` を head script に追加（47都道府県 → 英語小文字スラグ、`prefectures.json` の en フィールドに対応）
- GA4 初期ロード時の `gtag('config', ...)` に `page_type` / `prefecture` カスタムパラメータを追加
- SPA ナビゲーション（都道府県選択 / トップ戻り）の `page_view` イベントにも同パラメータを追加
- `index.template.html`（i18n 生成用テンプレート）に同一変更を適用

## 送信パラメータ

| URL | page_type | prefecture |
|-----|-----------|-----------|
| `/` | `map_index` | — |
| `/?pref=北海道` | `map_prefecture` | `hokkaido` |
| `/?pref=01` | `map_prefecture` | `hokkaido`（コード解決済み）|
| `/?manhole=xxx` | — (not set) | — |

※ `?manhole=xxx` の `page_type` は次フェーズ（`manhole_detail`）で対応

## GA4側設定（実装外）

GA4コンソール → カスタム定義 で以下を登録：
- `page_type`（スコープ: イベント）
- `prefecture`（スコープ: イベント）

## Test plan

- [ ] `/?` を開く → GA4 DebugView で `page_type: map_index` が届く
- [ ] `/?pref=北海道` を開く → `page_type: map_prefecture, prefecture: hokkaido`
- [ ] `/?pref=01` を開く → 同上（コード解決）
- [ ] 都道府県パネルから愛知を選択 → SPA `page_view` に `map_prefecture / aichi`
- [ ] トップに戻る → `page_view` に `map_index`
- [ ] `/?manhole=xxx` → `page_type` が送信されない

🤖 Generated with [Claude Code](https://claude.com/claude-code)