### PR TITLE
Update manhole semantic metadata (20260609)

### DIFF
--- a/dataset/manhole_titles.json
+++ b/dataset/manhole_titles.json
@@ -559,6 +559,11 @@
         "seaside"
       ]
     },
+    "11": {
+      "tags": [
+        "roadside"
+      ]
+    },
     "12": {
       "tags": [
         "seaside"
@@ -2093,6 +2098,11 @@
         "roadside"
       ]
     },
+    "373": {
+      "tags": [
+        "roadside"
+      ]
+    },
     "377": {
       "building": "道の駅ゆうひパーク浜田",
       "tags": [
@@ -2231,6 +2241,11 @@
         "seaside"
       ]
     },
+    "402": {
+      "tags": [
+        "roadside"
+      ]
+    },
     "403": {
       "tags": [
         "seaside"
@@ -2341,7 +2356,13 @@
     },
     "418": {
       "tags": [
-        "seaside"
+        "seaside",
+        "roadside"
+      ]
+    },
+    "419": {
+      "tags": [
+        "roadside"
       ]
     },
     "422": {
@@ -2557,7 +2578,8 @@
     },
     "471": {
       "tags": [
-        "seaside"
+        "seaside",
+        "roadside"
       ]
     },
     "472": {


### PR DESCRIPTION
## Summary

semantic metadata をセマンティックエディタで更新しました。

## 変更内容

- michineki_nearby: 6件

対象マンホール数（ユニーク）: 6件

## Tasks

- michineki_nearby: 6件

## Guardrails

- docs/pokefuta.ndjson は変更されていません
- dataset/manhole_titles.json のみ変更されています

## Validation

- [x] JSON parse OK
- [x] schema OK
- [x] docs/*.ndjson 汚染なし
- [x] changes.ndjson で操作ログ確認済み

🤖 Generated with Semantic Manhole Metadata Editor