### PR TITLE
fix: summaryページのhreflangに末尾スラッシュを追加

### DIFF
--- a/apps/scraper/generate_summary_pages.py
+++ b/apps/scraper/generate_summary_pages.py
@@ -937,12 +937,12 @@ _CSS = """\
     }"""
 
 _HREFLANG = """\
-  <link rel="alternate" hreflang="ja"      href="https://data.pokefuta.com/summary">
-  <link rel="alternate" hreflang="en"      href="https://data.pokefuta.com/en/summary">
-  <link rel="alternate" hreflang="zh-TW"   href="https://data.pokefuta.com/zh-TW/summary">
-  <link rel="alternate" hreflang="zh-Hans" href="https://data.pokefuta.com/zh-CN/summary">
-  <link rel="alternate" hreflang="ko"      href="https://data.pokefuta.com/ko/summary">
-  <link rel="alternate" hreflang="x-default" href="https://data.pokefuta.com/summary">"""
+  <link rel="alternate" hreflang="ja"      href="https://data.pokefuta.com/summary/">
+  <link rel="alternate" hreflang="en"      href="https://data.pokefuta.com/en/summary/">
+  <link rel="alternate" hreflang="zh-TW"   href="https://data.pokefuta.com/zh-TW/summary/">
+  <link rel="alternate" hreflang="zh-Hans" href="https://data.pokefuta.com/zh-CN/summary/">
+  <link rel="alternate" hreflang="ko"      href="https://data.pokefuta.com/ko/summary/">
+  <link rel="alternate" hreflang="x-default" href="https://data.pokefuta.com/summary/">"""
 
 
 def load_records(path: Path) -> list[dict]:


### PR DESCRIPTION
## Summary

- `generate_summary_pages.py` の `_HREFLANG` 定数（全5言語）の URL に末尾 `/` を追加
- 修正前: `https://data.pokefuta.com/summary`（スラッシュなし）
- 修正後: `https://data.pokefuta.com/summary/`（スラッシュあり）

## 背景

Google Search Console で `/summary`（スラッシュなし）が indexed、`/summary/` が「Alternate page with proper canonical tag」になっていた。canonical・og:url・sitemap は正しく `/summary/` を指していたが、hreflang だけスラッシュなしだったため Google が `/summary` を正規 URL と判断していた。

## Test plan

- [x] `python3 apps/scraper/generate_summary_pages.py` で5言語版が正常生成されること
- [x] 生成された `dist/summary/index.html` の hreflang が全て `/summary/` になっていること
- [ ] デプロイ後、GSC で `/summary/` が正規 URL として認識されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)