### PR TITLE
fix: /summary URL の末尾スラッシュを統一

### DIFF
--- a/apps/scraper/generate_manhole_pages.py
+++ b/apps/scraper/generate_manhole_pages.py
@@ -916,7 +916,9 @@ def generate_html(
     function gtag(){{dataLayer.push(arguments);}}
     gtag('js', new Date());
     gtag('config', '{GA_MEASUREMENT_ID}', {{
-      'page_path': '/manholes/' + {manhole_id_js} + '/'
+      'page_path': '/manholes/' + {manhole_id_js} + '/',
+      site_type: 'map',
+      page_type: 'map_manhole',
     }});
     gtag('event', 'view_manhole_detail', {{
       manhole_id: {manhole_id_js},

--- a/apps/scraper/generate_manhole_pages.py
+++ b/apps/scraper/generate_manhole_pages.py
@@ -433,6 +433,7 @@ def generate_html(
     manhole_id_js = _js_json(manhole_id)
     prefecture_js = _js_json(prefecture)
     city_js = _js_json(city)
+    pref_slug = PREFECTURE_EN.get(prefecture, "").lower().replace(" prefecture", "")
 
     # _attr_json() serializes dicts as JSON with " escaped to &quot; so they
     # are safe inside HTML double-quoted onclick attributes.
@@ -919,6 +920,7 @@ def generate_html(
       'page_path': '/manholes/' + {manhole_id_js} + '/',
       site_type: 'map',
       page_type: 'map_manhole',
+      prefecture: '{pref_slug}',
     }});
     gtag('event', 'view_manhole_detail', {{
       manhole_id: {manhole_id_js},

--- a/apps/scraper/generate_pokemon_index_page.py
+++ b/apps/scraper/generate_pokemon_index_page.py
@@ -816,7 +816,7 @@ def generate_html(
     window.dataLayer = window.dataLayer || [];
     function gtag(){{dataLayer.push(arguments);}}
     gtag('js', new Date());
-    gtag('config', '{GA_MEASUREMENT_ID}', {{'page_path': '/{url_prefix}pokemon/'}});
+    gtag('config', '{GA_MEASUREMENT_ID}', {{'page_path': '/{url_prefix}pokemon/', site_type: 'map', page_type: 'pokemon_index'}});
     gtag('event', 'view_pokemon_index', {{'pokemon_count': {total_count}, 'lang': '{lang}'}});
   </script>
 

--- a/apps/scraper/generate_pokemon_pages.py
+++ b/apps/scraper/generate_pokemon_pages.py
@@ -822,7 +822,9 @@ def generate_html(
     function gtag(){{dataLayer.push(arguments);}}
     gtag('js', new Date());
     gtag('config', '{GA_MEASUREMENT_ID}', {{
-      'page_path': '/{url_prefix}pokemon/' + {slug_js} + '/'
+      'page_path': '/{url_prefix}pokemon/' + {slug_js} + '/',
+      site_type: 'map',
+      page_type: 'pokemon_lp',
     }});
     gtag('event', 'view_pokemon_lp', {{
       pokemon_slug: {slug_js},

--- a/apps/scraper/generate_sitemap.py
+++ b/apps/scraper/generate_sitemap.py
@@ -183,7 +183,7 @@ def url_entry(loc: str, changefreq: str, priority: str) -> str:
 def build_sitemap(manhole_ids: list[str], pokemon_slugs: list[str] | None = None) -> str:
     entries = [
         url_entry(BASE_URL, "daily", "1.0"),
-        url_entry(f"{BASE_URL}summary", "weekly", "0.9"),
+        url_entry(f"{BASE_URL}summary/", "weekly", "0.9"),
         url_entry(f"{BASE_URL}pokemon/", "weekly", "0.9"),
         url_entry(f"{BASE_URL}nearby.html", "weekly", "0.6"),
         url_entry(f"{BASE_URL}gmanhole_map.html", "weekly", "0.6"),

--- a/apps/scraper/generate_summary_pages.py
+++ b/apps/scraper/generate_summary_pages.py
@@ -30,7 +30,7 @@ BASE_URL = "https://data.pokefuta.com"
 _OGP_PNG = ROOT / "apps" / "web" / "assets" / "ogp" / "pokefuta_summary_ogp.png"
 _ogp_hash = hashlib.md5(_OGP_PNG.read_bytes()).hexdigest()[:8] if _OGP_PNG.exists() else "0"
 OGP_IMAGE = f"{BASE_URL}/assets/ogp/pokefuta_summary_ogp.png?v={_ogp_hash}"
-SUMMARY_SHARE_URL = f"{BASE_URL}/summary"
+SUMMARY_SHARE_URL = f"{BASE_URL}/summary/"
 
 PREFECTURE_ORDER: list[str] = [
     "北海道", "青森県", "岩手県", "宮城県", "秋田県",
@@ -70,7 +70,7 @@ SUMMARY_STRINGS: dict[str, dict] = {
         "og_locale": "ja_JP",
         "pref_key": "ja",
         "out_path": "summary/index.html",
-        "canonical": f"{BASE_URL}/summary",
+        "canonical": f"{BASE_URL}/summary/",
         "map_base_href": "/",
         "page_title": "全国のポケモンマンホール（ポケふた）一覧・分布マップ",
         "meta_desc": "全国{total}枚のポケモンマンホール「ポケふた」を都道府県別・ポケモン別に検索。旅行先のポケふた探しにご活用ください。",
@@ -156,7 +156,7 @@ SUMMARY_STRINGS: dict[str, dict] = {
         "og_locale": "en_US",
         "pref_key": "en",
         "out_path": "en/summary/index.html",
-        "canonical": f"{BASE_URL}/en/summary",
+        "canonical": f"{BASE_URL}/en/summary/",
         "map_base_href": "/en/",
         "page_title": "How Many Pokéfuta Exist Nationwide? Count & Rankings by Prefecture",
         "meta_desc": "Explore the total number of Pokémon manholes (Pokéfuta) nationwide, the count by prefecture, top-ranking prefectures, and prefectures with none installed.",
@@ -229,7 +229,7 @@ SUMMARY_STRINGS: dict[str, dict] = {
         "og_locale": "zh_CN",
         "pref_key": "zh-Hans",
         "out_path": "zh-CN/summary/index.html",
-        "canonical": f"{BASE_URL}/zh-CN/summary",
+        "canonical": f"{BASE_URL}/zh-CN/summary/",
         "map_base_href": "/zh-CN/",
         "page_title": "全国共有多少个宝可梦井盖？分都道府县数量与排行榜",
         "meta_desc": "整理了全国宝可梦井盖（Pokéfuta）的总数、各都道府县的设置数量、数量最多的县以及尚未设置的县。",
@@ -302,7 +302,7 @@ SUMMARY_STRINGS: dict[str, dict] = {
         "og_locale": "zh_TW",
         "pref_key": "zh-Hant",
         "out_path": "zh-TW/summary/index.html",
-        "canonical": f"{BASE_URL}/zh-TW/summary",
+        "canonical": f"{BASE_URL}/zh-TW/summary/",
         "map_base_href": "/zh-TW/",
         "page_title": "全國共有多少個寶可夢人孔蓋？各都道府縣數量與排行榜",
         "meta_desc": "整理了全國寶可夢人孔蓋（Pokéfuta）的總數、各都道府縣的設置數量、數量最多的縣以及尚未設置的縣。",
@@ -375,7 +375,7 @@ SUMMARY_STRINGS: dict[str, dict] = {
         "og_locale": "ko_KR",
         "pref_key": "ko",
         "out_path": "ko/summary/index.html",
-        "canonical": f"{BASE_URL}/ko/summary",
+        "canonical": f"{BASE_URL}/ko/summary/",
         "map_base_href": "/ko/",
         "page_title": "포케후타는 전국에 몇 개 있을까? 도도부현별 수량 및 랭킹",
         "meta_desc": "전국 포케후타(포켓몬 맨홀)의 총 수량, 도도부현별 설치 수, 가장 많은 현, 아직 설치되지 않은 현을 정리했습니다.",

--- a/apps/scraper/generate_summary_pages.py
+++ b/apps/scraper/generate_summary_pages.py
@@ -2001,7 +2001,9 @@ def _build_tracking_script(s: dict) -> str:
     gtag('js', new Date());
     gtag('config', 'G-K18NR4GZG2', {
       'anonymize_ip': true,
-      'page_path': window.location.pathname
+      'page_path': window.location.pathname,
+      site_type: 'map',
+      page_type: 'summary',
     });
 
     document.addEventListener('click', function (event) {

--- a/apps/web/gmanhole_map.html
+++ b/apps/web/gmanhole_map.html
@@ -63,15 +63,18 @@
     const params = new URLSearchParams(window.location.search);
     const prefParam = params.get('pref');
     let pagePath = '/tracker_gmanhole_map';
+    let gmanholeGA4Params = { site_type: 'map', page_type: 'map_gmanhole' };
     if (prefParam) {
       // Normalize prefecture code to name
       const normalizedPref = (prefParam.length === 2 && !isNaN(prefParam)) ? (CODE_TO_PREF[prefParam] || prefParam) : prefParam;
       pagePath = `/tracker_gmanhole_map_pref/${encodeURIComponent(normalizedPref)}`;
+      gmanholeGA4Params.prefecture = normalizedPref;
     }
 
     gtag('config', 'G-K18NR4GZG2', {
       'anonymize_ip': true,
-      'page_path': pagePath
+      'page_path': pagePath,
+      ...gmanholeGA4Params,
     });
 
     // Event tracking helper function
@@ -339,7 +342,7 @@
 
           // Track prefecture selection
           if (window.trackEvent && willSelect) {
-            window.trackEvent('click_prefecture_gmanhole', {
+            window.trackEvent('click_prefecture', {
               'event_category': 'navigation',
               'event_label': pref,
               'value': total

--- a/apps/web/gmanhole_map.html
+++ b/apps/web/gmanhole_map.html
@@ -60,6 +60,7 @@
     // Dynamic page_path for Gundam manhole map
     // Inline code-to-name mapping to avoid duplication (full map defined globally below)
     const CODE_TO_PREF = {'01':'北海道','02':'青森県','03':'岩手県','04':'宮城県','05':'秋田県','06':'山形県','07':'福島県','08':'茨城県','09':'栃木県','10':'群馬県','11':'埼玉県','12':'千葉県','13':'東京都','14':'神奈川県','15':'新潟県','16':'富山県','17':'石川県','18':'福井県','19':'山梨県','20':'長野県','21':'岐阜県','22':'静岡県','23':'愛知県','24':'三重県','25':'滋賀県','26':'京都府','27':'大阪府','28':'兵庫県','29':'奈良県','30':'和歌山県','31':'鳥取県','32':'島根県','33':'岡山県','34':'広島県','35':'山口県','36':'徳島県','37':'香川県','38':'愛媛県','39':'高知県','40':'福岡県','41':'佐賀県','42':'長崎県','43':'熊本県','44':'大分県','45':'宮崎県','46':'鹿児島県','47':'沖縄県'};
+    const PREF_TO_SLUG = {'北海道':'hokkaido','青森県':'aomori','岩手県':'iwate','宮城県':'miyagi','秋田県':'akita','山形県':'yamagata','福島県':'fukushima','茨城県':'ibaraki','栃木県':'tochigi','群馬県':'gunma','埼玉県':'saitama','千葉県':'chiba','東京都':'tokyo','神奈川県':'kanagawa','新潟県':'niigata','富山県':'toyama','石川県':'ishikawa','福井県':'fukui','山梨県':'yamanashi','長野県':'nagano','岐阜県':'gifu','静岡県':'shizuoka','愛知県':'aichi','三重県':'mie','滋賀県':'shiga','京都府':'kyoto','大阪府':'osaka','兵庫県':'hyogo','奈良県':'nara','和歌山県':'wakayama','鳥取県':'tottori','島根県':'shimane','岡山県':'okayama','広島県':'hiroshima','山口県':'yamaguchi','徳島県':'tokushima','香川県':'kagawa','愛媛県':'ehime','高知県':'kochi','福岡県':'fukuoka','佐賀県':'saga','長崎県':'nagasaki','熊本県':'kumamoto','大分県':'oita','宮崎県':'miyazaki','鹿児島県':'kagoshima','沖縄県':'okinawa'};
     const params = new URLSearchParams(window.location.search);
     const prefParam = params.get('pref');
     let pagePath = '/tracker_gmanhole_map';
@@ -68,7 +69,7 @@
       // Normalize prefecture code to name
       const normalizedPref = (prefParam.length === 2 && !isNaN(prefParam)) ? (CODE_TO_PREF[prefParam] || prefParam) : prefParam;
       pagePath = `/tracker_gmanhole_map_pref/${encodeURIComponent(normalizedPref)}`;
-      gmanholeGA4Params.prefecture = normalizedPref;
+      gmanholeGA4Params.prefecture = PREF_TO_SLUG[normalizedPref] || normalizedPref;
     }
 
     gtag('config', 'G-K18NR4GZG2', {

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -320,7 +320,8 @@
 
     let mapGA4Params = { site_type: 'map', page_type: 'map_top' };
     if (manholeParam) {
-      mapGA4Params = { site_type: 'map', page_type: 'map_manhole' };
+      // prefecture slug unknown until data loads; suppress auto page_view and send manually from openManholePopup
+      mapGA4Params = { site_type: 'map', page_type: 'map_manhole', send_page_view: false };
     } else if (resolvedPref) {
       mapGA4Params = {
         site_type: 'map',
@@ -1203,9 +1204,9 @@
       const data = marker.pokefutaData;
       window.applyManholePageMeta(data);
       window.history.replaceState({ manhole: data.id }, '', window.buildManholeCanonicalPath(data.id));
-      // Send page_view for SPA navigation to manhole detail (skip initial page load)
+      // Send page_view for manhole detail (always: covers both initial ?manhole= load and SPA navigation)
       window.currentGA4PageType = 'map_manhole';
-      if (window.gtag && !isInitialPageLoad) {
+      if (window.gtag) {
         gtag('event', 'page_view', {
           'page_path': `/tracker_manhole/${encodeURIComponent(data.id)}`,
           site_type: 'map',

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -318,17 +318,15 @@
       pagePath = `/tracker_pref/${encodeURIComponent(resolvedPref)}`;
     }
 
-    let mapGA4Params = { site_type: 'map' };
-    if (!manholeParam) {
-      if (resolvedPref) {
-        mapGA4Params = {
-          site_type: 'map',
-          page_type: 'map_prefecture',
-          prefecture: window.PREFECTURE_SLUG_MAP[resolvedPref] || resolvedPref,
-        };
-      } else {
-        mapGA4Params = { site_type: 'map', page_type: 'map_top' };
-      }
+    let mapGA4Params = { site_type: 'map', page_type: 'map_top' };
+    if (manholeParam) {
+      mapGA4Params = { site_type: 'map', page_type: 'map_manhole' };
+    } else if (resolvedPref) {
+      mapGA4Params = {
+        site_type: 'map',
+        page_type: 'map_prefecture',
+        prefecture: window.PREFECTURE_SLUG_MAP[resolvedPref] || resolvedPref,
+      };
     }
 
     gtag('config', 'G-K18NR4GZG2', {
@@ -1206,6 +1204,7 @@
       window.applyManholePageMeta(data);
       window.history.replaceState({ manhole: data.id }, '', window.buildManholeCanonicalPath(data.id));
       // Send page_view for SPA navigation to manhole detail (skip initial page load)
+      window.currentGA4PageType = 'map_manhole';
       if (window.gtag && !isInitialPageLoad) {
         gtag('event', 'page_view', {
           'page_path': `/tracker_manhole/${encodeURIComponent(data.id)}`,

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -318,15 +318,16 @@
       pagePath = `/tracker_pref/${encodeURIComponent(resolvedPref)}`;
     }
 
-    let mapGA4Params = {};
+    let mapGA4Params = { site_type: 'map' };
     if (!manholeParam) {
       if (resolvedPref) {
         mapGA4Params = {
+          site_type: 'map',
           page_type: 'map_prefecture',
           prefecture: window.PREFECTURE_SLUG_MAP[resolvedPref] || resolvedPref,
         };
       } else {
-        mapGA4Params = { page_type: 'map_index' };
+        mapGA4Params = { site_type: 'map', page_type: 'map_top' };
       }
     }
 
@@ -335,6 +336,9 @@
       page_path: pagePath,
       ...mapGA4Params,
     });
+
+    // Current page_type for dynamic event params (updated on SPA navigation)
+    window.currentGA4PageType = mapGA4Params.page_type || 'map_top';
 
     // Event tracking helper function
     window.trackEvent = function(action, params = {}) {
@@ -620,9 +624,11 @@
         window.history.replaceState({ pref: prefecture }, '', window.buildCanonicalPath(prefecture));
         window.applyPrefecturePageMeta(prefecture);
         // Send page_view for SPA navigation (skip initial page load)
+        window.currentGA4PageType = 'map_prefecture';
         if (window.gtag && !isInitialPageLoad) {
           gtag('event', 'page_view', {
             page_path: `/tracker_pref/${encodeURIComponent(prefecture)}`,
+            site_type: 'map',
             page_type: 'map_prefecture',
             prefecture: window.PREFECTURE_SLUG_MAP[prefecture] || prefecture,
           });
@@ -631,11 +637,13 @@
         // URL をリセット
         window.history.replaceState({}, '', window.buildCanonicalPath(''));
         window.applyPrefecturePageMeta('');
+        window.currentGA4PageType = 'map_top';
         // Send page_view for SPA navigation back to top (skip initial page load)
         if (window.gtag && !isInitialPageLoad) {
           gtag('event', 'page_view', {
             page_path: '/tracker_top',
-            page_type: 'map_index',
+            site_type: 'map',
+            page_type: 'map_top',
           });
         }
       }
@@ -1086,7 +1094,9 @@
               window.trackEvent('click_manhole_marker', {
                 'event_category': 'navigation',
                 'event_label': d.prefecture || '不明',
-                'manhole_id': d.id
+                'manhole_id': d.id,
+                site_type: 'map',
+                page_type: window.currentGA4PageType || 'map_top',
               });
             }
             collapseBottomSheet();
@@ -1198,7 +1208,10 @@
       // Send page_view for SPA navigation to manhole detail (skip initial page load)
       if (window.gtag && !isInitialPageLoad) {
         gtag('event', 'page_view', {
-          'page_path': `/tracker_manhole/${encodeURIComponent(data.id)}`
+          'page_path': `/tracker_manhole/${encodeURIComponent(data.id)}`,
+          site_type: 'map',
+          page_type: 'map_manhole',
+          prefecture: window.PREFECTURE_SLUG_MAP[data.prefecture] || data.prefecture || '',
         });
       }
       const openPopup = () => {

--- a/apps/web/index.template.html
+++ b/apps/web/index.template.html
@@ -330,17 +330,15 @@
       pagePath = `/tracker_pref/${encodeURIComponent(resolvedPref)}`;
     }
 
-    let mapGA4Params = { site_type: 'map' };
-    if (!manholeParam) {
-      if (resolvedPref) {
-        mapGA4Params = {
-          site_type: 'map',
-          page_type: 'map_prefecture',
-          prefecture: window.PREFECTURE_SLUG_MAP[resolvedPref] || resolvedPref,
-        };
-      } else {
-        mapGA4Params = { site_type: 'map', page_type: 'map_top' };
-      }
+    let mapGA4Params = { site_type: 'map', page_type: 'map_top' };
+    if (manholeParam) {
+      mapGA4Params = { site_type: 'map', page_type: 'map_manhole' };
+    } else if (resolvedPref) {
+      mapGA4Params = {
+        site_type: 'map',
+        page_type: 'map_prefecture',
+        prefecture: window.PREFECTURE_SLUG_MAP[resolvedPref] || resolvedPref,
+      };
     }
 
     gtag('config', 'G-K18NR4GZG2', {
@@ -1197,6 +1195,7 @@
       window.applyManholePageMeta(data);
       window.history.replaceState({ manhole: data.id }, '', window.buildManholeCanonicalPath(data.id));
       // Send page_view for SPA navigation to manhole detail (skip initial page load)
+      window.currentGA4PageType = 'map_manhole';
       if (window.gtag && !isInitialPageLoad) {
         gtag('event', 'page_view', {
           'page_path': `/tracker_manhole/${encodeURIComponent(data.id)}`,

--- a/apps/web/index.template.html
+++ b/apps/web/index.template.html
@@ -332,7 +332,8 @@
 
     let mapGA4Params = { site_type: 'map', page_type: 'map_top' };
     if (manholeParam) {
-      mapGA4Params = { site_type: 'map', page_type: 'map_manhole' };
+      // prefecture slug unknown until data loads; suppress auto page_view and send manually from openManholePopup
+      mapGA4Params = { site_type: 'map', page_type: 'map_manhole', send_page_view: false };
     } else if (resolvedPref) {
       mapGA4Params = {
         site_type: 'map',
@@ -1194,9 +1195,9 @@
       const data = marker.pokefutaData;
       window.applyManholePageMeta(data);
       window.history.replaceState({ manhole: data.id }, '', window.buildManholeCanonicalPath(data.id));
-      // Send page_view for SPA navigation to manhole detail (skip initial page load)
+      // Send page_view for manhole detail (always: covers both initial ?manhole= load and SPA navigation)
       window.currentGA4PageType = 'map_manhole';
-      if (window.gtag && !isInitialPageLoad) {
+      if (window.gtag) {
         gtag('event', 'page_view', {
           'page_path': `/tracker_manhole/${encodeURIComponent(data.id)}`,
           site_type: 'map',

--- a/apps/web/index.template.html
+++ b/apps/web/index.template.html
@@ -330,15 +330,16 @@
       pagePath = `/tracker_pref/${encodeURIComponent(resolvedPref)}`;
     }
 
-    let mapGA4Params = {};
+    let mapGA4Params = { site_type: 'map' };
     if (!manholeParam) {
       if (resolvedPref) {
         mapGA4Params = {
+          site_type: 'map',
           page_type: 'map_prefecture',
           prefecture: window.PREFECTURE_SLUG_MAP[resolvedPref] || resolvedPref,
         };
       } else {
-        mapGA4Params = { page_type: 'map_index' };
+        mapGA4Params = { site_type: 'map', page_type: 'map_top' };
       }
     }
 
@@ -347,6 +348,9 @@
       page_path: pagePath,
       ...mapGA4Params,
     });
+
+    // Current page_type for dynamic event params (updated on SPA navigation)
+    window.currentGA4PageType = mapGA4Params.page_type || 'map_top';
 
     // Event tracking helper function
     window.trackEvent = function(action, params = {}) {
@@ -631,9 +635,11 @@
         window.history.replaceState({ pref: prefecture }, '', window.buildCanonicalPath(prefecture));
         window.applyPrefecturePageMeta(prefecture);
         // Send page_view for SPA navigation (skip initial page load)
+        window.currentGA4PageType = 'map_prefecture';
         if (window.gtag && !isInitialPageLoad) {
           gtag('event', 'page_view', {
             page_path: `/tracker_pref/${encodeURIComponent(prefecture)}`,
+            site_type: 'map',
             page_type: 'map_prefecture',
             prefecture: window.PREFECTURE_SLUG_MAP[prefecture] || prefecture,
           });
@@ -642,11 +648,13 @@
         // URL をリセット
         window.history.replaceState({}, '', window.buildCanonicalPath(''));
         window.applyPrefecturePageMeta('');
+        window.currentGA4PageType = 'map_top';
         // Send page_view for SPA navigation back to top (skip initial page load)
         if (window.gtag && !isInitialPageLoad) {
           gtag('event', 'page_view', {
             page_path: '/tracker_top',
-            page_type: 'map_index',
+            site_type: 'map',
+            page_type: 'map_top',
           });
         }
       }
@@ -1077,7 +1085,9 @@
               window.trackEvent('click_manhole_marker', {
                 'event_category': 'navigation',
                 'event_label': d.prefecture || '不明',
-                'manhole_id': d.id
+                'manhole_id': d.id,
+                site_type: 'map',
+                page_type: window.currentGA4PageType || 'map_top',
               });
             }
             collapseBottomSheet();
@@ -1189,7 +1199,10 @@
       // Send page_view for SPA navigation to manhole detail (skip initial page load)
       if (window.gtag && !isInitialPageLoad) {
         gtag('event', 'page_view', {
-          'page_path': `/tracker_manhole/${encodeURIComponent(data.id)}`
+          'page_path': `/tracker_manhole/${encodeURIComponent(data.id)}`,
+          site_type: 'map',
+          page_type: 'map_manhole',
+          prefecture: window.PREFECTURE_SLUG_MAP[data.prefecture] || data.prefecture || '',
         });
       }
       const openPopup = () => {

--- a/apps/web/nearby_manholes.html
+++ b/apps/web/nearby_manholes.html
@@ -516,7 +516,9 @@
 
   gtag('config', 'G-K18NR4GZG2', {
     'anonymize_ip': true,
-    'page_path': '/tracker_nearby'
+    'page_path': '/tracker_nearby',
+    site_type: 'map',
+    page_type: 'map_nearby',
   });
 
   // Event tracking helper function

--- a/apps/web/sitemap.xml
+++ b/apps/web/sitemap.xml
@@ -6,7 +6,7 @@
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://data.pokefuta.com/summary</loc>
+    <loc>https://data.pokefuta.com/summary/</loc>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>


### PR DESCRIPTION
## Summary

GA4 で `/summary` と `/summary/` の2行に分裂していた原因を修正。

| ファイル | 修正内容 |
|---------|---------|
| `apps/scraper/generate_sitemap.py` | `summary` → `summary/` |
| `apps/scraper/generate_summary_pages.py` | canonical（ja/en/zh-CN/zh-TW/ko）と `SUMMARY_SHARE_URL` を `summary/` に統一 |
| `apps/web/sitemap.xml` | `<loc>` を `summary/` に修正 |

内部リンク（`generate_pokemon_pages.py`・`generate_pokemon_index_page.py`）はすでに `/summary/` で正しかったため変更なし。

## Test plan

- [ ] `apps/web/sitemap.xml` の `<loc>` が `summary/` になっていることを確認
- [ ] CI 再生成後の `dist/sitemap.xml` が `summary/` になっていることを確認
- [ ] `dist/summary/index.html` の canonical タグが `summary/` になっていることを確認（CI 後）
- [ ] GA4 Search Console でインデックスされる URL が `/summary/` に統一されることを確認（数日後）

🤖 Generated with [Claude Code](https://claude.com/claude-code)