### PR TITLE
fix: GA4 page_path の都道府県を英語スラグに変更

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -315,7 +315,7 @@
     if (manholeParam) {
       pagePath = `/tracker_manhole/${manholeParam}`;
     } else if (resolvedPref) {
-      pagePath = `/tracker_pref/${encodeURIComponent(resolvedPref)}`;
+      pagePath = `/tracker_pref/${window.PREFECTURE_SLUG_MAP[resolvedPref] || encodeURIComponent(resolvedPref)}`;
     }
 
     let mapGA4Params = { site_type: 'map', page_type: 'map_top' };
@@ -626,7 +626,7 @@
         window.currentGA4PageType = 'map_prefecture';
         if (window.gtag && !isInitialPageLoad) {
           gtag('event', 'page_view', {
-            page_path: `/tracker_pref/${encodeURIComponent(prefecture)}`,
+            page_path: `/tracker_pref/${window.PREFECTURE_SLUG_MAP[prefecture] || encodeURIComponent(prefecture)}`,
             site_type: 'map',
             page_type: 'map_prefecture',
             prefecture: window.PREFECTURE_SLUG_MAP[prefecture] || prefecture,

--- a/apps/web/index.template.html
+++ b/apps/web/index.template.html
@@ -327,7 +327,7 @@
     if (manholeParam) {
       pagePath = `/tracker_manhole/${manholeParam}`;
     } else if (resolvedPref) {
-      pagePath = `/tracker_pref/${encodeURIComponent(resolvedPref)}`;
+      pagePath = `/tracker_pref/${window.PREFECTURE_SLUG_MAP[resolvedPref] || encodeURIComponent(resolvedPref)}`;
     }
 
     let mapGA4Params = { site_type: 'map', page_type: 'map_top' };
@@ -637,7 +637,7 @@
         window.currentGA4PageType = 'map_prefecture';
         if (window.gtag && !isInitialPageLoad) {
           gtag('event', 'page_view', {
-            page_path: `/tracker_pref/${encodeURIComponent(prefecture)}`,
+            page_path: `/tracker_pref/${window.PREFECTURE_SLUG_MAP[prefecture] || encodeURIComponent(prefecture)}`,
             site_type: 'map',
             page_type: 'map_prefecture',
             prefecture: window.PREFECTURE_SLUG_MAP[prefecture] || prefecture,


### PR DESCRIPTION
## Summary

- GA4 で `/tracker_pref/%E5%8D%83%E8%91%89%E7%9C%8C` と表示されていたものを `/tracker_pref/chiba` に変更
- `PREFECTURE_SLUG_MAP` を使って英語スラグに変換（マップにない場合は従来の `encodeURIComponent` にフォールバック）
- 変更対象は GA4 の `page_path` パラメータのみ。URL・ルーティング・ユーザー体験への影響なし

## Test plan

- [ ] 都道府県選択時に GA4 DebugView で `page_path: /tracker_pref/chiba` が送信されることを確認
- [ ] 初期 URL `/?pref=千葉県` でのページロード時も同様に確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)