### PR TITLE
[codex] 都道府県トリビアをデータから自動生成

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -14,7 +14,9 @@ on:
       - 'apps/scraper/generate_pokemon_index_page.py' # Pokemon index page generator
       - 'apps/scraper/generate_summary_pages.py' # summary page generator
       - 'apps/scraper/generate_summary_ogp.py' # summary page OGP generator
+      - 'apps/scraper/generate_prefecture_trivia.py' # prefecture trivia generator
       - 'docs/**'     # dataset changes copied into dist/
+      - 'dataset/prefecture_trivia*.json' # generated trivia and editorial sources
       - 'dataset/manhole/image/**' # local popup photos
       - 'tools/**'      # i18n build scripts
 
@@ -58,6 +60,8 @@ jobs:
         run: |
           set -e
           mkdir -p dist/assets
+          echo "[dist] Validate generated prefecture trivia"
+          python3 apps/scraper/generate_prefecture_trivia.py --check
           echo "[dist] Generate static manhole detail pages"
           python3 apps/scraper/generate_manhole_pages.py
           echo "[dist] Generate static Pokemon LP pages"

--- a/.github/workflows/update-pokefuta.yml
+++ b/.github/workflows/update-pokefuta.yml
@@ -67,10 +67,19 @@ jobs:
             --input apps/scraper/pokefuta.ndjson \
             --output docs/pokefuta.kml
 
+      - name: Generate prefecture trivia and social candidates
+        run: |
+          python apps/scraper/generate_prefecture_trivia.py
+          python apps/scraper/generate_social_posts.py
+
       - name: Detect dataset changes
         id: diff
         run: |
-          git add docs/pokefuta.ndjson docs/pokefuta.kml || true
+          git add \
+            docs/pokefuta.ndjson \
+            docs/pokefuta.kml \
+            docs/social-post-candidates.json \
+            dataset/prefecture_trivia.json || true
           if git diff --cached --quiet; then
             echo "changed=false" >> $GITHUB_OUTPUT
           else

--- a/apps/scraper/generate_prefecture_trivia.py
+++ b/apps/scraper/generate_prefecture_trivia.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""Generate prefecture trivia from the public Pokefuta dataset.
+
+Dataset-derived facts are recalculated on every run. Editorial facts and
+Pokemon groups live in dataset/prefecture_trivia_sources.json.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+from urllib.parse import urlparse
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_INPUT = ROOT / "docs" / "pokefuta.ndjson"
+DEFAULT_SOURCES = ROOT / "dataset" / "prefecture_trivia_sources.json"
+DEFAULT_OUTPUT = ROOT / "dataset" / "prefecture_trivia.json"
+
+PREFECTURE_ORDER = [
+    "北海道", "青森県", "岩手県", "宮城県", "秋田県",
+    "山形県", "福島県", "茨城県", "栃木県", "群馬県",
+    "埼玉県", "千葉県", "東京都", "神奈川県", "新潟県",
+    "富山県", "石川県", "福井県", "山梨県", "長野県",
+    "岐阜県", "静岡県", "愛知県", "三重県", "滋賀県",
+    "京都府", "大阪府", "兵庫県", "奈良県", "和歌山県",
+    "鳥取県", "島根県", "岡山県", "広島県", "山口県",
+    "徳島県", "香川県", "愛媛県", "高知県", "福岡県",
+    "佐賀県", "長崎県", "熊本県", "大分県", "宮崎県",
+    "鹿児島県", "沖縄県",
+]
+
+TRIVIA_PRIORITY = {
+    "local_connection": 100,
+    "wordplay": 95,
+    "support_pokemon": 90,
+    "single_municipality": 80,
+    "municipality_concentration": 75,
+    "pokemon_group_100": 70,
+    "pokemon_100": 65,
+    "top_pokemon": 20,
+    "remote_island": 15,
+    "world_heritage": 15,
+    "roadside_station": 15,
+    "station": 15,
+    "airport": 15,
+    "extreme_point": 15,
+}
+
+
+class ValidationError(ValueError):
+    pass
+
+
+def load_records(path: Path) -> list[dict]:
+    records: dict[str, dict] = {}
+    with path.open(encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, 1):
+            if not line.strip():
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ValidationError(f"{path}:{line_number}: invalid JSON: {exc}") from exc
+            record_id = str(record.get("id", "")).strip()
+            if not record_id:
+                raise ValidationError(f"{path}:{line_number}: record has no id")
+            records[record_id] = {**records.get(record_id, {}), **record}
+    return [record for record in records.values() if record.get("status", "active") == "active"]
+
+
+def load_sources(path: Path) -> dict:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValidationError(f"cannot load {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValidationError("source master must be a JSON object")
+    return data
+
+
+def _valid_https_url(value: object) -> bool:
+    if not isinstance(value, str):
+        return False
+    parsed = urlparse(value)
+    return parsed.scheme == "https" and bool(parsed.netloc)
+
+
+def validate_sources(sources: dict, records: list[dict]) -> None:
+    known_prefectures = {record.get("prefecture") for record in records}
+    known_pokemon = {
+        pokemon
+        for record in records
+        for pokemon in record.get("pokemons", [])
+        if isinstance(pokemon, str)
+    }
+    group_ids: set[str] = set()
+    trivia_ids: set[str] = set()
+
+    for group in sources.get("pokemon_groups", []):
+        group_id = group.get("id")
+        if not group_id or group_id in group_ids:
+            raise ValidationError(f"missing or duplicate Pokemon group id: {group_id!r}")
+        group_ids.add(group_id)
+        if group.get("prefecture") not in known_prefectures:
+            raise ValidationError(f"{group_id}: unknown prefecture")
+        pokemon = group.get("pokemon")
+        if not isinstance(pokemon, list) or not pokemon:
+            raise ValidationError(f"{group_id}: pokemon must be a non-empty list")
+        unknown = sorted(set(pokemon) - known_pokemon)
+        if unknown:
+            raise ValidationError(f"{group_id}: unknown Pokemon: {', '.join(unknown)}")
+
+    for entry in sources.get("editorial_trivia", []):
+        entry_id = entry.get("id")
+        if not entry_id or entry_id in trivia_ids:
+            raise ValidationError(f"missing or duplicate editorial trivia id: {entry_id!r}")
+        trivia_ids.add(entry_id)
+        if entry.get("prefecture") not in known_prefectures:
+            raise ValidationError(f"{entry_id}: unknown prefecture")
+        if entry.get("type") not in TRIVIA_PRIORITY:
+            raise ValidationError(f"{entry_id}: unknown trivia type")
+        if not entry.get("text"):
+            raise ValidationError(f"{entry_id}: text is required")
+        if not _valid_https_url(entry.get("source_url")):
+            raise ValidationError(f"{entry_id}: an HTTPS source_url is required")
+        if not entry.get("verified_at"):
+            raise ValidationError(f"{entry_id}: verified_at is required")
+        forbidden = {"count", "manhole_count", "municipality_count", "coverage_percent"}
+        present = forbidden.intersection(entry)
+        if present:
+            raise ValidationError(
+                f"{entry_id}: calculated values must not be stored in the source master: "
+                f"{', '.join(sorted(present))}"
+            )
+
+
+def _coverage(records: list[dict], pokemon: list[str]) -> int:
+    target = set(pokemon)
+    return sum(bool(target.intersection(record.get("pokemons", []))) for record in records)
+
+
+def _dataset_trivia(
+    prefecture: str,
+    records: list[dict],
+    municipality_counts: Counter,
+    pokemon_counts: Counter,
+    coverage: list[dict],
+) -> list[dict]:
+    trivia: list[dict] = []
+    municipalities = sorted({
+        record.get("city", "").strip()
+        for record in records
+        if record.get("city", "").strip()
+    })
+    total = len(records)
+
+    if len(municipalities) == 1 and total > 1:
+        city = municipalities[0]
+        trivia.append({
+            "id": f"{prefecture}-single-municipality",
+            "type": "single_municipality",
+            "text": f"県内{total}枚のポケふたはすべて{city}にあります",
+            "source_type": "dataset",
+        })
+    elif municipality_counts and total:
+        ranked = sorted(
+            municipality_counts.items(),
+            key=lambda item: (-item[1], item[0]),
+        )
+        top_city, top_count = ranked[0]
+        next_count = ranked[1][1] if len(ranked) > 1 else 0
+        top_share = top_count * 100 / total
+        if top_count >= 3 and top_share >= 30 and top_count > next_count:
+            remaining = ranked[1:]
+            if remaining and all(count == 1 for _, count in remaining):
+                text = (
+                    f"{top_city}に{top_count}枚が集まり、"
+                    f"ほかの{len(remaining)}自治体は各1枚です"
+                )
+            elif remaining:
+                runner_up_city, runner_up_count = remaining[0]
+                text = (
+                    f"最多は{top_city}の{top_count}枚で、"
+                    f"次いで{runner_up_city}の{runner_up_count}枚です"
+                )
+            else:
+                text = f"最多は{top_city}の{top_count}枚です"
+            trivia.append({
+                "id": f"{prefecture}-municipality-concentration",
+                "type": "municipality_concentration",
+                "text": text,
+                "source_type": "dataset",
+            })
+
+    for item in coverage:
+        if item["coverage_percent"] != 100:
+            continue
+        fact_type = "pokemon_group_100" if len(item["pokemon"]) > 1 else "pokemon_100"
+        trivia.append({
+            "id": f"{prefecture}-{item['id']}-100",
+            "type": fact_type,
+            "text": f"県内{total}枚すべてに{item['label']}が登場します",
+            "source_type": "dataset",
+        })
+
+    full_coverage_pokemon = {
+        pokemon
+        for item in coverage
+        if item["coverage_percent"] == 100
+        for pokemon in item["pokemon"]
+    }
+    if pokemon_counts and total and max(pokemon_counts.values()) >= 2:
+        count = max(pokemon_counts.values())
+        leaders = sorted(
+            name for name, appearances in pokemon_counts.items()
+            if appearances == count and name not in full_coverage_pokemon
+        )
+        if leaders:
+            pokemon = leaders[0]
+            if len(leaders) > 1:
+                examples = "・".join(leaders[:3])
+                text = f"最多は{examples}など{len(leaders)}種で、それぞれ{count}枚に登場します"
+            else:
+                text = f"最も多く登場するのは{pokemon}で、{count}枚に描かれています"
+            trivia.append({
+                "id": f"{prefecture}-top-pokemon",
+                "type": "top_pokemon",
+                "text": text,
+                "source_type": "dataset",
+            })
+    return trivia
+
+
+def generate(records: list[dict], sources: dict) -> list[dict]:
+    validate_sources(sources, records)
+    records_by_prefecture = {prefecture: [] for prefecture in PREFECTURE_ORDER}
+    for record in records:
+        prefecture = record.get("prefecture")
+        if prefecture in records_by_prefecture:
+            records_by_prefecture[prefecture].append(record)
+
+    groups_by_prefecture: dict[str, list[dict]] = {}
+    for group in sources.get("pokemon_groups", []):
+        groups_by_prefecture.setdefault(group["prefecture"], []).append(group)
+    editorial_by_prefecture: dict[str, list[dict]] = {}
+    for entry in sources.get("editorial_trivia", []):
+        editorial_by_prefecture.setdefault(entry["prefecture"], []).append(entry)
+
+    result = []
+    for prefecture in PREFECTURE_ORDER:
+        pref_records = records_by_prefecture[prefecture]
+        municipalities = sorted({
+            record.get("city", "").strip()
+            for record in pref_records
+            if record.get("city", "").strip()
+        })
+        municipality_counts = Counter(
+            record.get("city", "").strip()
+            for record in pref_records
+            if record.get("city", "").strip()
+        )
+        pokemon_counts = Counter(
+            pokemon
+            for record in pref_records
+            for pokemon in sorted(set(record.get("pokemons", [])))
+            if isinstance(pokemon, str) and pokemon.strip()
+        )
+        total = len(pref_records)
+
+        coverage: list[dict] = []
+        for pokemon, count in sorted(pokemon_counts.items(), key=lambda item: (-item[1], item[0])):
+            coverage.append({
+                "id": pokemon,
+                "label": pokemon,
+                "pokemon": [pokemon],
+                "cover_count": count,
+                "coverage_percent": round(count * 100 / total, 1) if total else 0,
+            })
+        for group in groups_by_prefecture.get(prefecture, []):
+            count = _coverage(pref_records, group["pokemon"])
+            coverage.append({
+                "id": group["id"],
+                "label": group["label"],
+                "pokemon": group["pokemon"],
+                "cover_count": count,
+                "coverage_percent": round(count * 100 / total, 1) if total else 0,
+            })
+
+        trivia = _dataset_trivia(
+            prefecture,
+            pref_records,
+            municipality_counts,
+            pokemon_counts,
+            coverage,
+        )
+        for entry in editorial_by_prefecture.get(prefecture, []):
+            trivia.append({
+                "id": entry["id"],
+                "type": entry["type"],
+                "text": entry["text"],
+                "source_type": "official",
+                "source_url": entry["source_url"],
+                "source_label": entry.get("source_label", "公式サイト"),
+                "verified_at": entry["verified_at"],
+            })
+        trivia.sort(key=lambda item: (-TRIVIA_PRIORITY[item["type"]], item["id"]))
+
+        result.append({
+            "prefecture": prefecture,
+            "manhole_count": total,
+            "municipality_count": len(municipalities),
+            "municipalities": municipalities,
+            "municipality_distribution": [
+                {"municipality": city, "manhole_count": count}
+                for city, count in sorted(
+                    municipality_counts.items(),
+                    key=lambda item: (-item[1], item[0]),
+                )
+            ],
+            "pokemon_coverage": coverage,
+            "trivia": trivia,
+        })
+    return result
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", type=Path, default=DEFAULT_INPUT)
+    parser.add_argument("--sources", type=Path, default=DEFAULT_SOURCES)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--check", action="store_true", help="Fail if output is stale")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        records = load_records(args.input)
+        generated = generate(records, load_sources(args.sources))
+    except (OSError, ValidationError) as exc:
+        print(f"[ERROR] {exc}", file=sys.stderr)
+        return 1
+
+    rendered = json.dumps(generated, ensure_ascii=False, indent=2) + "\n"
+    if args.check:
+        current = args.output.read_text(encoding="utf-8") if args.output.exists() else ""
+        if current != rendered:
+            print(f"[ERROR] stale generated file: {args.output}", file=sys.stderr)
+            return 1
+        print(f"[OK] {args.output} is current")
+        return 0
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(rendered, encoding="utf-8")
+    trivia_count = sum(len(item["trivia"]) for item in generated)
+    print(f"[OK] wrote {len(generated)} prefectures / {trivia_count} trivia to {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/scraper/generate_social_ogp.py
+++ b/apps/scraper/generate_social_ogp.py
@@ -1206,13 +1206,40 @@ def _vars_pref_trivia(raw: dict) -> dict:
     v = raw["values"]
     pref = v.get("prefecture", "")
     pokemon = v.get("pokemon", "")
+    if pokemon:
+        return {
+            "categoryLabel": "TRIVIA",
+            "titleLine1": f"{pref}の",
+            "titleLine2": "応援ポケモン",
+            "kicker": "都道府県キャラクター",
+            "mainNumber": pokemon,
+            "mainUnit": "",
+            "chips": [],
+            "description": v.get("summary", f"{pref}のポケモンマンホール"),
+            "mapCaption": f"{pref}のポケふた",
+        }
+
+    fact_type = raw.get("fact_type", "pref_trivia")
+    labels = {
+        "single_municipality": ("1自治体に集中", "自治体別データ"),
+        "municipality_concentration": ("自治体分布", "自治体別データ"),
+        "pokemon_100": ("全ふたに登場", "ポケモン出現率100%"),
+        "pokemon_group_100": ("全ふたに登場", "ポケモン出現率100%"),
+        "top_pokemon": ("登場ポケモン", "県内トップ"),
+        "support_pokemon": ("応援ポケモン", "公式ご当地ポケモン"),
+        "wordplay": ("ご当地トリビア", "名前の由来"),
+        "local_connection": ("ご当地トリビア", "地域とのつながり"),
+    }
+    title_line2, kicker = labels.get(
+        fact_type, ("ポケふたトリビア", "都道府県データ")
+    )
     return {
         "categoryLabel": "TRIVIA",
         "titleLine1": f"{pref}の",
-        "titleLine2": "応援ポケモン",
-        "kicker": "都道府県キャラクター",
-        "mainNumber": pokemon,
-        "mainUnit": "",
+        "titleLine2": title_line2,
+        "kicker": kicker,
+        "mainNumber": str(v.get("manhole_count", "")),
+        "mainUnit": "枚" if v.get("manhole_count") is not None else "",
         "chips": [],
         "description": v.get("summary", f"{pref}のポケモンマンホール"),
         "mapCaption": f"{pref}のポケふた",

--- a/apps/scraper/generate_social_posts.py
+++ b/apps/scraper/generate_social_posts.py
@@ -568,25 +568,32 @@ def gen_travel_trivia_candidates(stats: dict, pokemon_stats: dict) -> list[dict]
 
 def gen_pref_trivia_candidates(trivia_data: list[dict]) -> list[dict]:
     candidates = []
-    for entry in trivia_data:
-        candidates.append({
-            "id": f"pref-trivia-{entry['id']}",
-            "type": "pref_trivia",
-            "title": entry["title"],
-            "url": f"{BASE_URL}summary/",
-            "hashtags": ["#ポケふた", "#ポケモンマンホール"],
-            "imageType": "summary_trivia",
-            "source": "pref_trivia",
-            "raw_data": {
-                "fact_type": "pref_trivia",
-                "values": {
-                    "prefecture": entry["prefecture"],
-                    "pokemon": entry["pokemon"],
-                    "summary": entry["summary"],
-                    "map_pref": entry.get("map_pref", entry["prefecture"]),
+    for prefecture_entry in trivia_data:
+        prefecture = prefecture_entry.get("prefecture", "")
+        manhole_count = prefecture_entry.get("manhole_count", 0)
+        for trivia in prefecture_entry.get("trivia", []):
+            if not trivia.get("id") or not trivia.get("text"):
+                continue
+            candidates.append({
+                "id": f"pref-trivia-{trivia['id']}",
+                "type": "pref_trivia",
+                "title": f"{prefecture}のポケふたトリビア",
+                "url": f"{BASE_URL}summary/",
+                "hashtags": ["#ポケふた", "#ポケモンマンホール"],
+                "imageType": "summary_trivia",
+                "source": "pref_trivia",
+                "raw_data": {
+                    "fact_type": trivia.get("type", "pref_trivia"),
+                    "values": {
+                        "prefecture": prefecture,
+                        "manhole_count": manhole_count,
+                        "summary": trivia["text"],
+                        "map_pref": prefecture,
+                        "source_type": trivia.get("source_type", "dataset"),
+                        "source_url": trivia.get("source_url", ""),
+                    },
                 },
-            },
-        })
+            })
     return candidates
 
 

--- a/apps/scraper/generate_summary_pages.py
+++ b/apps/scraper/generate_summary_pages.py
@@ -65,19 +65,6 @@ REGION_MAP: dict[str, str] = {
     "鹿児島県": "九州", "沖縄県": "九州",
 }
 
-PREFECTURE_LOCAL_TRIVIA: dict[str, dict[str, str]] = {
-    "佐賀県": {
-        "pokemon": "ニャース3種",
-        "fact": "佐賀市にはニャース・アローラニャース・ガラルニャースの3枚があり、すべてに気球が描かれています。バルーンフェスタで知られる「気球のまち佐賀」ならではのデザインです。",
-        "official_url": "https://www.city.saga.lg.jp/",
-        "official_label": "佐賀市公式サイト",
-    },
-    "鹿児島県": {
-        "pokemon": "イーブイ系",
-        "fact": "ポケふた第1号は2018年12月20日、指宿駅前に設置されたイーブイ。「いーぶいすき＝指宿」の語呂合わせが縁です。指宿市には進化形8種類を含む9枚が揃い、市内だけでイーブイ系をコンプリートできます。",
-    },
-}
-
 SUMMARY_STRINGS: dict[str, dict] = {
     "ja": {
         "html_lang": "ja",
@@ -1266,6 +1253,17 @@ _CSS = """\
       font-size: .72rem;
       line-height: 1.4;
     }
+    .prefecture-info-facts {
+      grid-column: 1 / -1;
+      margin: 0;
+      padding-left: 1.1rem;
+      color: #716154;
+      font-size: .72rem;
+      line-height: 1.4;
+    }
+    .prefecture-info-facts li + li {
+      margin-top: .3rem;
+    }
 
     .prefecture-info-actions {
       grid-column: 1 / -1;
@@ -1394,6 +1392,9 @@ _CSS = """\
       }
 
       .prefecture-info-fact {
+        font-size: .66rem;
+      }
+      .prefecture-info-facts {
         font-size: .66rem;
       }
 
@@ -2446,6 +2447,12 @@ FACT_COPY["ko"]["facts"] = {
     },
 }
 
+LEGACY_EDITORIAL_FACT_IDS = {
+    "first-pokefuta",
+    "ibusuki-eevee-9",
+    "saga-nyansu",
+}
+
 
 def _localized_fact_copy(lang: str) -> dict:
     return FACT_COPY.get(lang, FACT_COPY["en"])
@@ -2502,6 +2509,8 @@ def _build_facts(s: dict, stats: dict, tr) -> list[dict]:
 
     facts = []
     for fact_id, template in copy["facts"].items():
+        if fact_id in LEGACY_EDITORIAL_FACT_IDS:
+            continue
         if fact_id == "empty-prefectures" and not empty_count:
             continue
         fact = {
@@ -2825,7 +2834,7 @@ def _build_prefecture_info_section(
             records_by_pref[pref].append(record)
 
     is_ja = s.get("pref_key") == "ja"
-    support_by_pref = {
+    trivia_by_pref = {
         entry["prefecture"]: entry
         for entry in trivia_data
         if entry.get("prefecture")
@@ -2847,17 +2856,47 @@ def _build_prefecture_info_section(
         )
         top_pokemon = pokemon_counts.most_common(1)
         pokemon_label = top_pokemon[0][0] if top_pokemon else s["no_pokemon_label"]
-        support = support_by_pref.get(pref)
-        local_trivia = PREFECTURE_LOCAL_TRIVIA.get(pref) if is_ja else None
+        pref_trivia = trivia_by_pref.get(pref) if is_ja else None
 
-        if local_trivia:
-            pokemon_label = local_trivia["pokemon"]
+        if pref_trivia:
+            coverage = pref_trivia.get("pokemon_coverage", [])
+            full_coverage = [
+                entry for entry in coverage
+                if entry.get("coverage_percent") == 100
+            ]
+            top_coverage = max(
+                full_coverage,
+                key=lambda entry: (
+                    len(entry.get("pokemon", [])),
+                    entry.get("cover_count", 0),
+                ),
+                default=None,
+            )
+            if top_coverage:
+                pokemon_label = top_coverage.get("label", pokemon_label)
+            else:
+                trivia_types = {
+                    entry.get("type")
+                    for entry in pref_trivia.get("trivia", [])
+                }
+                if "municipality_concentration" in trivia_types:
+                    pokemon_label = "自治体分布"
+                elif "single_municipality" in trivia_types:
+                    pokemon_label = "1自治体に集中"
+                elif pref_records:
+                    pokemon_label = "県内データ"
             display_count = item["count"]
-            fact = local_trivia["fact"]
-        elif support:
-            pokemon_label = support["pokemon"]
-            display_count = item["count"]
-            fact = support["summary"]
+            selected_trivia = pref_trivia.get("trivia", [])[:3]
+            if not pref_records:
+                selected_trivia = [{
+                    "type": "empty",
+                    "text": s["empty_pref_fact"],
+                    "source_type": "dataset",
+                }]
+            facts = [entry.get("text", "") for entry in selected_trivia if entry.get("text")]
+            fact = facts[0] if facts else s["pref_fact_generic"].format(
+                city_count=city_count, species_count=len(pokemon_counts)
+            )
         elif not pref_records:
             display_count = item["count"]
             fact = s["empty_pref_fact"]
@@ -2877,43 +2916,43 @@ def _build_prefecture_info_section(
                 city_count=city_count, species_count=species_count
             )
 
-        if local_trivia:
+        if pref_trivia:
             open_tag = '<article class="prefecture-info-card local-trivia-card">'
             close_tag = "</article>"
             pokemon_html = (
                 f'<span class="prefecture-info-pokemon">'
-                f'<span class="prefecture-info-label">ご当地雑学</span>'
+                f'<span class="prefecture-info-label">都道府県トリビア</span>'
                 f'{escape(pokemon_label)}</span>'
             )
+            facts_html = "".join(
+                f"<li>{escape(entry['text'])}</li>"
+                for entry in selected_trivia
+                if entry.get("text")
+            )
+            fact_html = (
+                f'<ul class="prefecture-info-facts">{facts_html}</ul>'
+                if facts_html
+                else f'<p class="prefecture-info-fact">{escape(fact)}</p>'
+            )
+            official = next(
+                (
+                    entry
+                    for entry in selected_trivia
+                    if entry.get("source_type") == "official"
+                    and _safe_https_url(entry.get("source_url"), "")
+                ),
+                None,
+            )
             official_html = ""
-            if local_trivia.get("official_url"):
+            if official:
                 official_html = (
-                    f'<a href="{escape(local_trivia["official_url"])}" target="_blank" '
+                    f'<a href="{escape(official["source_url"])}" target="_blank" '
                     f'rel="noopener noreferrer">'
-                    f'{escape(local_trivia.get("official_label", "公式サイト"))}</a>'
+                    f'{escape(official.get("source_label", "公式サイト"))}</a>'
                 )
             actions_html = (
                 f'<div class="prefecture-info-actions">'
                 f'{official_html}'
-                f'<a href="{escape(_map_href(s["map_base_href"], pref))}">'
-                f'{escape(s["map_link_text"])}</a>'
-                f'</div>'
-            )
-        elif support:
-            official_url = _safe_https_url(
-                support.get("source_url"), "https://local.pokemon.jp/"
-            )
-            open_tag = '<article class="prefecture-info-card support-pokemon-card">'
-            close_tag = "</article>"
-            pokemon_html = (
-                f'<span class="prefecture-info-pokemon">'
-                f'<span class="prefecture-info-label">応援ポケモン</span>'
-                f'{escape(pokemon_label)}</span>'
-            )
-            actions_html = (
-                f'<div class="prefecture-info-actions">'
-                f'<a href="{escape(official_url)}" target="_blank" '
-                f'rel="noopener noreferrer">公式サイト</a>'
                 f'<a href="{escape(_map_href(s["map_base_href"], pref))}">'
                 f'{escape(s["map_link_text"])}</a>'
                 f'</div>'
@@ -2929,6 +2968,7 @@ def _build_prefecture_info_section(
                 f'{escape(pokemon_label)}</span>'
             )
             actions_html = ""
+            fact_html = f'<p class="prefecture-info-fact">{escape(fact)}</p>'
         else:
             open_tag = '<article class="prefecture-info-card">'
             close_tag = "</article>"
@@ -2937,13 +2977,14 @@ def _build_prefecture_info_section(
                 f'{escape(pokemon_label)}</span>'
             )
             actions_html = ""
+            fact_html = f'<p class="prefecture-info-fact">{escape(fact)}</p>'
         cards.append(
             open_tag
             +
             f'<h3>{escape(tr(pref))}</h3>'
             f'{pokemon_html}'
             f'<strong class="prefecture-info-count">{display_count}{escape(count_unit)}</strong>'
-            f'<p class="prefecture-info-fact">{escape(fact)}</p>'
+            f'{fact_html}'
             f'{actions_html}'
             f'{close_tag}'
         )

--- a/apps/scraper/test_generate_prefecture_trivia.py
+++ b/apps/scraper/test_generate_prefecture_trivia.py
@@ -14,6 +14,12 @@ MODULE = importlib.util.module_from_spec(SPEC)
 assert SPEC.loader
 SPEC.loader.exec_module(MODULE)
 
+OGP_MODULE_PATH = Path(__file__).with_name("generate_social_ogp.py")
+OGP_SPEC = importlib.util.spec_from_file_location("generate_social_ogp", OGP_MODULE_PATH)
+OGP_MODULE = importlib.util.module_from_spec(OGP_SPEC)
+assert OGP_SPEC.loader
+OGP_SPEC.loader.exec_module(OGP_MODULE)
+
 ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -152,6 +158,35 @@ class GeneratePrefectureTriviaTest(unittest.TestCase):
             with self.subTest(source=json.dumps(sources, ensure_ascii=False)[:80]):
                 with self.assertRaises(MODULE.ValidationError):
                     MODULE.validate_sources(sources, self.records)
+
+    def test_social_ogp_uses_new_trivia_schema(self) -> None:
+        variables = OGP_MODULE._vars_pref_trivia({
+            "fact_type": "municipality_concentration",
+            "values": {
+                "prefecture": "愛知県",
+                "manhole_count": 9,
+                "summary": "豊橋市に4枚が集まり、ほかの5自治体は各1枚です",
+            },
+        })
+        self.assertEqual("自治体分布", variables["titleLine2"])
+        self.assertEqual("9", variables["mainNumber"])
+        self.assertEqual("枚", variables["mainUnit"])
+        self.assertEqual(
+            "豊橋市に4枚が集まり、ほかの5自治体は各1枚です",
+            variables["description"],
+        )
+
+    def test_social_ogp_keeps_legacy_schema_compatibility(self) -> None:
+        variables = OGP_MODULE._vars_pref_trivia({
+            "values": {
+                "prefecture": "北海道",
+                "pokemon": "ロコン",
+                "summary": "北海道の応援ポケモンはロコンです",
+            },
+        })
+        self.assertEqual("応援ポケモン", variables["titleLine2"])
+        self.assertEqual("ロコン", variables["mainNumber"])
+        self.assertEqual("", variables["mainUnit"])
 
 
 if __name__ == "__main__":

--- a/apps/scraper/test_generate_prefecture_trivia.py
+++ b/apps/scraper/test_generate_prefecture_trivia.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).with_name("generate_prefecture_trivia.py")
+SPEC = importlib.util.spec_from_file_location("generate_prefecture_trivia", MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+SPEC.loader.exec_module(MODULE)
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class GeneratePrefectureTriviaTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.records = MODULE.load_records(ROOT / "docs" / "pokefuta.ndjson")
+        cls.sources = MODULE.load_sources(
+            ROOT / "dataset" / "prefecture_trivia_sources.json"
+        )
+        cls.generated = {
+            entry["prefecture"]: entry
+            for entry in MODULE.generate(cls.records, cls.sources)
+        }
+
+    def test_single_municipality_prefectures(self) -> None:
+        actual = {
+            prefecture
+            for prefecture, entry in self.generated.items()
+            if entry["manhole_count"] > 1 and entry["municipality_count"] == 1
+        }
+        expected = {
+            "埼玉県", "千葉県", "栃木県", "神奈川県", "新潟県",
+            "富山県", "大阪府", "兵庫県", "奈良県", "岡山県",
+            "山口県", "徳島県", "愛媛県", "佐賀県", "鹿児島県",
+        }
+        self.assertEqual(expected, actual)
+
+    def test_non_single_municipality_regressions(self) -> None:
+        self.assertEqual(2, self.generated["福岡県"]["municipality_count"])
+        self.assertEqual(4, self.generated["東京都"]["municipality_count"])
+        self.assertEqual(5, self.generated["静岡県"]["municipality_count"])
+
+    def test_municipality_concentration(self) -> None:
+        expected = {
+            "東京都": "最多は町田の6枚で、次いで小笠原の4枚です",
+            "滋賀県": "最多は甲賀の3枚で、次いで大津の2枚です",
+            "京都府": "最多は京都の5枚で、次いで宇治の3枚です",
+            "愛知県": "豊橋市に4枚が集まり、ほかの5自治体は各1枚です",
+            "福岡県": "最多は北九州の5枚で、次いで太宰府の3枚です",
+        }
+        for prefecture, text in expected.items():
+            matching = [
+                trivia["text"]
+                for trivia in self.generated[prefecture]["trivia"]
+                if trivia["type"] == "municipality_concentration"
+            ]
+            self.assertEqual([text], matching)
+
+        for prefecture in ("宮城県", "岩手県", "鳥取県"):
+            self.assertFalse(any(
+                trivia["type"] == "municipality_concentration"
+                for trivia in self.generated[prefecture]["trivia"]
+            ))
+
+    def test_top_pokemon_requires_repeat_appearance(self) -> None:
+        for prefecture in ("埼玉県", "愛知県", "東京都", "京都府", "福岡県"):
+            self.assertFalse(any(
+                trivia["type"] == "top_pokemon"
+                for trivia in self.generated[prefecture]["trivia"]
+            ))
+
+        for prefecture in (
+            "神奈川県", "新潟県", "宮城県", "福島県",
+            "三重県", "福井県", "長崎県", "高知県",
+        ):
+            self.assertFalse(any(
+                trivia["type"] == "top_pokemon"
+                for trivia in self.generated[prefecture]["trivia"]
+            ))
+
+        self.assertTrue(any(
+            trivia["type"] == "top_pokemon"
+            and trivia["text"] == "最も多く登場するのはヤドンで、17枚に描かれています"
+            for trivia in self.generated["香川県"]["trivia"]
+        ))
+
+    def test_single_pokemon_full_coverage(self) -> None:
+        expected = {
+            "新潟県": ("コイキング", 4),
+            "神奈川県": ("ピカチュウ", 5),
+            "宮城県": ("ラプラス", 37),
+            "福島県": ("ラッキー", 43),
+            "三重県": ("ミジュマル", 31),
+            "福井県": ("カイリュー", 17),
+            "長崎県": ("デンリュウ", 10),
+            "高知県": ("ヌオー", 18),
+        }
+        for prefecture, (label, count) in expected.items():
+            coverage = {
+                item["label"]: item
+                for item in self.generated[prefecture]["pokemon_coverage"]
+            }
+            self.assertEqual(count, coverage[label]["cover_count"])
+            self.assertEqual(100, coverage[label]["coverage_percent"])
+
+    def test_group_full_coverage(self) -> None:
+        expected = {
+            "北海道": ("ロコン系", 50),
+            "鳥取県": ("サンド系", 20),
+            "宮崎県": ("ナッシー系", 26),
+            "佐賀県": ("ニャース3種", 3),
+        }
+        for prefecture, (label, count) in expected.items():
+            coverage = {
+                item["label"]: item
+                for item in self.generated[prefecture]["pokemon_coverage"]
+            }
+            self.assertEqual(count, coverage[label]["cover_count"])
+            self.assertEqual(100, coverage[label]["coverage_percent"])
+
+    def test_source_validation(self) -> None:
+        cases = []
+
+        missing_url = copy.deepcopy(self.sources)
+        missing_url["editorial_trivia"][0].pop("source_url")
+        cases.append(missing_url)
+
+        unknown_prefecture = copy.deepcopy(self.sources)
+        unknown_prefecture["editorial_trivia"][0]["prefecture"] = "架空県"
+        cases.append(unknown_prefecture)
+
+        unknown_pokemon = copy.deepcopy(self.sources)
+        unknown_pokemon["pokemon_groups"][0]["pokemon"] = ["架空ポケモン"]
+        cases.append(unknown_pokemon)
+
+        hard_coded_count = copy.deepcopy(self.sources)
+        hard_coded_count["editorial_trivia"][0]["count"] = 50
+        cases.append(hard_coded_count)
+
+        duplicate_id = copy.deepcopy(self.sources)
+        duplicate_id["editorial_trivia"][1]["id"] = duplicate_id["editorial_trivia"][0]["id"]
+        cases.append(duplicate_id)
+
+        for sources in cases:
+            with self.subTest(source=json.dumps(sources, ensure_ascii=False)[:80]):
+                with self.assertRaises(MODULE.ValidationError):
+                    MODULE.validate_sources(sources, self.records)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dataset/prefecture_trivia.json
+++ b/dataset/prefecture_trivia.json
@@ -1,160 +1,8875 @@
 [
   {
-    "id": "hokkaido-vulpix",
     "prefecture": "北海道",
-    "pokemon": "ロコン",
-    "alt_pokemon": "アローラロコン",
-    "count": 27,
-    "title": "北海道の応援ポケモンはロコン",
-    "summary": "雪国・北海道のイメージにぴったりのロコン。アローラロコンも設置されており、北の大地で2種類に出会えます。",
-    "status": "ongoing",
-    "source_url": "https://local.pokemon.jp/",
-    "map_pref": "北海道",
-    "manhole_ids": [],
-    "links": []
+    "manhole_count": 50,
+    "municipality_count": 50,
+    "municipalities": [
+      "えりも",
+      "三笠",
+      "上ノ国",
+      "上富良野",
+      "中標津",
+      "函館",
+      "別海",
+      "剣淵",
+      "北見",
+      "厚沢部",
+      "士別",
+      "大空",
+      "天塩",
+      "室蘭",
+      "小樽",
+      "帯広",
+      "幌延",
+      "当別",
+      "恵庭",
+      "斜里",
+      "新得",
+      "旭川",
+      "木古内",
+      "本別",
+      "札幌",
+      "東川",
+      "根室",
+      "森",
+      "歌志内",
+      "比布",
+      "洞爺湖",
+      "津別",
+      "湧別",
+      "猿払",
+      "由仁",
+      "登別",
+      "石狩",
+      "砂川",
+      "稚内",
+      "紋別",
+      "網走",
+      "美幌",
+      "美瑛",
+      "苫小牧",
+      "豊富",
+      "赤井川",
+      "足寄",
+      "遠軽",
+      "釧路",
+      "陸別"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "えりも",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "三笠",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "上ノ国",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "上富良野",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "中標津",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "函館",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "別海",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "剣淵",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "北見",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "厚沢部",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "士別",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "大空",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "天塩",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "室蘭",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "小樽",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "帯広",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "幌延",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "当別",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "恵庭",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "斜里",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "新得",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "旭川",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "木古内",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "本別",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "札幌",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "東川",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "根室",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "森",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "歌志内",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "比布",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "洞爺湖",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "津別",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "湧別",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "猿払",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "由仁",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "登別",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "石狩",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "砂川",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "稚内",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "紋別",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "網走",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "美幌",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "美瑛",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "苫小牧",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "豊富",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "赤井川",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "足寄",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "遠軽",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "釧路",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "陸別",
+        "manhole_count": 1
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "アローラロコン",
+        "label": "アローラロコン",
+        "pokemon": [
+          "アローラロコン"
+        ],
+        "cover_count": 37,
+        "coverage_percent": 74.0
+      },
+      {
+        "id": "ロコン",
+        "label": "ロコン",
+        "pokemon": [
+          "ロコン"
+        ],
+        "cover_count": 27,
+        "coverage_percent": 54.0
+      },
+      {
+        "id": "アグノム",
+        "label": "アグノム",
+        "pokemon": [
+          "アグノム"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "アブリー",
+        "label": "アブリー",
+        "pokemon": [
+          "アブリー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "アローラキュウコン",
+        "label": "アローラキュウコン",
+        "pokemon": [
+          "アローラキュウコン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "イルミーゼ",
+        "label": "イルミーゼ",
+        "pokemon": [
+          "イルミーゼ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "ウリムー",
+        "label": "ウリムー",
+        "pokemon": [
+          "ウリムー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "エイパム",
+        "label": "エイパム",
+        "pokemon": [
+          "エイパム"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "エネコロロ",
+        "label": "エネコロロ",
+        "pokemon": [
+          "エネコロロ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "エムリット",
+        "label": "エムリット",
+        "pokemon": [
+          "エムリット"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "オムナイト",
+        "label": "オムナイト",
+        "pokemon": [
+          "オムナイト"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "カチコール",
+        "label": "カチコール",
+        "pokemon": [
+          "カチコール"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "キテルグマ",
+        "label": "キテルグマ",
+        "pokemon": [
+          "キテルグマ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "キュウコン",
+        "label": "キュウコン",
+        "pokemon": [
+          "キュウコン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "クマシュン",
+        "label": "クマシュン",
+        "pokemon": [
+          "クマシュン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "ケッキング",
+        "label": "ケッキング",
+        "pokemon": [
+          "ケッキング"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "コオリッポ",
+        "label": "コオリッポ",
+        "pokemon": [
+          "コオリッポ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "ジュナイパー",
+        "label": "ジュナイパー",
+        "pokemon": [
+          "ジュナイパー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "ズガイドス",
+        "label": "ズガイドス",
+        "pokemon": [
+          "ズガイドス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "タマザラシ",
+        "label": "タマザラシ",
+        "pokemon": [
+          "タマザラシ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "ディアルガ",
+        "label": "ディアルガ",
+        "pokemon": [
+          "ディアルガ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "トゲキッス",
+        "label": "トゲキッス",
+        "pokemon": [
+          "トゲキッス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "トドグラー",
+        "label": "トドグラー",
+        "pokemon": [
+          "トドグラー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "ドロバンコ",
+        "label": "ドロバンコ",
+        "pokemon": [
+          "ドロバンコ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "ナエトル",
+        "label": "ナエトル",
+        "pokemon": [
+          "ナエトル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "ハネッコ",
+        "label": "ハネッコ",
+        "pokemon": [
+          "ハネッコ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "バチュル",
+        "label": "バチュル",
+        "pokemon": [
+          "バチュル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "バニプッチ",
+        "label": "バニプッチ",
+        "pokemon": [
+          "バニプッチ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "バリコオル",
+        "label": "バリコオル",
+        "pokemon": [
+          "バリコオル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "パルキア",
+        "label": "パルキア",
+        "pokemon": [
+          "パルキア"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "ヒコザル",
+        "label": "ヒコザル",
+        "pokemon": [
+          "ヒコザル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "ヒスイウォーグル",
+        "label": "ヒスイウォーグル",
+        "pokemon": [
+          "ヒスイウォーグル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "ヒトツキ",
+        "label": "ヒトツキ",
+        "pokemon": [
+          "ヒトツキ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "ヒメグマ",
+        "label": "ヒメグマ",
+        "pokemon": [
+          "ヒメグマ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "ヒメンカ",
+        "label": "ヒメンカ",
+        "pokemon": [
+          "ヒメンカ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "フラベベ",
+        "label": "フラベベ",
+        "pokemon": [
+          "フラベベ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "ペロリーム",
+        "label": "ペロリーム",
+        "pokemon": [
+          "ペロリーム"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "ポッチャマ",
+        "label": "ポッチャマ",
+        "pokemon": [
+          "ポッチャマ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "ポットデス",
+        "label": "ポットデス",
+        "pokemon": [
+          "ポットデス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "マニューラ",
+        "label": "マニューラ",
+        "pokemon": [
+          "マニューラ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "マーイーカ",
+        "label": "マーイーカ",
+        "pokemon": [
+          "マーイーカ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "ミノマダム",
+        "label": "ミノマダム",
+        "pokemon": [
+          "ミノマダム"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "ミブリム",
+        "label": "ミブリム",
+        "pokemon": [
+          "ミブリム"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "ミルタンク",
+        "label": "ミルタンク",
+        "pokemon": [
+          "ミルタンク"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "ムクホーク",
+        "label": "ムクホーク",
+        "pokemon": [
+          "ムクホーク"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "メタモン",
+        "label": "メタモン",
+        "pokemon": [
+          "メタモン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "メブキジカ",
+        "label": "メブキジカ",
+        "pokemon": [
+          "メブキジカ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "メリープ",
+        "label": "メリープ",
+        "pokemon": [
+          "メリープ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "ヤクデ",
+        "label": "ヤクデ",
+        "pokemon": [
+          "ヤクデ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "ヤバチャ",
+        "label": "ヤバチャ",
+        "pokemon": [
+          "ヤバチャ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "ユキメノコ",
+        "label": "ユキメノコ",
+        "pokemon": [
+          "ユキメノコ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "ユクシー",
+        "label": "ユクシー",
+        "pokemon": [
+          "ユクシー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "ルガルガン",
+        "label": "ルガルガン",
+        "pokemon": [
+          "ルガルガン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "ワカシャモ",
+        "label": "ワカシャモ",
+        "pokemon": [
+          "ワカシャモ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.0
+      },
+      {
+        "id": "vulpix-family",
+        "label": "ロコン系",
+        "pokemon": [
+          "ロコン",
+          "アローラロコン"
+        ],
+        "cover_count": 50,
+        "coverage_percent": 100.0
+      }
+    ],
+    "trivia": [
+      {
+        "id": "hokkaido-support-vulpix",
+        "type": "support_pokemon",
+        "text": "北海道の推しポケモンは、雪景色にもなじむアローラロコンとロコンです",
+        "source_type": "official",
+        "source_url": "https://local.pokemon.jp/municipality/hokkaido/",
+        "source_label": "ポケモンローカルActs",
+        "verified_at": "2026-06-13"
+      },
+      {
+        "id": "北海道-vulpix-family-100",
+        "type": "pokemon_group_100",
+        "text": "県内50枚すべてにロコン系が登場します",
+        "source_type": "dataset"
+      }
+    ]
   },
   {
-    "id": "iwate-geodude",
+    "prefecture": "青森県",
+    "manhole_count": 2,
+    "municipality_count": 2,
+    "municipalities": [
+      "八戸",
+      "階上"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "八戸",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "階上",
+        "manhole_count": 1
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "イシツブテ",
+        "label": "イシツブテ",
+        "pokemon": [
+          "イシツブテ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 50.0
+      },
+      {
+        "id": "キャモメ",
+        "label": "キャモメ",
+        "pokemon": [
+          "キャモメ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 50.0
+      },
+      {
+        "id": "ナマコブシ",
+        "label": "ナマコブシ",
+        "pokemon": [
+          "ナマコブシ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 50.0
+      },
+      {
+        "id": "バチンウニ",
+        "label": "バチンウニ",
+        "pokemon": [
+          "バチンウニ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 50.0
+      },
+      {
+        "id": "ユキハミ",
+        "label": "ユキハミ",
+        "pokemon": [
+          "ユキハミ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 50.0
+      }
+    ],
+    "trivia": []
+  },
+  {
     "prefecture": "岩手県",
-    "pokemon": "イシツブテ",
-    "count": 20,
-    "title": "岩手県の応援ポケモンはイシツブテ",
-    "summary": "「岩手」という地名とイシツブテの語呂合わせが縁。県内各地に設置されています。",
-    "status": "ongoing",
-    "source_url": "https://local.pokemon.jp/",
-    "map_pref": "岩手県",
-    "manhole_ids": [],
-    "links": []
+    "manhole_count": 36,
+    "municipality_count": 33,
+    "municipalities": [
+      "一戸",
+      "一関",
+      "久慈",
+      "九戸",
+      "二戸",
+      "住田",
+      "八幡平",
+      "北上",
+      "大槌",
+      "大船渡",
+      "奥州",
+      "宮古",
+      "山田",
+      "岩手",
+      "岩泉",
+      "平泉",
+      "普代",
+      "洋野",
+      "滝沢",
+      "田野畑",
+      "盛岡",
+      "矢巾",
+      "紫波",
+      "花巻",
+      "葛巻",
+      "西和賀",
+      "軽米",
+      "遠野",
+      "野田",
+      "金ヶ崎",
+      "釜石",
+      "陸前高田",
+      "雫石"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "久慈",
+        "manhole_count": 2
+      },
+      {
+        "municipality": "北上",
+        "manhole_count": 2
+      },
+      {
+        "municipality": "盛岡",
+        "manhole_count": 2
+      },
+      {
+        "municipality": "一戸",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "一関",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "九戸",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "二戸",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "住田",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "八幡平",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "大槌",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "大船渡",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "奥州",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "宮古",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "山田",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "岩手",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "岩泉",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "平泉",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "普代",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "洋野",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "滝沢",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "田野畑",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "矢巾",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "紫波",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "花巻",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "葛巻",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "西和賀",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "軽米",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "遠野",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "野田",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "金ヶ崎",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "釜石",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "陸前高田",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "雫石",
+        "manhole_count": 1
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "イシツブテ",
+        "label": "イシツブテ",
+        "pokemon": [
+          "イシツブテ"
+        ],
+        "cover_count": 20,
+        "coverage_percent": 55.6
+      },
+      {
+        "id": "アローライシツブテ",
+        "label": "アローライシツブテ",
+        "pokemon": [
+          "アローライシツブテ"
+        ],
+        "cover_count": 4,
+        "coverage_percent": 11.1
+      },
+      {
+        "id": "イワンコ",
+        "label": "イワンコ",
+        "pokemon": [
+          "イワンコ"
+        ],
+        "cover_count": 4,
+        "coverage_percent": 11.1
+      },
+      {
+        "id": "プテラ",
+        "label": "プテラ",
+        "pokemon": [
+          "プテラ"
+        ],
+        "cover_count": 2,
+        "coverage_percent": 5.6
+      },
+      {
+        "id": "アママイコ",
+        "label": "アママイコ",
+        "pokemon": [
+          "アママイコ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "アマルス",
+        "label": "アマルス",
+        "pokemon": [
+          "アマルス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "イワーク",
+        "label": "イワーク",
+        "pokemon": [
+          "イワーク"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "ウソッキー",
+        "label": "ウソッキー",
+        "pokemon": [
+          "ウソッキー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "ウールー",
+        "label": "ウールー",
+        "pokemon": [
+          "ウールー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "オムナイト",
+        "label": "オムナイト",
+        "pokemon": [
+          "オムナイト"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "オーガポン",
+        "label": "オーガポン",
+        "pokemon": [
+          "オーガポン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "カジッチュ",
+        "label": "カジッチュ",
+        "pokemon": [
+          "カジッチュ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "カブト",
+        "label": "カブト",
+        "pokemon": [
+          "カブト"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "カミッチュ",
+        "label": "カミッチュ",
+        "pokemon": [
+          "カミッチュ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "ガブリアス",
+        "label": "ガブリアス",
+        "pokemon": [
+          "ガブリアス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "キマワリ",
+        "label": "キマワリ",
+        "pokemon": [
+          "キマワリ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "キリキザン",
+        "label": "キリキザン",
+        "pokemon": [
+          "キリキザン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "クレセリア",
+        "label": "クレセリア",
+        "pokemon": [
+          "クレセリア"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "ココドラ",
+        "label": "ココドラ",
+        "pokemon": [
+          "ココドラ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "コスモッグ",
+        "label": "コスモッグ",
+        "pokemon": [
+          "コスモッグ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "ゴローニャ",
+        "label": "ゴローニャ",
+        "pokemon": [
+          "ゴローニャ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "サイホーン",
+        "label": "サイホーン",
+        "pokemon": [
+          "サイホーン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "タテトプス",
+        "label": "タテトプス",
+        "pokemon": [
+          "タテトプス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "ダンゴロ",
+        "label": "ダンゴロ",
+        "pokemon": [
+          "ダンゴロ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "チゴラス",
+        "label": "チゴラス",
+        "pokemon": [
+          "チゴラス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "ツボツボ",
+        "label": "ツボツボ",
+        "pokemon": [
+          "ツボツボ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "ドサイドン",
+        "label": "ドサイドン",
+        "pokemon": [
+          "ドサイドン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "ドロバンコ",
+        "label": "ドロバンコ",
+        "pokemon": [
+          "ドロバンコ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "ナゲツケサル",
+        "label": "ナゲツケサル",
+        "pokemon": [
+          "ナゲツケサル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "ノズパス",
+        "label": "ノズパス",
+        "pokemon": [
+          "ノズパス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "ハスブレロ",
+        "label": "ハスブレロ",
+        "pokemon": [
+          "ハスブレロ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "ヒスイガーディ",
+        "label": "ヒスイガーディ",
+        "pokemon": [
+          "ヒスイガーディ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "ビーダル",
+        "label": "ビーダル",
+        "pokemon": [
+          "ビーダル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "フクスロー",
+        "label": "フクスロー",
+        "pokemon": [
+          "フクスロー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "ブロロン",
+        "label": "ブロロン",
+        "pokemon": [
+          "ブロロン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "ホーホー",
+        "label": "ホーホー",
+        "pokemon": [
+          "ホーホー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "マホミル",
+        "label": "マホミル",
+        "pokemon": [
+          "マホミル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "ミノムッチ",
+        "label": "ミノムッチ",
+        "pokemon": [
+          "ミノムッチ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "ミルタンク",
+        "label": "ミルタンク",
+        "pokemon": [
+          "ミルタンク"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "メタモン",
+        "label": "メタモン",
+        "pokemon": [
+          "メタモン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "メブキジカ",
+        "label": "メブキジカ",
+        "pokemon": [
+          "メブキジカ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "メルタン",
+        "label": "メルタン",
+        "pokemon": [
+          "メルタン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "ヤジロン",
+        "label": "ヤジロン",
+        "pokemon": [
+          "ヤジロン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "ユキワラシ",
+        "label": "ユキワラシ",
+        "pokemon": [
+          "ユキワラシ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "ヨーギラス",
+        "label": "ヨーギラス",
+        "pokemon": [
+          "ヨーギラス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "ルガルガン",
+        "label": "ルガルガン",
+        "pokemon": [
+          "ルガルガン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "ルチャブル",
+        "label": "ルチャブル",
+        "pokemon": [
+          "ルチャブル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "ルナトーン",
+        "label": "ルナトーン",
+        "pokemon": [
+          "ルナトーン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "ルンパッパ",
+        "label": "ルンパッパ",
+        "pokemon": [
+          "ルンパッパ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      },
+      {
+        "id": "レックウザ",
+        "label": "レックウザ",
+        "pokemon": [
+          "レックウザ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.8
+      }
+    ],
+    "trivia": [
+      {
+        "id": "iwate-geodude-wordplay",
+        "type": "wordplay",
+        "text": "岩タイプで「岩」に「手」が付いたイシツブテが、いわて応援ポケモンを務めています",
+        "source_type": "official",
+        "source_url": "https://local.pokemon.jp/municipality/iwate/",
+        "source_label": "ポケモンローカルActs",
+        "verified_at": "2026-06-13"
+      },
+      {
+        "id": "岩手県-top-pokemon",
+        "type": "top_pokemon",
+        "text": "最も多く登場するのはイシツブテで、20枚に描かれています",
+        "source_type": "dataset"
+      }
+    ]
   },
   {
-    "id": "miyagi-lapras",
     "prefecture": "宮城県",
-    "pokemon": "ラプラス",
-    "count": 37,
-    "title": "宮城県の応援ポケモンはラプラス",
-    "summary": "松島の海をイメージしたラプラス。宮城の豊かな海辺の風景と重なります。",
-    "status": "ongoing",
-    "source_url": "https://local.pokemon.jp/",
-    "map_pref": "宮城県",
-    "manhole_ids": [],
-    "links": []
+    "manhole_count": 37,
+    "municipality_count": 36,
+    "municipalities": [
+      "七ヶ宿",
+      "七ヶ浜",
+      "丸森",
+      "亘理",
+      "仙台",
+      "利府",
+      "加瀬沼公園",
+      "加美",
+      "南三陸",
+      "名取",
+      "塩竈",
+      "多賀城",
+      "大和",
+      "大崎",
+      "大河原",
+      "大衡",
+      "大郷",
+      "女川",
+      "富谷",
+      "山元",
+      "岩沼",
+      "川崎",
+      "村田",
+      "東松島",
+      "松島",
+      "柴田",
+      "栗原",
+      "気仙沼",
+      "涌谷",
+      "登米",
+      "白石",
+      "石巻",
+      "美里",
+      "色麻",
+      "蔵王",
+      "角田"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "仙台",
+        "manhole_count": 2
+      },
+      {
+        "municipality": "七ヶ宿",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "七ヶ浜",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "丸森",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "亘理",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "利府",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "加瀬沼公園",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "加美",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "南三陸",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "名取",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "塩竈",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "多賀城",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "大和",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "大崎",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "大河原",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "大衡",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "大郷",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "女川",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "富谷",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "山元",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "岩沼",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "川崎",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "村田",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "東松島",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "松島",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "柴田",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "栗原",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "気仙沼",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "涌谷",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "登米",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "白石",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "石巻",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "美里",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "色麻",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "蔵王",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "角田",
+        "manhole_count": 1
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "ラプラス",
+        "label": "ラプラス",
+        "pokemon": [
+          "ラプラス"
+        ],
+        "cover_count": 37,
+        "coverage_percent": 100.0
+      },
+      {
+        "id": "ニャース",
+        "label": "ニャース",
+        "pokemon": [
+          "ニャース"
+        ],
+        "cover_count": 2,
+        "coverage_percent": 5.4
+      },
+      {
+        "id": "イシツブテ",
+        "label": "イシツブテ",
+        "pokemon": [
+          "イシツブテ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "ウミディグダ",
+        "label": "ウミディグダ",
+        "pokemon": [
+          "ウミディグダ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "エネコ",
+        "label": "エネコ",
+        "pokemon": [
+          "エネコ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "オクタン",
+        "label": "オクタン",
+        "pokemon": [
+          "オクタン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "オニスズメ",
+        "label": "オニスズメ",
+        "pokemon": [
+          "オニスズメ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "キャモメ",
+        "label": "キャモメ",
+        "pokemon": [
+          "キャモメ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "クスネ",
+        "label": "クスネ",
+        "pokemon": [
+          "クスネ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "コアルヒー",
+        "label": "コアルヒー",
+        "pokemon": [
+          "コアルヒー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "ジラーチ",
+        "label": "ジラーチ",
+        "pokemon": [
+          "ジラーチ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "スバメ",
+        "label": "スバメ",
+        "pokemon": [
+          "スバメ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "スワンナ",
+        "label": "スワンナ",
+        "pokemon": [
+          "スワンナ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "タッツー",
+        "label": "タッツー",
+        "pokemon": [
+          "タッツー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "タマゲタケ",
+        "label": "タマゲタケ",
+        "pokemon": [
+          "タマゲタケ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "タマンタ",
+        "label": "タマンタ",
+        "pokemon": [
+          "タマンタ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "ダグトリオ",
+        "label": "ダグトリオ",
+        "pokemon": [
+          "ダグトリオ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "チェリム",
+        "label": "チェリム",
+        "pokemon": [
+          "チェリム"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "チュリネ",
+        "label": "チュリネ",
+        "pokemon": [
+          "チュリネ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "チョンチー",
+        "label": "チョンチー",
+        "pokemon": [
+          "チョンチー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "チルット",
+        "label": "チルット",
+        "pokemon": [
+          "チルット"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "トゲピー",
+        "label": "トゲピー",
+        "pokemon": [
+          "トゲピー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "ドダイトス",
+        "label": "ドダイトス",
+        "pokemon": [
+          "ドダイトス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "ドードリオ",
+        "label": "ドードリオ",
+        "pokemon": [
+          "ドードリオ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "ドードー",
+        "label": "ドードー",
+        "pokemon": [
+          "ドードー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "ニャスパー",
+        "label": "ニャスパー",
+        "pokemon": [
+          "ニャスパー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "ニャビー",
+        "label": "ニャビー",
+        "pokemon": [
+          "ニャビー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "ニャルマー",
+        "label": "ニャルマー",
+        "pokemon": [
+          "ニャルマー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "ハスブレロ",
+        "label": "ハスブレロ",
+        "pokemon": [
+          "ハスブレロ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "ハスボー",
+        "label": "ハスボー",
+        "pokemon": [
+          "ハスボー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "バンバドロ",
+        "label": "バンバドロ",
+        "pokemon": [
+          "バンバドロ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "ヒトデマン",
+        "label": "ヒトデマン",
+        "pokemon": [
+          "ヒトデマン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "ビーダル",
+        "label": "ビーダル",
+        "pokemon": [
+          "ビーダル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "フラベベ",
+        "label": "フラベベ",
+        "pokemon": [
+          "フラベベ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "ブルー",
+        "label": "ブルー",
+        "pokemon": [
+          "ブルー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "プラスル",
+        "label": "プラスル",
+        "pokemon": [
+          "プラスル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "プルリル",
+        "label": "プルリル",
+        "pokemon": [
+          "プルリル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "ベロベルト",
+        "label": "ベロベルト",
+        "pokemon": [
+          "ベロベルト"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "ホエルコ",
+        "label": "ホエルコ",
+        "pokemon": [
+          "ホエルコ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "マイナン",
+        "label": "マイナン",
+        "pokemon": [
+          "マイナン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "マメパト",
+        "label": "マメパト",
+        "pokemon": [
+          "マメパト"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "ムックル",
+        "label": "ムックル",
+        "pokemon": [
+          "ムックル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "メタモン",
+        "label": "メタモン",
+        "pokemon": [
+          "メタモン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "ユキノオー",
+        "label": "ユキノオー",
+        "pokemon": [
+          "ユキノオー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "ラッキー",
+        "label": "ラッキー",
+        "pokemon": [
+          "ラッキー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "ラティアス",
+        "label": "ラティアス",
+        "pokemon": [
+          "ラティアス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "ラティオス",
+        "label": "ラティオス",
+        "pokemon": [
+          "ラティオス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "ラブカス",
+        "label": "ラブカス",
+        "pokemon": [
+          "ラブカス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      },
+      {
+        "id": "ロゼリア",
+        "label": "ロゼリア",
+        "pokemon": [
+          "ロゼリア"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.7
+      }
+    ],
+    "trivia": [
+      {
+        "id": "miyagi-support-lapras",
+        "type": "support_pokemon",
+        "text": "宮城県ではラプラスがみやぎ応援ポケモンとして地域の魅力を発信しています",
+        "source_type": "official",
+        "source_url": "https://local.pokemon.jp/municipality/miyagi/",
+        "source_label": "ポケモンローカルActs",
+        "verified_at": "2026-06-13"
+      },
+      {
+        "id": "宮城県-ラプラス-100",
+        "type": "pokemon_100",
+        "text": "県内37枚すべてにラプラスが登場します",
+        "source_type": "dataset"
+      }
+    ]
   },
   {
-    "id": "fukushima-chansey",
+    "prefecture": "秋田県",
+    "manhole_count": 5,
+    "municipality_count": 5,
+    "municipalities": [
+      "仙北",
+      "横手",
+      "男鹿",
+      "秋田",
+      "鹿角"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "仙北",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "横手",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "男鹿",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "秋田",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "鹿角",
+        "manhole_count": 1
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "イワンコ",
+        "label": "イワンコ",
+        "pokemon": [
+          "イワンコ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "オニゴーリ",
+        "label": "オニゴーリ",
+        "pokemon": [
+          "オニゴーリ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "カラカラ",
+        "label": "カラカラ",
+        "pokemon": [
+          "カラカラ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ガラルデスマス",
+        "label": "ガラルデスマス",
+        "pokemon": [
+          "ガラルデスマス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ガーディ",
+        "label": "ガーディ",
+        "pokemon": [
+          "ガーディ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "グランブル",
+        "label": "グランブル",
+        "pokemon": [
+          "グランブル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ハクリュー",
+        "label": "ハクリュー",
+        "pokemon": [
+          "ハクリュー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "バウッツェル",
+        "label": "バウッツェル",
+        "pokemon": [
+          "バウッツェル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "パピモッチ",
+        "label": "パピモッチ",
+        "pokemon": [
+          "パピモッチ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ヘルガー",
+        "label": "ヘルガー",
+        "pokemon": [
+          "ヘルガー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ユキワラシ",
+        "label": "ユキワラシ",
+        "pokemon": [
+          "ユキワラシ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ワシボン",
+        "label": "ワシボン",
+        "pokemon": [
+          "ワシボン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      }
+    ],
+    "trivia": []
+  },
+  {
+    "prefecture": "山形県",
+    "manhole_count": 5,
+    "municipality_count": 5,
+    "municipalities": [
+      "大蔵",
+      "寒河江",
+      "小国",
+      "山形",
+      "鶴岡"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "大蔵",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "寒河江",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "小国",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "山形",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "鶴岡",
+        "manhole_count": 1
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "アルクジラ",
+        "label": "アルクジラ",
+        "pokemon": [
+          "アルクジラ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ガラルヒヒダルマ",
+        "label": "ガラルヒヒダルマ",
+        "pokemon": [
+          "ガラルヒヒダルマ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "クマシュン",
+        "label": "クマシュン",
+        "pokemon": [
+          "クマシュン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "チェリム",
+        "label": "チェリム",
+        "pokemon": [
+          "チェリム"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "チェリンボ",
+        "label": "チェリンボ",
+        "pokemon": [
+          "チェリンボ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ツンベアー",
+        "label": "ツンベアー",
+        "pokemon": [
+          "ツンベアー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "テールナー",
+        "label": "テールナー",
+        "pokemon": [
+          "テールナー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ドククラゲ",
+        "label": "ドククラゲ",
+        "pokemon": [
+          "ドククラゲ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ドレディア",
+        "label": "ドレディア",
+        "pokemon": [
+          "ドレディア"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ブルンゲル",
+        "label": "ブルンゲル",
+        "pokemon": [
+          "ブルンゲル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "プルリル",
+        "label": "プルリル",
+        "pokemon": [
+          "プルリル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ポポッコ",
+        "label": "ポポッコ",
+        "pokemon": [
+          "ポポッコ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "メノクラゲ",
+        "label": "メノクラゲ",
+        "pokemon": [
+          "メノクラゲ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ラフレシア",
+        "label": "ラフレシア",
+        "pokemon": [
+          "ラフレシア"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ランプラー",
+        "label": "ランプラー",
+        "pokemon": [
+          "ランプラー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      }
+    ],
+    "trivia": []
+  },
+  {
     "prefecture": "福島県",
-    "pokemon": "ラッキー",
-    "count": 43,
-    "title": "福島県の応援ポケモンはラッキー",
-    "summary": "「福」の字が縁で選ばれたラッキー。幸運を運ぶイメージが福島県とぴったりで、県内に多く設置されています。",
-    "status": "ongoing",
-    "source_url": "https://local.pokemon.jp/",
-    "map_pref": "福島県",
-    "manhole_ids": [],
-    "links": []
+    "manhole_count": 43,
+    "municipality_count": 43,
+    "municipalities": [
+      "いわき",
+      "三春",
+      "下郷",
+      "二本松",
+      "伊達",
+      "会津坂下",
+      "会津美里",
+      "会津若松",
+      "北塩原",
+      "南会津",
+      "南相馬",
+      "双葉",
+      "古殿",
+      "国見",
+      "大熊",
+      "天栄",
+      "小野",
+      "川俣",
+      "川内",
+      "平田",
+      "広野",
+      "新地",
+      "昭和",
+      "柳津",
+      "棚倉",
+      "楢葉",
+      "泉崎",
+      "浅川",
+      "浪江",
+      "湯川",
+      "猪苗代",
+      "田",
+      "白河",
+      "相馬",
+      "矢吹",
+      "福島",
+      "西会津",
+      "西郷",
+      "郡山",
+      "鏡石",
+      "須賀川",
+      "飯舘",
+      "鮫川"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "いわき",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "三春",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "下郷",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "二本松",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "伊達",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "会津坂下",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "会津美里",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "会津若松",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "北塩原",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "南会津",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "南相馬",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "双葉",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "古殿",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "国見",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "大熊",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "天栄",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "小野",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "川俣",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "川内",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "平田",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "広野",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "新地",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "昭和",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "柳津",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "棚倉",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "楢葉",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "泉崎",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "浅川",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "浪江",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "湯川",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "猪苗代",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "田",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "白河",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "相馬",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "矢吹",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "福島",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "西会津",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "西郷",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "郡山",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "鏡石",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "須賀川",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "飯舘",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "鮫川",
+        "manhole_count": 1
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "ラッキー",
+        "label": "ラッキー",
+        "pokemon": [
+          "ラッキー"
+        ],
+        "cover_count": 43,
+        "coverage_percent": 100.0
+      },
+      {
+        "id": "ピンプク",
+        "label": "ピンプク",
+        "pokemon": [
+          "ピンプク"
+        ],
+        "cover_count": 3,
+        "coverage_percent": 7.0
+      },
+      {
+        "id": "アオガラス",
+        "label": "アオガラス",
+        "pokemon": [
+          "アオガラス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "アブリー",
+        "label": "アブリー",
+        "pokemon": [
+          "アブリー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "イエッサン",
+        "label": "イエッサン",
+        "pokemon": [
+          "イエッサン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "ウパー",
+        "label": "ウパー",
+        "pokemon": [
+          "ウパー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "エルレイド",
+        "label": "エルレイド",
+        "pokemon": [
+          "エルレイド"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "オドシシ",
+        "label": "オドシシ",
+        "pokemon": [
+          "オドシシ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "カイリキー",
+        "label": "カイリキー",
+        "pokemon": [
+          "カイリキー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "カジリガメ",
+        "label": "カジリガメ",
+        "pokemon": [
+          "カジリガメ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "カプサイジ",
+        "label": "カプサイジ",
+        "pokemon": [
+          "カプサイジ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "カモネギ",
+        "label": "カモネギ",
+        "pokemon": [
+          "カモネギ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "カラサリス",
+        "label": "カラサリス",
+        "pokemon": [
+          "カラサリス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "キテルグマ",
+        "label": "キテルグマ",
+        "pokemon": [
+          "キテルグマ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "キレイハナ",
+        "label": "キレイハナ",
+        "pokemon": [
+          "キレイハナ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "ギャロップ",
+        "label": "ギャロップ",
+        "pokemon": [
+          "ギャロップ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "クルマユ",
+        "label": "クルマユ",
+        "pokemon": [
+          "クルマユ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "クルミル",
+        "label": "クルミル",
+        "pokemon": [
+          "クルミル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "ゴチミル",
+        "label": "ゴチミル",
+        "pokemon": [
+          "ゴチミル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "ゴリランダー",
+        "label": "ゴリランダー",
+        "pokemon": [
+          "ゴリランダー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "サシカマス",
+        "label": "サシカマス",
+        "pokemon": [
+          "サシカマス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "サメハダー",
+        "label": "サメハダー",
+        "pokemon": [
+          "サメハダー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "スコヴィラン",
+        "label": "スコヴィラン",
+        "pokemon": [
+          "スコヴィラン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "スワンナ",
+        "label": "スワンナ",
+        "pokemon": [
+          "スワンナ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "タブンネ",
+        "label": "タブンネ",
+        "pokemon": [
+          "タブンネ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "ダルマッカ",
+        "label": "ダルマッカ",
+        "pokemon": [
+          "ダルマッカ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "チリーン",
+        "label": "チリーン",
+        "pokemon": [
+          "チリーン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "ドッコラー",
+        "label": "ドッコラー",
+        "pokemon": [
+          "ドッコラー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "ドレディア",
+        "label": "ドレディア",
+        "pokemon": [
+          "ドレディア"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "ニョロトノ",
+        "label": "ニョロトノ",
+        "pokemon": [
+          "ニョロトノ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "ヌイコグマ",
+        "label": "ヌイコグマ",
+        "pokemon": [
+          "ヌイコグマ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "ハピナス",
+        "label": "ハピナス",
+        "pokemon": [
+          "ハピナス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "ハヤシガメ",
+        "label": "ハヤシガメ",
+        "pokemon": [
+          "ハヤシガメ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "ハリマロン",
+        "label": "ハリマロン",
+        "pokemon": [
+          "ハリマロン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "バオップ",
+        "label": "バオップ",
+        "pokemon": [
+          "バオップ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "バニリッチ",
+        "label": "バニリッチ",
+        "pokemon": [
+          "バニリッチ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "ヒマナッツ",
+        "label": "ヒマナッツ",
+        "pokemon": [
+          "ヒマナッツ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "ヒメグマ",
+        "label": "ヒメグマ",
+        "pokemon": [
+          "ヒメグマ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "ピクシー",
+        "label": "ピクシー",
+        "pokemon": [
+          "ピクシー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "ファイアロー",
+        "label": "ファイアロー",
+        "pokemon": [
+          "ファイアロー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "フカマル",
+        "label": "フカマル",
+        "pokemon": [
+          "フカマル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "フラエッテ",
+        "label": "フラエッテ",
+        "pokemon": [
+          "フラエッテ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "ブリムオン",
+        "label": "ブリムオン",
+        "pokemon": [
+          "ブリムオン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "プリン",
+        "label": "プリン",
+        "pokemon": [
+          "プリン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "ヘラクロス",
+        "label": "ヘラクロス",
+        "pokemon": [
+          "ヘラクロス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "ペロッパフ",
+        "label": "ペロッパフ",
+        "pokemon": [
+          "ペロッパフ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "ポニータ",
+        "label": "ポニータ",
+        "pokemon": [
+          "ポニータ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "マシェード",
+        "label": "マシェード",
+        "pokemon": [
+          "マシェード"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "マフォクシー",
+        "label": "マフォクシー",
+        "pokemon": [
+          "マフォクシー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "マユルド",
+        "label": "マユルド",
+        "pokemon": [
+          "マユルド"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "ミルタンク",
+        "label": "ミルタンク",
+        "pokemon": [
+          "ミルタンク"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "メリープ",
+        "label": "メリープ",
+        "pokemon": [
+          "メリープ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "モルペコ",
+        "label": "モルペコ",
+        "pokemon": [
+          "モルペコ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "ヤジロン",
+        "label": "ヤジロン",
+        "pokemon": [
+          "ヤジロン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "ヤンヤンマ",
+        "label": "ヤンヤンマ",
+        "pokemon": [
+          "ヤンヤンマ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "ヨワシ",
+        "label": "ヨワシ",
+        "pokemon": [
+          "ヨワシ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "ラビフット",
+        "label": "ラビフット",
+        "pokemon": [
+          "ラビフット"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "ラルトス",
+        "label": "ラルトス",
+        "pokemon": [
+          "ラルトス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      },
+      {
+        "id": "ロズレイド",
+        "label": "ロズレイド",
+        "pokemon": [
+          "ロズレイド"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 2.3
+      }
+    ],
+    "trivia": [
+      {
+        "id": "fukushima-support-chansey",
+        "type": "support_pokemon",
+        "text": "福島県では、幸せを運ぶといわれるラッキーがふくしま応援ポケモンを務めています",
+        "source_type": "official",
+        "source_url": "https://local.pokemon.jp/municipality/fukushima/",
+        "source_label": "ポケモンローカルActs",
+        "verified_at": "2026-06-13"
+      },
+      {
+        "id": "福島県-ラッキー-100",
+        "type": "pokemon_100",
+        "text": "県内43枚すべてにラッキーが登場します",
+        "source_type": "dataset"
+      }
+    ]
   },
   {
-    "id": "tottori-sandshrew",
-    "prefecture": "鳥取県",
-    "pokemon": "サンド",
-    "alt_pokemon": "アローラのすがた",
-    "count": 17,
-    "title": "鳥取県の応援ポケモンはサンド",
-    "summary": "「砂丘のまち」鳥取ならではの選択。通常のすがたとアローラのすがたの2種が設置されており、鳥取砂丘との縁は一目瞭然です。",
-    "status": "ongoing",
-    "source_url": "https://local.pokemon.jp/",
-    "map_pref": "鳥取県",
-    "manhole_ids": [],
-    "links": []
+    "prefecture": "茨城県",
+    "manhole_count": 5,
+    "municipality_count": 5,
+    "municipalities": [
+      "つくば",
+      "常陸太田",
+      "水戸",
+      "神栖",
+      "筑西"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "つくば",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "常陸太田",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "水戸",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "神栖",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "筑西",
+        "manhole_count": 1
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "オトシドリ",
+        "label": "オトシドリ",
+        "pokemon": [
+          "オトシドリ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "グレッグル",
+        "label": "グレッグル",
+        "pokemon": [
+          "グレッグル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ジャローダ",
+        "label": "ジャローダ",
+        "pokemon": [
+          "ジャローダ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ナットレイ",
+        "label": "ナットレイ",
+        "pokemon": [
+          "ナットレイ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ハラバリー",
+        "label": "ハラバリー",
+        "pokemon": [
+          "ハラバリー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ハーデリア",
+        "label": "ハーデリア",
+        "pokemon": [
+          "ハーデリア"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ボーマンダ",
+        "label": "ボーマンダ",
+        "pokemon": [
+          "ボーマンダ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "マラカッチ",
+        "label": "マラカッチ",
+        "pokemon": [
+          "マラカッチ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ルチャブル",
+        "label": "ルチャブル",
+        "pokemon": [
+          "ルチャブル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "レックウザ",
+        "label": "レックウザ",
+        "pokemon": [
+          "レックウザ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      }
+    ],
+    "trivia": []
   },
   {
-    "id": "fukui-dragonite",
+    "prefecture": "栃木県",
+    "manhole_count": 3,
+    "municipality_count": 1,
+    "municipalities": [
+      "宇都宮"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "宇都宮",
+        "manhole_count": 3
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "イワパレス",
+        "label": "イワパレス",
+        "pokemon": [
+          "イワパレス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 33.3
+      },
+      {
+        "id": "エレブー",
+        "label": "エレブー",
+        "pokemon": [
+          "エレブー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 33.3
+      },
+      {
+        "id": "ホシガリス",
+        "label": "ホシガリス",
+        "pokemon": [
+          "ホシガリス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 33.3
+      },
+      {
+        "id": "ボルトロス",
+        "label": "ボルトロス",
+        "pokemon": [
+          "ボルトロス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 33.3
+      },
+      {
+        "id": "ラクライ",
+        "label": "ラクライ",
+        "pokemon": [
+          "ラクライ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 33.3
+      }
+    ],
+    "trivia": [
+      {
+        "id": "栃木県-single-municipality",
+        "type": "single_municipality",
+        "text": "県内3枚のポケふたはすべて宇都宮にあります",
+        "source_type": "dataset"
+      }
+    ]
+  },
+  {
+    "prefecture": "群馬県",
+    "manhole_count": 0,
+    "municipality_count": 0,
+    "municipalities": [],
+    "municipality_distribution": [],
+    "pokemon_coverage": [],
+    "trivia": []
+  },
+  {
+    "prefecture": "埼玉県",
+    "manhole_count": 3,
+    "municipality_count": 1,
+    "municipalities": [
+      "所沢"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "所沢",
+        "manhole_count": 3
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "アーマーガア",
+        "label": "アーマーガア",
+        "pokemon": [
+          "アーマーガア"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 33.3
+      },
+      {
+        "id": "エアームド",
+        "label": "エアームド",
+        "pokemon": [
+          "エアームド"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 33.3
+      },
+      {
+        "id": "カイリュー",
+        "label": "カイリュー",
+        "pokemon": [
+          "カイリュー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 33.3
+      },
+      {
+        "id": "ハクリュー",
+        "label": "ハクリュー",
+        "pokemon": [
+          "ハクリュー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 33.3
+      },
+      {
+        "id": "ミニリュウ",
+        "label": "ミニリュウ",
+        "pokemon": [
+          "ミニリュウ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 33.3
+      }
+    ],
+    "trivia": [
+      {
+        "id": "埼玉県-single-municipality",
+        "type": "single_municipality",
+        "text": "県内3枚のポケふたはすべて所沢にあります",
+        "source_type": "dataset"
+      }
+    ]
+  },
+  {
+    "prefecture": "千葉県",
+    "manhole_count": 4,
+    "municipality_count": 1,
+    "municipalities": [
+      "香取"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "香取",
+        "manhole_count": 4
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "ガラルカモネギ",
+        "label": "ガラルカモネギ",
+        "pokemon": [
+          "ガラルカモネギ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 25.0
+      },
+      {
+        "id": "ココガラ",
+        "label": "ココガラ",
+        "pokemon": [
+          "ココガラ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 25.0
+      },
+      {
+        "id": "タイレーツ",
+        "label": "タイレーツ",
+        "pokemon": [
+          "タイレーツ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 25.0
+      },
+      {
+        "id": "タネボー",
+        "label": "タネボー",
+        "pokemon": [
+          "タネボー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 25.0
+      },
+      {
+        "id": "ハスボー",
+        "label": "ハスボー",
+        "pokemon": [
+          "ハスボー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 25.0
+      },
+      {
+        "id": "フラージェス",
+        "label": "フラージェス",
+        "pokemon": [
+          "フラージェス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 25.0
+      },
+      {
+        "id": "ムクバード",
+        "label": "ムクバード",
+        "pokemon": [
+          "ムクバード"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 25.0
+      },
+      {
+        "id": "ヤヤコマ",
+        "label": "ヤヤコマ",
+        "pokemon": [
+          "ヤヤコマ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 25.0
+      }
+    ],
+    "trivia": [
+      {
+        "id": "千葉県-single-municipality",
+        "type": "single_municipality",
+        "text": "県内4枚のポケふたはすべて香取にあります",
+        "source_type": "dataset"
+      }
+    ]
+  },
+  {
+    "prefecture": "東京都",
+    "manhole_count": 13,
+    "municipality_count": 4,
+    "municipalities": [
+      "台東区上野",
+      "小笠原",
+      "町田",
+      "稲城市"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "町田",
+        "manhole_count": 6
+      },
+      {
+        "municipality": "小笠原",
+        "manhole_count": 4
+      },
+      {
+        "municipality": "台東区上野",
+        "manhole_count": 2
+      },
+      {
+        "municipality": "稲城市",
+        "manhole_count": 1
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "イーブイ",
+        "label": "イーブイ",
+        "pokemon": [
+          "イーブイ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 7.7
+      },
+      {
+        "id": "カメックス",
+        "label": "カメックス",
+        "pokemon": [
+          "カメックス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 7.7
+      },
+      {
+        "id": "キャタピー",
+        "label": "キャタピー",
+        "pokemon": [
+          "キャタピー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 7.7
+      },
+      {
+        "id": "コラッタ",
+        "label": "コラッタ",
+        "pokemon": [
+          "コラッタ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 7.7
+      },
+      {
+        "id": "ゼニガメ",
+        "label": "ゼニガメ",
+        "pokemon": [
+          "ゼニガメ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 7.7
+      },
+      {
+        "id": "ソーナノ",
+        "label": "ソーナノ",
+        "pokemon": [
+          "ソーナノ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 7.7
+      },
+      {
+        "id": "チゴラス",
+        "label": "チゴラス",
+        "pokemon": [
+          "チゴラス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 7.7
+      },
+      {
+        "id": "ドーミラー",
+        "label": "ドーミラー",
+        "pokemon": [
+          "ドーミラー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 7.7
+      },
+      {
+        "id": "ナゾノクサ",
+        "label": "ナゾノクサ",
+        "pokemon": [
+          "ナゾノクサ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 7.7
+      },
+      {
+        "id": "ニョロモ",
+        "label": "ニョロモ",
+        "pokemon": [
+          "ニョロモ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 7.7
+      },
+      {
+        "id": "ヒトカゲ",
+        "label": "ヒトカゲ",
+        "pokemon": [
+          "ヒトカゲ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 7.7
+      },
+      {
+        "id": "ビードル",
+        "label": "ビードル",
+        "pokemon": [
+          "ビードル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 7.7
+      },
+      {
+        "id": "ピカチュウ",
+        "label": "ピカチュウ",
+        "pokemon": [
+          "ピカチュウ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 7.7
+      },
+      {
+        "id": "フシギダネ",
+        "label": "フシギダネ",
+        "pokemon": [
+          "フシギダネ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 7.7
+      },
+      {
+        "id": "フシギバナ",
+        "label": "フシギバナ",
+        "pokemon": [
+          "フシギバナ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 7.7
+      },
+      {
+        "id": "ポッポ",
+        "label": "ポッポ",
+        "pokemon": [
+          "ポッポ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 7.7
+      },
+      {
+        "id": "ミュウ",
+        "label": "ミュウ",
+        "pokemon": [
+          "ミュウ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 7.7
+      },
+      {
+        "id": "ヤジロン",
+        "label": "ヤジロン",
+        "pokemon": [
+          "ヤジロン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 7.7
+      },
+      {
+        "id": "リザードン",
+        "label": "リザードン",
+        "pokemon": [
+          "リザードン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 7.7
+      }
+    ],
+    "trivia": [
+      {
+        "id": "tokyo-pokepark-kanto-admission",
+        "type": "local_connection",
+        "text": "稲城市のポケパーク カントー内にも1枚あり、見るにはポケパーク カントーへの入場が必要です",
+        "source_type": "official",
+        "source_url": "https://local.pokemon.jp/manhole/desc/448/",
+        "source_label": "ポケふた公式",
+        "verified_at": "2026-06-13"
+      },
+      {
+        "id": "東京都-municipality-concentration",
+        "type": "municipality_concentration",
+        "text": "最多は町田の6枚で、次いで小笠原の4枚です",
+        "source_type": "dataset"
+      }
+    ]
+  },
+  {
+    "prefecture": "神奈川県",
+    "manhole_count": 5,
+    "municipality_count": 1,
+    "municipalities": [
+      "横浜"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "横浜",
+        "manhole_count": 5
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "ピカチュウ",
+        "label": "ピカチュウ",
+        "pokemon": [
+          "ピカチュウ"
+        ],
+        "cover_count": 5,
+        "coverage_percent": 100.0
+      },
+      {
+        "id": "コダック",
+        "label": "コダック",
+        "pokemon": [
+          "コダック"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ゴンべ",
+        "label": "ゴンべ",
+        "pokemon": [
+          "ゴンべ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ビクティニ",
+        "label": "ビクティニ",
+        "pokemon": [
+          "ビクティニ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ペリッパー",
+        "label": "ペリッパー",
+        "pokemon": [
+          "ペリッパー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ライチュウ",
+        "label": "ライチュウ",
+        "pokemon": [
+          "ライチュウ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ワンリキー",
+        "label": "ワンリキー",
+        "pokemon": [
+          "ワンリキー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      }
+    ],
+    "trivia": [
+      {
+        "id": "神奈川県-single-municipality",
+        "type": "single_municipality",
+        "text": "県内5枚のポケふたはすべて横浜にあります",
+        "source_type": "dataset"
+      },
+      {
+        "id": "神奈川県-ピカチュウ-100",
+        "type": "pokemon_100",
+        "text": "県内5枚すべてにピカチュウが登場します",
+        "source_type": "dataset"
+      }
+    ]
+  },
+  {
+    "prefecture": "新潟県",
+    "manhole_count": 4,
+    "municipality_count": 1,
+    "municipalities": [
+      "小千谷"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "小千谷",
+        "manhole_count": 4
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "コイキング",
+        "label": "コイキング",
+        "pokemon": [
+          "コイキング"
+        ],
+        "cover_count": 4,
+        "coverage_percent": 100.0
+      },
+      {
+        "id": "ヒンバス",
+        "label": "ヒンバス",
+        "pokemon": [
+          "ヒンバス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 25.0
+      },
+      {
+        "id": "ピジョン",
+        "label": "ピジョン",
+        "pokemon": [
+          "ピジョン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 25.0
+      }
+    ],
+    "trivia": [
+      {
+        "id": "niigata-ojiya-koi",
+        "type": "local_connection",
+        "text": "錦鯉発祥の地として知られる小千谷にちなみ、コイキングのポケふたが設置されています",
+        "source_type": "official",
+        "source_url": "https://www.city.ojiya.niigata.jp/site/kanko/pokemon.html",
+        "source_label": "小千谷市",
+        "verified_at": "2026-06-13"
+      },
+      {
+        "id": "新潟県-single-municipality",
+        "type": "single_municipality",
+        "text": "県内4枚のポケふたはすべて小千谷にあります",
+        "source_type": "dataset"
+      },
+      {
+        "id": "新潟県-コイキング-100",
+        "type": "pokemon_100",
+        "text": "県内4枚すべてにコイキングが登場します",
+        "source_type": "dataset"
+      }
+    ]
+  },
+  {
+    "prefecture": "富山県",
+    "manhole_count": 3,
+    "municipality_count": 1,
+    "municipalities": [
+      "富山"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "富山",
+        "manhole_count": 3
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "アブソル",
+        "label": "アブソル",
+        "pokemon": [
+          "アブソル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 33.3
+      },
+      {
+        "id": "キュワワー",
+        "label": "キュワワー",
+        "pokemon": [
+          "キュワワー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 33.3
+      },
+      {
+        "id": "マーイーカ",
+        "label": "マーイーカ",
+        "pokemon": [
+          "マーイーカ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 33.3
+      },
+      {
+        "id": "レディバ",
+        "label": "レディバ",
+        "pokemon": [
+          "レディバ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 33.3
+      }
+    ],
+    "trivia": [
+      {
+        "id": "富山県-single-municipality",
+        "type": "single_municipality",
+        "text": "県内3枚のポケふたはすべて富山にあります",
+        "source_type": "dataset"
+      }
+    ]
+  },
+  {
+    "prefecture": "石川県",
+    "manhole_count": 7,
+    "municipality_count": 7,
+    "municipalities": [
+      "七尾",
+      "志賀",
+      "珠洲",
+      "穴水",
+      "能登",
+      "輪島",
+      "金沢"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "七尾",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "志賀",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "珠洲",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "穴水",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "能登",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "輪島",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "金沢",
+        "manhole_count": 1
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "カイデン",
+        "label": "カイデン",
+        "pokemon": [
+          "カイデン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 14.3
+      },
+      {
+        "id": "カビゴン",
+        "label": "カビゴン",
+        "pokemon": [
+          "カビゴン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 14.3
+      },
+      {
+        "id": "ギャラドス",
+        "label": "ギャラドス",
+        "pokemon": [
+          "ギャラドス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 14.3
+      },
+      {
+        "id": "ゲッコウガ",
+        "label": "ゲッコウガ",
+        "pokemon": [
+          "ゲッコウガ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 14.3
+      },
+      {
+        "id": "サクラビス",
+        "label": "サクラビス",
+        "pokemon": [
+          "サクラビス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 14.3
+      },
+      {
+        "id": "ダルマッカ",
+        "label": "ダルマッカ",
+        "pokemon": [
+          "ダルマッカ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 14.3
+      },
+      {
+        "id": "ニョロトノ",
+        "label": "ニョロトノ",
+        "pokemon": [
+          "ニョロトノ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 14.3
+      },
+      {
+        "id": "ニョロモ",
+        "label": "ニョロモ",
+        "pokemon": [
+          "ニョロモ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 14.3
+      },
+      {
+        "id": "ニンフィア",
+        "label": "ニンフィア",
+        "pokemon": [
+          "ニンフィア"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 14.3
+      },
+      {
+        "id": "ハスボー",
+        "label": "ハスボー",
+        "pokemon": [
+          "ハスボー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 14.3
+      },
+      {
+        "id": "プラスル",
+        "label": "プラスル",
+        "pokemon": [
+          "プラスル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 14.3
+      },
+      {
+        "id": "マイナン",
+        "label": "マイナン",
+        "pokemon": [
+          "マイナン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 14.3
+      },
+      {
+        "id": "ミロカロス",
+        "label": "ミロカロス",
+        "pokemon": [
+          "ミロカロス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 14.3
+      },
+      {
+        "id": "メテノ",
+        "label": "メテノ",
+        "pokemon": [
+          "メテノ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 14.3
+      },
+      {
+        "id": "ラブカス",
+        "label": "ラブカス",
+        "pokemon": [
+          "ラブカス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 14.3
+      },
+      {
+        "id": "ロゼリア",
+        "label": "ロゼリア",
+        "pokemon": [
+          "ロゼリア"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 14.3
+      }
+    ],
+    "trivia": []
+  },
+  {
     "prefecture": "福井県",
-    "pokemon": "カイリュー",
-    "count": 17,
-    "title": "福井県の応援ポケモンはカイリュー",
-    "summary": "九頭竜川をはじめ「竜」の地名が多い福井。カイリューは県内17枚すべてに登場するほど定着しています。",
-    "status": "ongoing",
-    "source_url": "https://local.pokemon.jp/",
-    "map_pref": "福井県",
-    "manhole_ids": [],
-    "links": []
+    "manhole_count": 17,
+    "municipality_count": 16,
+    "municipalities": [
+      "あわら",
+      "おおい",
+      "勝山",
+      "南越前",
+      "坂井",
+      "大野",
+      "小浜",
+      "敦賀",
+      "永平寺",
+      "池田",
+      "福井",
+      "美浜",
+      "若狭",
+      "越前",
+      "高浜",
+      "鯖江"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "越前",
+        "manhole_count": 2
+      },
+      {
+        "municipality": "あわら",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "おおい",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "勝山",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "南越前",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "坂井",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "大野",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "小浜",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "敦賀",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "永平寺",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "池田",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "福井",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "美浜",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "若狭",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "高浜",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "鯖江",
+        "manhole_count": 1
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "カイリュー",
+        "label": "カイリュー",
+        "pokemon": [
+          "カイリュー"
+        ],
+        "cover_count": 17,
+        "coverage_percent": 100.0
+      },
+      {
+        "id": "アーケン",
+        "label": "アーケン",
+        "pokemon": [
+          "アーケン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "ウミディグダ",
+        "label": "ウミディグダ",
+        "pokemon": [
+          "ウミディグダ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "エレズン",
+        "label": "エレズン",
+        "pokemon": [
+          "エレズン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "ガチゴラス",
+        "label": "ガチゴラス",
+        "pokemon": [
+          "ガチゴラス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "クワッス",
+        "label": "クワッス",
+        "pokemon": [
+          "クワッス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "ケーシィ",
+        "label": "ケーシィ",
+        "pokemon": [
+          "ケーシィ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "コアルヒー",
+        "label": "コアルヒー",
+        "pokemon": [
+          "コアルヒー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "ココガラ",
+        "label": "ココガラ",
+        "pokemon": [
+          "ココガラ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "サッチムシ",
+        "label": "サッチムシ",
+        "pokemon": [
+          "サッチムシ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "シャリタツ",
+        "label": "シャリタツ",
+        "pokemon": [
+          "シャリタツ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "ジグザグマ",
+        "label": "ジグザグマ",
+        "pokemon": [
+          "ジグザグマ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "ジャラランガ",
+        "label": "ジャラランガ",
+        "pokemon": [
+          "ジャラランガ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "ダクマ",
+        "label": "ダクマ",
+        "pokemon": [
+          "ダクマ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "トゲチック",
+        "label": "トゲチック",
+        "pokemon": [
+          "トゲチック"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "ニャオニクス",
+        "label": "ニャオニクス",
+        "pokemon": [
+          "ニャオニクス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "ハクリュー",
+        "label": "ハクリュー",
+        "pokemon": [
+          "ハクリュー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "バタフリー",
+        "label": "バタフリー",
+        "pokemon": [
+          "バタフリー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "ヒトツキ",
+        "label": "ヒトツキ",
+        "pokemon": [
+          "ヒトツキ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "ヒドイデ",
+        "label": "ヒドイデ",
+        "pokemon": [
+          "ヒドイデ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "プクリン",
+        "label": "プクリン",
+        "pokemon": [
+          "プクリン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "マッギョ",
+        "label": "マッギョ",
+        "pokemon": [
+          "マッギョ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "マフィティフ",
+        "label": "マフィティフ",
+        "pokemon": [
+          "マフィティフ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "ミニリュウ",
+        "label": "ミニリュウ",
+        "pokemon": [
+          "ミニリュウ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "モルペコ",
+        "label": "モルペコ",
+        "pokemon": [
+          "モルペコ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      }
+    ],
+    "trivia": [
+      {
+        "id": "fukui-support-dragonite",
+        "type": "support_pokemon",
+        "text": "福井県ではカイリューがふくい応援ポケモンとして地域を盛り上げています",
+        "source_type": "official",
+        "source_url": "https://local.pokemon.jp/municipality/fukui/",
+        "source_label": "ポケモンローカルActs",
+        "verified_at": "2026-06-13"
+      },
+      {
+        "id": "福井県-カイリュー-100",
+        "type": "pokemon_100",
+        "text": "県内17枚すべてにカイリューが登場します",
+        "source_type": "dataset"
+      }
+    ]
   },
   {
-    "id": "kagawa-slowpoke",
-    "prefecture": "香川県",
-    "pokemon": "ヤドン",
-    "count": 17,
-    "title": "香川県の応援ポケモンはヤドン",
-    "summary": "香川県は2021年に公式で「ヤドン県」を一時採用した実績あり。冗談ではなく公式です。その縁で県内各地にヤドンのポケふたが設置されています。",
-    "status": "ongoing",
-    "source_url": "https://local.pokemon.jp/",
-    "map_pref": "香川県",
-    "manhole_ids": [],
-    "links": []
+    "prefecture": "山梨県",
+    "manhole_count": 0,
+    "municipality_count": 0,
+    "municipalities": [],
+    "municipality_distribution": [],
+    "pokemon_coverage": [],
+    "trivia": []
   },
   {
-    "id": "kochi-quagsire",
-    "prefecture": "高知県",
-    "pokemon": "ヌオー",
-    "count": 18,
-    "title": "高知県の応援ポケモンはヌオー",
-    "summary": "日本最後の清流・四万十川をイメージしたヌオー。水辺をのんびり過ごすイメージが高知の川文化と重なります。県内18枚すべてにヌオーが登場します。",
-    "status": "ongoing",
-    "source_url": "https://local.pokemon.jp/",
-    "map_pref": "高知県",
-    "manhole_ids": [],
-    "links": []
+    "prefecture": "長野県",
+    "manhole_count": 0,
+    "municipality_count": 0,
+    "municipalities": [],
+    "municipality_distribution": [],
+    "pokemon_coverage": [],
+    "trivia": []
   },
   {
-    "id": "mie-oshawott",
+    "prefecture": "岐阜県",
+    "manhole_count": 5,
+    "municipality_count": 5,
+    "municipalities": [
+      "下呂",
+      "各務原",
+      "関",
+      "関ケ原",
+      "高山"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "下呂",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "各務原",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "関",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "関ケ原",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "高山",
+        "manhole_count": 1
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "ウッウ",
+        "label": "ウッウ",
+        "pokemon": [
+          "ウッウ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "オタマロ",
+        "label": "オタマロ",
+        "pokemon": [
+          "オタマロ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ガマガル",
+        "label": "ガマガル",
+        "pokemon": [
+          "ガマガル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ガマゲロゲ",
+        "label": "ガマゲロゲ",
+        "pokemon": [
+          "ガマゲロゲ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "コマタナ",
+        "label": "コマタナ",
+        "pokemon": [
+          "コマタナ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ドジョッチ",
+        "label": "ドジョッチ",
+        "pokemon": [
+          "ドジョッチ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ドドゲザン",
+        "label": "ドドゲザン",
+        "pokemon": [
+          "ドドゲザン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ナマズン",
+        "label": "ナマズン",
+        "pokemon": [
+          "ナマズン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "バオップ",
+        "label": "バオップ",
+        "pokemon": [
+          "バオップ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ヒヤップ",
+        "label": "ヒヤップ",
+        "pokemon": [
+          "ヒヤップ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ヤナップ",
+        "label": "ヤナップ",
+        "pokemon": [
+          "ヤナップ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      }
+    ],
+    "trivia": []
+  },
+  {
+    "prefecture": "静岡県",
+    "manhole_count": 5,
+    "municipality_count": 5,
+    "municipalities": [
+      "伊豆",
+      "富士",
+      "沼津",
+      "浜松",
+      "静岡"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "伊豆",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "富士",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "沼津",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "浜松",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "静岡",
+        "manhole_count": 1
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "ゴロンダ",
+        "label": "ゴロンダ",
+        "pokemon": [
+          "ゴロンダ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "サクラビス",
+        "label": "サクラビス",
+        "pokemon": [
+          "サクラビス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "シビルドン",
+        "label": "シビルドン",
+        "pokemon": [
+          "シビルドン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ジーランス",
+        "label": "ジーランス",
+        "pokemon": [
+          "ジーランス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ハンテール",
+        "label": "ハンテール",
+        "pokemon": [
+          "ハンテール"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ファイヤー",
+        "label": "ファイヤー",
+        "pokemon": [
+          "ファイヤー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "フシギソウ",
+        "label": "フシギソウ",
+        "pokemon": [
+          "フシギソウ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ムクホーク",
+        "label": "ムクホーク",
+        "pokemon": [
+          "ムクホーク"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "メロエッタ",
+        "label": "メロエッタ",
+        "pokemon": [
+          "メロエッタ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ヤンチャム",
+        "label": "ヤンチャム",
+        "pokemon": [
+          "ヤンチャム"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      }
+    ],
+    "trivia": []
+  },
+  {
+    "prefecture": "愛知県",
+    "manhole_count": 9,
+    "municipality_count": 6,
+    "municipalities": [
+      "刈谷市",
+      "名古屋市中区",
+      "常滑",
+      "瀬戸市",
+      "西尾市",
+      "豊橋市"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "豊橋市",
+        "manhole_count": 4
+      },
+      {
+        "municipality": "刈谷市",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "名古屋市中区",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "常滑",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "瀬戸市",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "西尾市",
+        "manhole_count": 1
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "アゴジムシ",
+        "label": "アゴジムシ",
+        "pokemon": [
+          "アゴジムシ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 11.1
+      },
+      {
+        "id": "アブリボン",
+        "label": "アブリボン",
+        "pokemon": [
+          "アブリボン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 11.1
+      },
+      {
+        "id": "アローラニャース",
+        "label": "アローラニャース",
+        "pokemon": [
+          "アローラニャース"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 11.1
+      },
+      {
+        "id": "カブト",
+        "label": "カブト",
+        "pokemon": [
+          "カブト"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 11.1
+      },
+      {
+        "id": "キバゴ",
+        "label": "キバゴ",
+        "pokemon": [
+          "キバゴ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 11.1
+      },
+      {
+        "id": "クワガノン",
+        "label": "クワガノン",
+        "pokemon": [
+          "クワガノン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 11.1
+      },
+      {
+        "id": "コイキング",
+        "label": "コイキング",
+        "pokemon": [
+          "コイキング"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 11.1
+      },
+      {
+        "id": "ゴクリン",
+        "label": "ゴクリン",
+        "pokemon": [
+          "ゴクリン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 11.1
+      },
+      {
+        "id": "ジュカイン",
+        "label": "ジュカイン",
+        "pokemon": [
+          "ジュカイン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 11.1
+      },
+      {
+        "id": "スターミー",
+        "label": "スターミー",
+        "pokemon": [
+          "スターミー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 11.1
+      },
+      {
+        "id": "タツベイ",
+        "label": "タツベイ",
+        "pokemon": [
+          "タツベイ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 11.1
+      },
+      {
+        "id": "デンヂムシ",
+        "label": "デンヂムシ",
+        "pokemon": [
+          "デンヂムシ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 11.1
+      },
+      {
+        "id": "ニャヒート",
+        "label": "ニャヒート",
+        "pokemon": [
+          "ニャヒート"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 11.1
+      },
+      {
+        "id": "ネッコアラ",
+        "label": "ネッコアラ",
+        "pokemon": [
+          "ネッコアラ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 11.1
+      },
+      {
+        "id": "バクフーン",
+        "label": "バクフーン",
+        "pokemon": [
+          "バクフーン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 11.1
+      },
+      {
+        "id": "ピジョット",
+        "label": "ピジョット",
+        "pokemon": [
+          "ピジョット"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 11.1
+      },
+      {
+        "id": "ブーバー",
+        "label": "ブーバー",
+        "pokemon": [
+          "ブーバー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 11.1
+      },
+      {
+        "id": "マホイップ",
+        "label": "マホイップ",
+        "pokemon": [
+          "マホイップ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 11.1
+      }
+    ],
+    "trivia": [
+      {
+        "id": "愛知県-municipality-concentration",
+        "type": "municipality_concentration",
+        "text": "豊橋市に4枚が集まり、ほかの5自治体は各1枚です",
+        "source_type": "dataset"
+      }
+    ]
+  },
+  {
     "prefecture": "三重県",
-    "pokemon": "ミジュマル",
-    "count": 31,
-    "title": "三重県の応援ポケモンはミジュマル",
-    "summary": "「みえ」と「みず」のイメージが重なるミジュマル。伊勢志摩の海の雰囲気とも相性が良く、県内各地に設置されています。",
-    "status": "ongoing",
-    "source_url": "https://local.pokemon.jp/",
-    "map_pref": "三重県",
-    "manhole_ids": [],
-    "links": []
+    "manhole_count": 31,
+    "municipality_count": 30,
+    "municipalities": [
+      "いなべ市",
+      "三重郡川越町",
+      "三重郡朝日町",
+      "三重郡菰野町",
+      "亀山市",
+      "伊勢市",
+      "伊賀市",
+      "北牟婁郡紀北町",
+      "南牟婁郡御浜町",
+      "南牟婁郡紀宝町",
+      "名張市",
+      "員弁郡東員町",
+      "四日市市",
+      "多気郡多気町",
+      "多気郡大台町",
+      "多気郡明和町",
+      "尾鷲市",
+      "度会郡南伊勢町",
+      "度会郡大紀町",
+      "度会郡度会町",
+      "度会郡玉城町",
+      "志摩市",
+      "松阪市",
+      "桑名市",
+      "桑名郡木曽岬町",
+      "津市",
+      "熊野市",
+      "鈴鹿",
+      "鈴鹿市",
+      "鳥羽市"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "鳥羽市",
+        "manhole_count": 2
+      },
+      {
+        "municipality": "いなべ市",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "三重郡川越町",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "三重郡朝日町",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "三重郡菰野町",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "亀山市",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "伊勢市",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "伊賀市",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "北牟婁郡紀北町",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "南牟婁郡御浜町",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "南牟婁郡紀宝町",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "名張市",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "員弁郡東員町",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "四日市市",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "多気郡多気町",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "多気郡大台町",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "多気郡明和町",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "尾鷲市",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "度会郡南伊勢町",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "度会郡大紀町",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "度会郡度会町",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "度会郡玉城町",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "志摩市",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "松阪市",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "桑名市",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "桑名郡木曽岬町",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "津市",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "熊野市",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "鈴鹿",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "鈴鹿市",
+        "manhole_count": 1
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "ミジュマル",
+        "label": "ミジュマル",
+        "pokemon": [
+          "ミジュマル"
+        ],
+        "cover_count": 31,
+        "coverage_percent": 100.0
+      },
+      {
+        "id": "アギルダー",
+        "label": "アギルダー",
+        "pokemon": [
+          "アギルダー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.2
+      },
+      {
+        "id": "アマカジ",
+        "label": "アマカジ",
+        "pokemon": [
+          "アマカジ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.2
+      },
+      {
+        "id": "アメタマ",
+        "label": "アメタマ",
+        "pokemon": [
+          "アメタマ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.2
+      },
+      {
+        "id": "エルフーン",
+        "label": "エルフーン",
+        "pokemon": [
+          "エルフーン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.2
+      },
+      {
+        "id": "グルトン",
+        "label": "グルトン",
+        "pokemon": [
+          "グルトン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.2
+      },
+      {
+        "id": "ゴマゾウ",
+        "label": "ゴマゾウ",
+        "pokemon": [
+          "ゴマゾウ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.2
+      },
+      {
+        "id": "ゴーゴート",
+        "label": "ゴーゴート",
+        "pokemon": [
+          "ゴーゴート"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.2
+      },
+      {
+        "id": "ゴーリキー",
+        "label": "ゴーリキー",
+        "pokemon": [
+          "ゴーリキー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.2
+      },
+      {
+        "id": "ジャランゴ",
+        "label": "ジャランゴ",
+        "pokemon": [
+          "ジャランゴ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.2
+      },
+      {
+        "id": "ジュゴン",
+        "label": "ジュゴン",
+        "pokemon": [
+          "ジュゴン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.2
+      },
+      {
+        "id": "スバメ",
+        "label": "スバメ",
+        "pokemon": [
+          "スバメ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.2
+      },
+      {
+        "id": "ダイケンキ",
+        "label": "ダイケンキ",
+        "pokemon": [
+          "ダイケンキ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.2
+      },
+      {
+        "id": "ダブラン",
+        "label": "ダブラン",
+        "pokemon": [
+          "ダブラン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.2
+      },
+      {
+        "id": "ドゴーム",
+        "label": "ドゴーム",
+        "pokemon": [
+          "ドゴーム"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.2
+      },
+      {
+        "id": "ドダイトス",
+        "label": "ドダイトス",
+        "pokemon": [
+          "ドダイトス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.2
+      },
+      {
+        "id": "ニャイキング",
+        "label": "ニャイキング",
+        "pokemon": [
+          "ニャイキング"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.2
+      },
+      {
+        "id": "ニャース",
+        "label": "ニャース",
+        "pokemon": [
+          "ニャース"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.2
+      },
+      {
+        "id": "ヌイコグマ",
+        "label": "ヌイコグマ",
+        "pokemon": [
+          "ヌイコグマ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.2
+      },
+      {
+        "id": "ネンドール",
+        "label": "ネンドール",
+        "pokemon": [
+          "ネンドール"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.2
+      },
+      {
+        "id": "バネブー",
+        "label": "バネブー",
+        "pokemon": [
+          "バネブー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.2
+      },
+      {
+        "id": "パチリス",
+        "label": "パチリス",
+        "pokemon": [
+          "パチリス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.2
+      },
+      {
+        "id": "パールル",
+        "label": "パールル",
+        "pokemon": [
+          "パールル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.2
+      },
+      {
+        "id": "ビリジオン",
+        "label": "ビリジオン",
+        "pokemon": [
+          "ビリジオン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.2
+      },
+      {
+        "id": "フタチマル",
+        "label": "フタチマル",
+        "pokemon": [
+          "フタチマル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.2
+      },
+      {
+        "id": "フラージェス",
+        "label": "フラージェス",
+        "pokemon": [
+          "フラージェス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.2
+      },
+      {
+        "id": "プラスル",
+        "label": "プラスル",
+        "pokemon": [
+          "プラスル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.2
+      },
+      {
+        "id": "プロトーガ",
+        "label": "プロトーガ",
+        "pokemon": [
+          "プロトーガ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.2
+      },
+      {
+        "id": "マイナン",
+        "label": "マイナン",
+        "pokemon": [
+          "マイナン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.2
+      },
+      {
+        "id": "マネネ",
+        "label": "マネネ",
+        "pokemon": [
+          "マネネ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.2
+      },
+      {
+        "id": "ママンボウ",
+        "label": "ママンボウ",
+        "pokemon": [
+          "ママンボウ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.2
+      },
+      {
+        "id": "マリル",
+        "label": "マリル",
+        "pokemon": [
+          "マリル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.2
+      },
+      {
+        "id": "ミルタンク",
+        "label": "ミルタンク",
+        "pokemon": [
+          "ミルタンク"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.2
+      },
+      {
+        "id": "メェークル",
+        "label": "メェークル",
+        "pokemon": [
+          "メェークル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.2
+      },
+      {
+        "id": "メタモン",
+        "label": "メタモン",
+        "pokemon": [
+          "メタモン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.2
+      },
+      {
+        "id": "モトトカゲ",
+        "label": "モトトカゲ",
+        "pokemon": [
+          "モトトカゲ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.2
+      },
+      {
+        "id": "ヤナップ",
+        "label": "ヤナップ",
+        "pokemon": [
+          "ヤナップ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.2
+      },
+      {
+        "id": "ランクルス",
+        "label": "ランクルス",
+        "pokemon": [
+          "ランクルス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.2
+      },
+      {
+        "id": "リオル",
+        "label": "リオル",
+        "pokemon": [
+          "リオル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.2
+      },
+      {
+        "id": "リーシャン",
+        "label": "リーシャン",
+        "pokemon": [
+          "リーシャン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.2
+      }
+    ],
+    "trivia": [
+      {
+        "id": "mie-support-oshawott",
+        "type": "support_pokemon",
+        "text": "三重県ではミジュマルがみえ応援ポケモンとして地域の魅力を発信しています",
+        "source_type": "official",
+        "source_url": "https://local.pokemon.jp/municipality/mie/",
+        "source_label": "ポケモンローカルActs",
+        "verified_at": "2026-06-13"
+      },
+      {
+        "id": "三重県-ミジュマル-100",
+        "type": "pokemon_100",
+        "text": "県内31枚すべてにミジュマルが登場します",
+        "source_type": "dataset"
+      }
+    ]
   },
   {
-    "id": "nagasaki-ampharos",
+    "prefecture": "滋賀県",
+    "manhole_count": 5,
+    "municipality_count": 2,
+    "municipalities": [
+      "大津",
+      "甲賀"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "甲賀",
+        "manhole_count": 3
+      },
+      {
+        "municipality": "大津",
+        "manhole_count": 2
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "ゲッコウガ",
+        "label": "ゲッコウガ",
+        "pokemon": [
+          "ゲッコウガ"
+        ],
+        "cover_count": 3,
+        "coverage_percent": 60.0
+      },
+      {
+        "id": "ギャラドス",
+        "label": "ギャラドス",
+        "pokemon": [
+          "ギャラドス"
+        ],
+        "cover_count": 2,
+        "coverage_percent": 40.0
+      },
+      {
+        "id": "ゲコガシラ",
+        "label": "ゲコガシラ",
+        "pokemon": [
+          "ゲコガシラ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      }
+    ],
+    "trivia": [
+      {
+        "id": "滋賀県-municipality-concentration",
+        "type": "municipality_concentration",
+        "text": "最多は甲賀の3枚で、次いで大津の2枚です",
+        "source_type": "dataset"
+      },
+      {
+        "id": "滋賀県-top-pokemon",
+        "type": "top_pokemon",
+        "text": "最も多く登場するのはゲッコウガで、3枚に描かれています",
+        "source_type": "dataset"
+      }
+    ]
+  },
+  {
+    "prefecture": "京都府",
+    "manhole_count": 8,
+    "municipality_count": 2,
+    "municipalities": [
+      "京都",
+      "宇治"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "京都",
+        "manhole_count": 5
+      },
+      {
+        "municipality": "宇治",
+        "manhole_count": 3
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "ダーテング",
+        "label": "ダーテング",
+        "pokemon": [
+          "ダーテング"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 12.5
+      },
+      {
+        "id": "チコリータ",
+        "label": "チコリータ",
+        "pokemon": [
+          "チコリータ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 12.5
+      },
+      {
+        "id": "チャデス",
+        "label": "チャデス",
+        "pokemon": [
+          "チャデス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 12.5
+      },
+      {
+        "id": "パッチール",
+        "label": "パッチール",
+        "pokemon": [
+          "パッチール"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 12.5
+      },
+      {
+        "id": "ヒノアラシ",
+        "label": "ヒノアラシ",
+        "pokemon": [
+          "ヒノアラシ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 12.5
+      },
+      {
+        "id": "ヒバニー",
+        "label": "ヒバニー",
+        "pokemon": [
+          "ヒバニー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 12.5
+      },
+      {
+        "id": "ヒヒダルマ",
+        "label": "ヒヒダルマ",
+        "pokemon": [
+          "ヒヒダルマ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 12.5
+      },
+      {
+        "id": "ピィ",
+        "label": "ピィ",
+        "pokemon": [
+          "ピィ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 12.5
+      },
+      {
+        "id": "ピカチュウ",
+        "label": "ピカチュウ",
+        "pokemon": [
+          "ピカチュウ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 12.5
+      },
+      {
+        "id": "ピチュー",
+        "label": "ピチュー",
+        "pokemon": [
+          "ピチュー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 12.5
+      },
+      {
+        "id": "ププリン",
+        "label": "ププリン",
+        "pokemon": [
+          "ププリン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 12.5
+      },
+      {
+        "id": "ホウオウ",
+        "label": "ホウオウ",
+        "pokemon": [
+          "ホウオウ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 12.5
+      },
+      {
+        "id": "マリルリ",
+        "label": "マリルリ",
+        "pokemon": [
+          "マリルリ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 12.5
+      },
+      {
+        "id": "ヤバソチャ",
+        "label": "ヤバソチャ",
+        "pokemon": [
+          "ヤバソチャ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 12.5
+      },
+      {
+        "id": "ワニノコ",
+        "label": "ワニノコ",
+        "pokemon": [
+          "ワニノコ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 12.5
+      }
+    ],
+    "trivia": [
+      {
+        "id": "京都府-municipality-concentration",
+        "type": "municipality_concentration",
+        "text": "最多は京都の5枚で、次いで宇治の3枚です",
+        "source_type": "dataset"
+      }
+    ]
+  },
+  {
+    "prefecture": "大阪府",
+    "manhole_count": 5,
+    "municipality_count": 1,
+    "municipalities": [
+      "東大阪"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "東大阪",
+        "manhole_count": 5
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "エレキッド",
+        "label": "エレキッド",
+        "pokemon": [
+          "エレキッド"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ギアル",
+        "label": "ギアル",
+        "pokemon": [
+          "ギアル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ギギアル",
+        "label": "ギギアル",
+        "pokemon": [
+          "ギギアル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "クチート",
+        "label": "クチート",
+        "pokemon": [
+          "クチート"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "コイル",
+        "label": "コイル",
+        "pokemon": [
+          "コイル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "トゲデマル",
+        "label": "トゲデマル",
+        "pokemon": [
+          "トゲデマル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ライコウ",
+        "label": "ライコウ",
+        "pokemon": [
+          "ライコウ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "レアコイル",
+        "label": "レアコイル",
+        "pokemon": [
+          "レアコイル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ワンパチ",
+        "label": "ワンパチ",
+        "pokemon": [
+          "ワンパチ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      }
+    ],
+    "trivia": [
+      {
+        "id": "大阪府-single-municipality",
+        "type": "single_municipality",
+        "text": "県内5枚のポケふたはすべて東大阪にあります",
+        "source_type": "dataset"
+      }
+    ]
+  },
+  {
+    "prefecture": "兵庫県",
+    "manhole_count": 3,
+    "municipality_count": 1,
+    "municipalities": [
+      "淡路"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "淡路",
+        "manhole_count": 3
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "トリトドン",
+        "label": "トリトドン",
+        "pokemon": [
+          "トリトドン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 33.3
+      },
+      {
+        "id": "パルシェン",
+        "label": "パルシェン",
+        "pokemon": [
+          "パルシェン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 33.3
+      },
+      {
+        "id": "フレフワン",
+        "label": "フレフワン",
+        "pokemon": [
+          "フレフワン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 33.3
+      },
+      {
+        "id": "ベイリーフ",
+        "label": "ベイリーフ",
+        "pokemon": [
+          "ベイリーフ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 33.3
+      },
+      {
+        "id": "ルギア",
+        "label": "ルギア",
+        "pokemon": [
+          "ルギア"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 33.3
+      }
+    ],
+    "trivia": [
+      {
+        "id": "兵庫県-single-municipality",
+        "type": "single_municipality",
+        "text": "県内3枚のポケふたはすべて淡路にあります",
+        "source_type": "dataset"
+      }
+    ]
+  },
+  {
+    "prefecture": "奈良県",
+    "manhole_count": 5,
+    "municipality_count": 1,
+    "municipalities": [
+      "斑鳩"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "斑鳩",
+        "manhole_count": 5
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "エンテイ",
+        "label": "エンテイ",
+        "pokemon": [
+          "エンテイ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ガーディ",
+        "label": "ガーディ",
+        "pokemon": [
+          "ガーディ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "シキジカ",
+        "label": "シキジカ",
+        "pokemon": [
+          "シキジカ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "チリーン",
+        "label": "チリーン",
+        "pokemon": [
+          "チリーン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ドータクン",
+        "label": "ドータクン",
+        "pokemon": [
+          "ドータクン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "バオッキー",
+        "label": "バオッキー",
+        "pokemon": [
+          "バオッキー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ヒノヤコマ",
+        "label": "ヒノヤコマ",
+        "pokemon": [
+          "ヒノヤコマ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ブビィ",
+        "label": "ブビィ",
+        "pokemon": [
+          "ブビィ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "マダツボミ",
+        "label": "マダツボミ",
+        "pokemon": [
+          "マダツボミ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      }
+    ],
+    "trivia": [
+      {
+        "id": "奈良県-single-municipality",
+        "type": "single_municipality",
+        "text": "県内5枚のポケふたはすべて斑鳩にあります",
+        "source_type": "dataset"
+      }
+    ]
+  },
+  {
+    "prefecture": "和歌山県",
+    "manhole_count": 5,
+    "municipality_count": 5,
+    "municipalities": [
+      "串本",
+      "和歌山",
+      "白浜",
+      "那智勝浦",
+      "高野"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "串本",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "和歌山",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "白浜",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "那智勝浦",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "高野",
+        "manhole_count": 1
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "アシレーヌ",
+        "label": "アシレーヌ",
+        "pokemon": [
+          "アシレーヌ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ウーラオス",
+        "label": "ウーラオス",
+        "pokemon": [
+          "ウーラオス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ジバコイル",
+        "label": "ジバコイル",
+        "pokemon": [
+          "ジバコイル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "セレビィ",
+        "label": "セレビィ",
+        "pokemon": [
+          "セレビィ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ナミイルカ",
+        "label": "ナミイルカ",
+        "pokemon": [
+          "ナミイルカ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ピィ",
+        "label": "ピィ",
+        "pokemon": [
+          "ピィ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ヤンチャム",
+        "label": "ヤンチャム",
+        "pokemon": [
+          "ヤンチャム"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "リグレー",
+        "label": "リグレー",
+        "pokemon": [
+          "リグレー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "レントラー",
+        "label": "レントラー",
+        "pokemon": [
+          "レントラー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      }
+    ],
+    "trivia": []
+  },
+  {
+    "prefecture": "鳥取県",
+    "manhole_count": 20,
+    "municipality_count": 19,
+    "municipalities": [
+      "三朝",
+      "伯耆",
+      "倉吉",
+      "八頭",
+      "北栄",
+      "南部",
+      "境港",
+      "大山",
+      "岩美",
+      "日南",
+      "日吉津",
+      "日野",
+      "智頭",
+      "江府",
+      "湯梨浜",
+      "琴浦",
+      "米子",
+      "若桜",
+      "鳥取"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "鳥取",
+        "manhole_count": 2
+      },
+      {
+        "municipality": "三朝",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "伯耆",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "倉吉",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "八頭",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "北栄",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "南部",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "境港",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "大山",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "岩美",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "日南",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "日吉津",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "日野",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "智頭",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "江府",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "湯梨浜",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "琴浦",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "米子",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "若桜",
+        "manhole_count": 1
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "サンド",
+        "label": "サンド",
+        "pokemon": [
+          "サンド"
+        ],
+        "cover_count": 17,
+        "coverage_percent": 85.0
+      },
+      {
+        "id": "アローラサンド",
+        "label": "アローラサンド",
+        "pokemon": [
+          "アローラサンド"
+        ],
+        "cover_count": 14,
+        "coverage_percent": 70.0
+      },
+      {
+        "id": "アローラサンドパン",
+        "label": "アローラサンドパン",
+        "pokemon": [
+          "アローラサンドパン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.0
+      },
+      {
+        "id": "イルミーゼ",
+        "label": "イルミーゼ",
+        "pokemon": [
+          "イルミーゼ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.0
+      },
+      {
+        "id": "ウソッキー",
+        "label": "ウソッキー",
+        "pokemon": [
+          "ウソッキー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.0
+      },
+      {
+        "id": "オニゴーリ",
+        "label": "オニゴーリ",
+        "pokemon": [
+          "オニゴーリ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.0
+      },
+      {
+        "id": "カモネギ",
+        "label": "カモネギ",
+        "pokemon": [
+          "カモネギ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.0
+      },
+      {
+        "id": "クラブ",
+        "label": "クラブ",
+        "pokemon": [
+          "クラブ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.0
+      },
+      {
+        "id": "ケロマツ",
+        "label": "ケロマツ",
+        "pokemon": [
+          "ケロマツ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.0
+      },
+      {
+        "id": "サンドパン",
+        "label": "サンドパン",
+        "pokemon": [
+          "サンドパン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.0
+      },
+      {
+        "id": "シェルダー",
+        "label": "シェルダー",
+        "pokemon": [
+          "シェルダー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.0
+      },
+      {
+        "id": "スワンナ",
+        "label": "スワンナ",
+        "pokemon": [
+          "スワンナ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.0
+      },
+      {
+        "id": "チルット",
+        "label": "チルット",
+        "pokemon": [
+          "チルット"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.0
+      },
+      {
+        "id": "ナックラー",
+        "label": "ナックラー",
+        "pokemon": [
+          "ナックラー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.0
+      },
+      {
+        "id": "ネイティオ",
+        "label": "ネイティオ",
+        "pokemon": [
+          "ネイティオ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.0
+      },
+      {
+        "id": "バルビート",
+        "label": "バルビート",
+        "pokemon": [
+          "バルビート"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.0
+      },
+      {
+        "id": "ヒトモシ",
+        "label": "ヒトモシ",
+        "pokemon": [
+          "ヒトモシ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.0
+      },
+      {
+        "id": "ホルビー",
+        "label": "ホルビー",
+        "pokemon": [
+          "ホルビー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.0
+      },
+      {
+        "id": "ミミロル",
+        "label": "ミミロル",
+        "pokemon": [
+          "ミミロル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.0
+      },
+      {
+        "id": "メタモン",
+        "label": "メタモン",
+        "pokemon": [
+          "メタモン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.0
+      },
+      {
+        "id": "ユキカブリ",
+        "label": "ユキカブリ",
+        "pokemon": [
+          "ユキカブリ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.0
+      },
+      {
+        "id": "sandshrew-family",
+        "label": "サンド系",
+        "pokemon": [
+          "サンド",
+          "アローラサンド"
+        ],
+        "cover_count": 20,
+        "coverage_percent": 100.0
+      }
+    ],
+    "trivia": [
+      {
+        "id": "tottori-sand",
+        "type": "local_connection",
+        "text": "鳥取砂丘をはじめ砂で知られる鳥取県では、サンドとアローラサンドが推しポケモンです",
+        "source_type": "official",
+        "source_url": "https://local.pokemon.jp/municipality/tottori/",
+        "source_label": "ポケモンローカルActs",
+        "verified_at": "2026-06-13"
+      },
+      {
+        "id": "鳥取県-sandshrew-family-100",
+        "type": "pokemon_group_100",
+        "text": "県内20枚すべてにサンド系が登場します",
+        "source_type": "dataset"
+      }
+    ]
+  },
+  {
+    "prefecture": "島根県",
+    "manhole_count": 5,
+    "municipality_count": 5,
+    "municipalities": [
+      "出雲",
+      "大田",
+      "安来",
+      "浜田",
+      "隠岐の島"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "出雲",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "大田",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "安来",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "浜田",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "隠岐の島",
+        "manhole_count": 1
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "エルレイド",
+        "label": "エルレイド",
+        "pokemon": [
+          "エルレイド"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "オムスター",
+        "label": "オムスター",
+        "pokemon": [
+          "オムスター"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "サザンドラ",
+        "label": "サザンドラ",
+        "pokemon": [
+          "サザンドラ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "デデンネ",
+        "label": "デデンネ",
+        "pokemon": [
+          "デデンネ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ドジョッチ",
+        "label": "ドジョッチ",
+        "pokemon": [
+          "ドジョッチ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "バリヤード",
+        "label": "バリヤード",
+        "pokemon": [
+          "バリヤード"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "マッギョ",
+        "label": "マッギョ",
+        "pokemon": [
+          "マッギョ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ミミロップ",
+        "label": "ミミロップ",
+        "pokemon": [
+          "ミミロップ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ラブカス",
+        "label": "ラブカス",
+        "pokemon": [
+          "ラブカス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      },
+      {
+        "id": "ワッカネズミ",
+        "label": "ワッカネズミ",
+        "pokemon": [
+          "ワッカネズミ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 20.0
+      }
+    ],
+    "trivia": []
+  },
+  {
+    "prefecture": "岡山県",
+    "manhole_count": 4,
+    "municipality_count": 1,
+    "municipalities": [
+      "倉敷"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "倉敷",
+        "manhole_count": 4
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "アゲハント",
+        "label": "アゲハント",
+        "pokemon": [
+          "アゲハント"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 25.0
+      },
+      {
+        "id": "ケンホロウ",
+        "label": "ケンホロウ",
+        "pokemon": [
+          "ケンホロウ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 25.0
+      },
+      {
+        "id": "サルノリ",
+        "label": "サルノリ",
+        "pokemon": [
+          "サルノリ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 25.0
+      },
+      {
+        "id": "ポチエナ",
+        "label": "ポチエナ",
+        "pokemon": [
+          "ポチエナ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 25.0
+      },
+      {
+        "id": "ルカリオ",
+        "label": "ルカリオ",
+        "pokemon": [
+          "ルカリオ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 25.0
+      },
+      {
+        "id": "ワタシラガ",
+        "label": "ワタシラガ",
+        "pokemon": [
+          "ワタシラガ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 25.0
+      }
+    ],
+    "trivia": [
+      {
+        "id": "岡山県-single-municipality",
+        "type": "single_municipality",
+        "text": "県内4枚のポケふたはすべて倉敷にあります",
+        "source_type": "dataset"
+      }
+    ]
+  },
+  {
+    "prefecture": "広島県",
+    "manhole_count": 0,
+    "municipality_count": 0,
+    "municipalities": [],
+    "municipality_distribution": [],
+    "pokemon_coverage": [],
+    "trivia": []
+  },
+  {
+    "prefecture": "山口県",
+    "manhole_count": 4,
+    "municipality_count": 1,
+    "municipalities": [
+      "下関"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "下関",
+        "manhole_count": 4
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "アーボ",
+        "label": "アーボ",
+        "pokemon": [
+          "アーボ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 25.0
+      },
+      {
+        "id": "エンペルト",
+        "label": "エンペルト",
+        "pokemon": [
+          "エンペルト"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 25.0
+      },
+      {
+        "id": "チョンチー",
+        "label": "チョンチー",
+        "pokemon": [
+          "チョンチー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 25.0
+      },
+      {
+        "id": "ドガース",
+        "label": "ドガース",
+        "pokemon": [
+          "ドガース"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 25.0
+      },
+      {
+        "id": "ハリーセン",
+        "label": "ハリーセン",
+        "pokemon": [
+          "ハリーセン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 25.0
+      },
+      {
+        "id": "ホエルコ",
+        "label": "ホエルコ",
+        "pokemon": [
+          "ホエルコ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 25.0
+      }
+    ],
+    "trivia": [
+      {
+        "id": "山口県-single-municipality",
+        "type": "single_municipality",
+        "text": "県内4枚のポケふたはすべて下関にあります",
+        "source_type": "dataset"
+      }
+    ]
+  },
+  {
+    "prefecture": "徳島県",
+    "manhole_count": 3,
+    "municipality_count": 1,
+    "municipalities": [
+      "鳴門"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "鳴門",
+        "manhole_count": 3
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "キングドラ",
+        "label": "キングドラ",
+        "pokemon": [
+          "キングドラ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 33.3
+      },
+      {
+        "id": "シードラ",
+        "label": "シードラ",
+        "pokemon": [
+          "シードラ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 33.3
+      },
+      {
+        "id": "スイクン",
+        "label": "スイクン",
+        "pokemon": [
+          "スイクン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 33.3
+      },
+      {
+        "id": "ディグダ",
+        "label": "ディグダ",
+        "pokemon": [
+          "ディグダ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 33.3
+      },
+      {
+        "id": "ニョロゾ",
+        "label": "ニョロゾ",
+        "pokemon": [
+          "ニョロゾ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 33.3
+      },
+      {
+        "id": "ニョロモ",
+        "label": "ニョロモ",
+        "pokemon": [
+          "ニョロモ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 33.3
+      }
+    ],
+    "trivia": [
+      {
+        "id": "徳島県-single-municipality",
+        "type": "single_municipality",
+        "text": "県内3枚のポケふたはすべて鳴門にあります",
+        "source_type": "dataset"
+      }
+    ]
+  },
+  {
+    "prefecture": "香川県",
+    "manhole_count": 18,
+    "municipality_count": 17,
+    "municipalities": [
+      "さぬき",
+      "まんのう",
+      "三木",
+      "三豊",
+      "丸亀",
+      "善通寺",
+      "土庄",
+      "坂出",
+      "多度津",
+      "宇多津",
+      "小豆島",
+      "東かがわ",
+      "琴平",
+      "直島",
+      "綾川",
+      "観音寺",
+      "高松"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "綾川",
+        "manhole_count": 2
+      },
+      {
+        "municipality": "さぬき",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "まんのう",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "三木",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "三豊",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "丸亀",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "善通寺",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "土庄",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "坂出",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "多度津",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "宇多津",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "小豆島",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "東かがわ",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "琴平",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "直島",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "観音寺",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "高松",
+        "manhole_count": 1
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "ヤドン",
+        "label": "ヤドン",
+        "pokemon": [
+          "ヤドン"
+        ],
+        "cover_count": 17,
+        "coverage_percent": 94.4
+      },
+      {
+        "id": "ガラルヤドン",
+        "label": "ガラルヤドン",
+        "pokemon": [
+          "ガラルヤドン"
+        ],
+        "cover_count": 2,
+        "coverage_percent": 11.1
+      },
+      {
+        "id": "シェルダー",
+        "label": "シェルダー",
+        "pokemon": [
+          "シェルダー"
+        ],
+        "cover_count": 2,
+        "coverage_percent": 11.1
+      },
+      {
+        "id": "コイキング",
+        "label": "コイキング",
+        "pokemon": [
+          "コイキング"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.6
+      },
+      {
+        "id": "ヌオー",
+        "label": "ヌオー",
+        "pokemon": [
+          "ヌオー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.6
+      },
+      {
+        "id": "ピッピ",
+        "label": "ピッピ",
+        "pokemon": [
+          "ピッピ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.6
+      },
+      {
+        "id": "メタモン",
+        "label": "メタモン",
+        "pokemon": [
+          "メタモン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.6
+      },
+      {
+        "id": "ヤドキング",
+        "label": "ヤドキング",
+        "pokemon": [
+          "ヤドキング"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.6
+      },
+      {
+        "id": "ヤドラン",
+        "label": "ヤドラン",
+        "pokemon": [
+          "ヤドラン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.6
+      }
+    ],
+    "trivia": [
+      {
+        "id": "kagawa-slowpoke-wordplay",
+        "type": "wordplay",
+        "text": "香川県では「うどん」と音の響きが似ているヤドンが推しポケモンです",
+        "source_type": "official",
+        "source_url": "https://local.pokemon.jp/municipality/kagawa/",
+        "source_label": "ポケモンローカルActs",
+        "verified_at": "2026-06-13"
+      },
+      {
+        "id": "香川県-top-pokemon",
+        "type": "top_pokemon",
+        "text": "最も多く登場するのはヤドンで、17枚に描かれています",
+        "source_type": "dataset"
+      }
+    ]
+  },
+  {
+    "prefecture": "愛媛県",
+    "manhole_count": 2,
+    "municipality_count": 1,
+    "municipalities": [
+      "松山"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "松山",
+        "manhole_count": 2
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "アマカジ",
+        "label": "アマカジ",
+        "pokemon": [
+          "アマカジ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 50.0
+      },
+      {
+        "id": "アマージョ",
+        "label": "アマージョ",
+        "pokemon": [
+          "アマージョ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 50.0
+      },
+      {
+        "id": "シュバルゴ",
+        "label": "シュバルゴ",
+        "pokemon": [
+          "シュバルゴ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 50.0
+      },
+      {
+        "id": "ネギガナイト",
+        "label": "ネギガナイト",
+        "pokemon": [
+          "ネギガナイト"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 50.0
+      }
+    ],
+    "trivia": [
+      {
+        "id": "愛媛県-single-municipality",
+        "type": "single_municipality",
+        "text": "県内2枚のポケふたはすべて松山にあります",
+        "source_type": "dataset"
+      }
+    ]
+  },
+  {
+    "prefecture": "高知県",
+    "manhole_count": 18,
+    "municipality_count": 18,
+    "municipalities": [
+      "三原",
+      "仁淀川",
+      "土佐清水",
+      "大月",
+      "大豊",
+      "奈半利",
+      "安田",
+      "安芸",
+      "室戸",
+      "宿毛",
+      "日高",
+      "本山",
+      "東洋",
+      "津野",
+      "須崎",
+      "香南",
+      "香美",
+      "高知"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "三原",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "仁淀川",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "土佐清水",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "大月",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "大豊",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "奈半利",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "安田",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "安芸",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "室戸",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "宿毛",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "日高",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "本山",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "東洋",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "津野",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "須崎",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "香南",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "香美",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "高知",
+        "manhole_count": 1
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "ヌオー",
+        "label": "ヌオー",
+        "pokemon": [
+          "ヌオー"
+        ],
+        "cover_count": 18,
+        "coverage_percent": 100.0
+      },
+      {
+        "id": "アメタマ",
+        "label": "アメタマ",
+        "pokemon": [
+          "アメタマ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.6
+      },
+      {
+        "id": "アメモース",
+        "label": "アメモース",
+        "pokemon": [
+          "アメモース"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.6
+      },
+      {
+        "id": "ウパー",
+        "label": "ウパー",
+        "pokemon": [
+          "ウパー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.6
+      },
+      {
+        "id": "カラナクシ",
+        "label": "カラナクシ",
+        "pokemon": [
+          "カラナクシ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.6
+      },
+      {
+        "id": "ケイコウオ",
+        "label": "ケイコウオ",
+        "pokemon": [
+          "ケイコウオ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.6
+      },
+      {
+        "id": "コジオ",
+        "label": "コジオ",
+        "pokemon": [
+          "コジオ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.6
+      },
+      {
+        "id": "コマタナ",
+        "label": "コマタナ",
+        "pokemon": [
+          "コマタナ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.6
+      },
+      {
+        "id": "サニーゴ",
+        "label": "サニーゴ",
+        "pokemon": [
+          "サニーゴ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.6
+      },
+      {
+        "id": "シズクモ",
+        "label": "シズクモ",
+        "pokemon": [
+          "シズクモ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.6
+      },
+      {
+        "id": "シビシラス",
+        "label": "シビシラス",
+        "pokemon": [
+          "シビシラス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.6
+      },
+      {
+        "id": "チルタリス",
+        "label": "チルタリス",
+        "pokemon": [
+          "チルタリス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.6
+      },
+      {
+        "id": "トサキント",
+        "label": "トサキント",
+        "pokemon": [
+          "トサキント"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.6
+      },
+      {
+        "id": "ドオー",
+        "label": "ドオー",
+        "pokemon": [
+          "ドオー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.6
+      },
+      {
+        "id": "ノクタス",
+        "label": "ノクタス",
+        "pokemon": [
+          "ノクタス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.6
+      },
+      {
+        "id": "ピィ",
+        "label": "ピィ",
+        "pokemon": [
+          "ピィ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.6
+      },
+      {
+        "id": "フィオネ",
+        "label": "フィオネ",
+        "pokemon": [
+          "フィオネ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.6
+      },
+      {
+        "id": "フローゼル",
+        "label": "フローゼル",
+        "pokemon": [
+          "フローゼル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.6
+      },
+      {
+        "id": "ブイゼル",
+        "label": "ブイゼル",
+        "pokemon": [
+          "ブイゼル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.6
+      },
+      {
+        "id": "ホーホー",
+        "label": "ホーホー",
+        "pokemon": [
+          "ホーホー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.6
+      },
+      {
+        "id": "マンタイン",
+        "label": "マンタイン",
+        "pokemon": [
+          "マンタイン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.6
+      },
+      {
+        "id": "メタモン",
+        "label": "メタモン",
+        "pokemon": [
+          "メタモン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.6
+      },
+      {
+        "id": "メッソン",
+        "label": "メッソン",
+        "pokemon": [
+          "メッソン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.6
+      },
+      {
+        "id": "モノズ",
+        "label": "モノズ",
+        "pokemon": [
+          "モノズ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.6
+      },
+      {
+        "id": "ヤンヤンマ",
+        "label": "ヤンヤンマ",
+        "pokemon": [
+          "ヤンヤンマ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.6
+      },
+      {
+        "id": "リリーラ",
+        "label": "リリーラ",
+        "pokemon": [
+          "リリーラ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.6
+      }
+    ],
+    "trivia": [
+      {
+        "id": "kochi-support-quagsire",
+        "type": "support_pokemon",
+        "text": "高知県では、水辺に生息するヌオーがこうちだいすきポケモンとして活動しています",
+        "source_type": "official",
+        "source_url": "https://local.pokemon.jp/municipality/kochi/",
+        "source_label": "ポケモンローカルActs",
+        "verified_at": "2026-06-13"
+      },
+      {
+        "id": "高知県-ヌオー-100",
+        "type": "pokemon_100",
+        "text": "県内18枚すべてにヌオーが登場します",
+        "source_type": "dataset"
+      }
+    ]
+  },
+  {
+    "prefecture": "福岡県",
+    "manhole_count": 8,
+    "municipality_count": 2,
+    "municipalities": [
+      "北九州",
+      "太宰府"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "北九州",
+        "manhole_count": 5
+      },
+      {
+        "municipality": "太宰府",
+        "manhole_count": 3
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "アローラダグトリオ",
+        "label": "アローラダグトリオ",
+        "pokemon": [
+          "アローラダグトリオ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 12.5
+      },
+      {
+        "id": "キルリア",
+        "label": "キルリア",
+        "pokemon": [
+          "キルリア"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 12.5
+      },
+      {
+        "id": "ギルガルド",
+        "label": "ギルガルド",
+        "pokemon": [
+          "ギルガルド"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 12.5
+      },
+      {
+        "id": "サーナイト",
+        "label": "サーナイト",
+        "pokemon": [
+          "サーナイト"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 12.5
+      },
+      {
+        "id": "ジュラルドン",
+        "label": "ジュラルドン",
+        "pokemon": [
+          "ジュラルドン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 12.5
+      },
+      {
+        "id": "トロッゴン",
+        "label": "トロッゴン",
+        "pokemon": [
+          "トロッゴン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 12.5
+      },
+      {
+        "id": "トロピウス",
+        "label": "トロピウス",
+        "pokemon": [
+          "トロピウス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 12.5
+      },
+      {
+        "id": "フーディン",
+        "label": "フーディン",
+        "pokemon": [
+          "フーディン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 12.5
+      },
+      {
+        "id": "ボスゴドラ",
+        "label": "ボスゴドラ",
+        "pokemon": [
+          "ボスゴドラ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 12.5
+      },
+      {
+        "id": "メブキジカ",
+        "label": "メブキジカ",
+        "pokemon": [
+          "メブキジカ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 12.5
+      },
+      {
+        "id": "ヤドキング",
+        "label": "ヤドキング",
+        "pokemon": [
+          "ヤドキング"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 12.5
+      },
+      {
+        "id": "ヤミラミ",
+        "label": "ヤミラミ",
+        "pokemon": [
+          "ヤミラミ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 12.5
+      },
+      {
+        "id": "ヤヤコマ",
+        "label": "ヤヤコマ",
+        "pokemon": [
+          "ヤヤコマ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 12.5
+      },
+      {
+        "id": "ヤレユータン",
+        "label": "ヤレユータン",
+        "pokemon": [
+          "ヤレユータン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 12.5
+      },
+      {
+        "id": "ルナトーン",
+        "label": "ルナトーン",
+        "pokemon": [
+          "ルナトーン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 12.5
+      }
+    ],
+    "trivia": [
+      {
+        "id": "福岡県-municipality-concentration",
+        "type": "municipality_concentration",
+        "text": "最多は北九州の5枚で、次いで太宰府の3枚です",
+        "source_type": "dataset"
+      }
+    ]
+  },
+  {
+    "prefecture": "佐賀県",
+    "manhole_count": 3,
+    "municipality_count": 1,
+    "municipalities": [
+      "佐賀"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "佐賀",
+        "manhole_count": 3
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "アローラニャース",
+        "label": "アローラニャース",
+        "pokemon": [
+          "アローラニャース"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 33.3
+      },
+      {
+        "id": "ガラルニャース",
+        "label": "ガラルニャース",
+        "pokemon": [
+          "ガラルニャース"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 33.3
+      },
+      {
+        "id": "ニャース",
+        "label": "ニャース",
+        "pokemon": [
+          "ニャース"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 33.3
+      },
+      {
+        "id": "meowth-forms",
+        "label": "ニャース3種",
+        "pokemon": [
+          "ニャース",
+          "アローラニャース",
+          "ガラルニャース"
+        ],
+        "cover_count": 3,
+        "coverage_percent": 100.0
+      }
+    ],
+    "trivia": [
+      {
+        "id": "佐賀県-single-municipality",
+        "type": "single_municipality",
+        "text": "県内3枚のポケふたはすべて佐賀にあります",
+        "source_type": "dataset"
+      },
+      {
+        "id": "佐賀県-meowth-forms-100",
+        "type": "pokemon_group_100",
+        "text": "県内3枚すべてにニャース3種が登場します",
+        "source_type": "dataset"
+      }
+    ]
+  },
+  {
     "prefecture": "長崎県",
-    "pokemon": "デンリュウ",
-    "count": 10,
-    "title": "長崎県の応援ポケモンはデンリュウ",
-    "summary": "「灯台のポケモン」デンリュウが選ばれた長崎。港町・長崎の灯台文化と重なり、県内10枚すべてにデンリュウが登場します。",
-    "status": "ongoing",
-    "source_url": "https://local.pokemon.jp/",
-    "map_pref": "長崎県",
-    "manhole_ids": [],
-    "links": []
+    "manhole_count": 10,
+    "municipality_count": 10,
+    "municipalities": [
+      "佐々",
+      "佐世保",
+      "壱岐",
+      "大",
+      "島原",
+      "新上五島",
+      "時津",
+      "東彼杵",
+      "長崎",
+      "雲仙"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "佐々",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "佐世保",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "壱岐",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "大",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "島原",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "新上五島",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "時津",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "東彼杵",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "長崎",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "雲仙",
+        "manhole_count": 1
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "デンリュウ",
+        "label": "デンリュウ",
+        "pokemon": [
+          "デンリュウ"
+        ],
+        "cover_count": 10,
+        "coverage_percent": 100.0
+      },
+      {
+        "id": "イキリンコ",
+        "label": "イキリンコ",
+        "pokemon": [
+          "イキリンコ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 10.0
+      },
+      {
+        "id": "イルカマン",
+        "label": "イルカマン",
+        "pokemon": [
+          "イルカマン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 10.0
+      },
+      {
+        "id": "オタチ",
+        "label": "オタチ",
+        "pokemon": [
+          "オタチ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 10.0
+      },
+      {
+        "id": "キモリ",
+        "label": "キモリ",
+        "pokemon": [
+          "キモリ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 10.0
+      },
+      {
+        "id": "キャモメ",
+        "label": "キャモメ",
+        "pokemon": [
+          "キャモメ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 10.0
+      },
+      {
+        "id": "コータス",
+        "label": "コータス",
+        "pokemon": [
+          "コータス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 10.0
+      },
+      {
+        "id": "ゴローン",
+        "label": "ゴローン",
+        "pokemon": [
+          "ゴローン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 10.0
+      },
+      {
+        "id": "シビシラス",
+        "label": "シビシラス",
+        "pokemon": [
+          "シビシラス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 10.0
+      },
+      {
+        "id": "シビビール",
+        "label": "シビビール",
+        "pokemon": [
+          "シビビール"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 10.0
+      },
+      {
+        "id": "ジュペッタ",
+        "label": "ジュペッタ",
+        "pokemon": [
+          "ジュペッタ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 10.0
+      },
+      {
+        "id": "タマザラシ",
+        "label": "タマザラシ",
+        "pokemon": [
+          "タマザラシ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 10.0
+      },
+      {
+        "id": "チェリム",
+        "label": "チェリム",
+        "pokemon": [
+          "チェリム"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 10.0
+      },
+      {
+        "id": "トゲピー",
+        "label": "トゲピー",
+        "pokemon": [
+          "トゲピー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 10.0
+      },
+      {
+        "id": "ドレディア",
+        "label": "ドレディア",
+        "pokemon": [
+          "ドレディア"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 10.0
+      },
+      {
+        "id": "ノズパス",
+        "label": "ノズパス",
+        "pokemon": [
+          "ノズパス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 10.0
+      },
+      {
+        "id": "バクーダ",
+        "label": "バクーダ",
+        "pokemon": [
+          "バクーダ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 10.0
+      },
+      {
+        "id": "ヒラヒナ",
+        "label": "ヒラヒナ",
+        "pokemon": [
+          "ヒラヒナ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 10.0
+      },
+      {
+        "id": "ホーホー",
+        "label": "ホーホー",
+        "pokemon": [
+          "ホーホー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 10.0
+      },
+      {
+        "id": "ワタッコ",
+        "label": "ワタッコ",
+        "pokemon": [
+          "ワタッコ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 10.0
+      }
+    ],
+    "trivia": [
+      {
+        "id": "nagasaki-support-ampharos",
+        "type": "support_pokemon",
+        "text": "長崎県では、尻尾の光が遠くまで届くデンリュウがながさき未来応援ポケモンを務めています",
+        "source_type": "official",
+        "source_url": "https://local.pokemon.jp/municipality/nagasaki/",
+        "source_label": "ポケモンローカルActs",
+        "verified_at": "2026-06-13"
+      },
+      {
+        "id": "長崎県-デンリュウ-100",
+        "type": "pokemon_100",
+        "text": "県内10枚すべてにデンリュウが登場します",
+        "source_type": "dataset"
+      }
+    ]
   },
   {
-    "id": "miyazaki-exeggutor",
+    "prefecture": "熊本県",
+    "manhole_count": 0,
+    "municipality_count": 0,
+    "municipalities": [],
+    "municipality_distribution": [],
+    "pokemon_coverage": [],
+    "trivia": []
+  },
+  {
+    "prefecture": "大分県",
+    "manhole_count": 0,
+    "municipality_count": 0,
+    "municipalities": [],
+    "municipality_distribution": [],
+    "pokemon_coverage": [],
+    "trivia": []
+  },
+  {
     "prefecture": "宮崎県",
-    "pokemon": "ナッシー",
-    "count": 18,
-    "title": "宮崎県の応援ポケモンはナッシー",
-    "summary": "温暖な南国・宮崎の雰囲気にぴったりのナッシー。県木のフェニックス（ヤシ科）とも相性抜群で、南国感あふれる設置地点が多いです。",
-    "status": "ongoing",
-    "source_url": "https://local.pokemon.jp/",
-    "map_pref": "宮崎県",
-    "manhole_ids": [],
-    "links": []
+    "manhole_count": 26,
+    "municipality_count": 26,
+    "municipalities": [
+      "えびの",
+      "三股",
+      "串間",
+      "五ヶ瀬",
+      "国富",
+      "宮崎",
+      "小林",
+      "川南",
+      "延岡",
+      "新富",
+      "日之影",
+      "日南",
+      "日向",
+      "木城",
+      "椎葉",
+      "綾",
+      "美郷",
+      "西米良",
+      "西都",
+      "諸塚",
+      "都城",
+      "都農",
+      "門川",
+      "高千穂",
+      "高原",
+      "高鍋"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "えびの",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "三股",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "串間",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "五ヶ瀬",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "国富",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "宮崎",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "小林",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "川南",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "延岡",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "新富",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "日之影",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "日南",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "日向",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "木城",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "椎葉",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "綾",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "美郷",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "西米良",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "西都",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "諸塚",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "都城",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "都農",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "門川",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "高千穂",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "高原",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "高鍋",
+        "manhole_count": 1
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "ナッシー",
+        "label": "ナッシー",
+        "pokemon": [
+          "ナッシー"
+        ],
+        "cover_count": 18,
+        "coverage_percent": 69.2
+      },
+      {
+        "id": "アローラナッシー",
+        "label": "アローラナッシー",
+        "pokemon": [
+          "アローラナッシー"
+        ],
+        "cover_count": 9,
+        "coverage_percent": 34.6
+      },
+      {
+        "id": "アローラライチュウ",
+        "label": "アローラライチュウ",
+        "pokemon": [
+          "アローラライチュウ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.8
+      },
+      {
+        "id": "オドリドリ",
+        "label": "オドリドリ",
+        "pokemon": [
+          "オドリドリ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.8
+      },
+      {
+        "id": "ガラルポニータ",
+        "label": "ガラルポニータ",
+        "pokemon": [
+          "ガラルポニータ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.8
+      },
+      {
+        "id": "キマワリ",
+        "label": "キマワリ",
+        "pokemon": [
+          "キマワリ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.8
+      },
+      {
+        "id": "コロモリ",
+        "label": "コロモリ",
+        "pokemon": [
+          "コロモリ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.8
+      },
+      {
+        "id": "コータス",
+        "label": "コータス",
+        "pokemon": [
+          "コータス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.8
+      },
+      {
+        "id": "ゴクリン",
+        "label": "ゴクリン",
+        "pokemon": [
+          "ゴクリン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.8
+      },
+      {
+        "id": "ゴルーグ",
+        "label": "ゴルーグ",
+        "pokemon": [
+          "ゴルーグ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.8
+      },
+      {
+        "id": "シンボラー",
+        "label": "シンボラー",
+        "pokemon": [
+          "シンボラー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.8
+      },
+      {
+        "id": "タマタマ",
+        "label": "タマタマ",
+        "pokemon": [
+          "タマタマ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.8
+      },
+      {
+        "id": "ダイノーズ",
+        "label": "ダイノーズ",
+        "pokemon": [
+          "ダイノーズ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.8
+      },
+      {
+        "id": "ナマケロ",
+        "label": "ナマケロ",
+        "pokemon": [
+          "ナマケロ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.8
+      },
+      {
+        "id": "ヌマクロー",
+        "label": "ヌマクロー",
+        "pokemon": [
+          "ヌマクロー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.8
+      },
+      {
+        "id": "ブイゼル",
+        "label": "ブイゼル",
+        "pokemon": [
+          "ブイゼル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.8
+      },
+      {
+        "id": "ポワルン",
+        "label": "ポワルン",
+        "pokemon": [
+          "ポワルン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.8
+      },
+      {
+        "id": "マクノシタ",
+        "label": "マクノシタ",
+        "pokemon": [
+          "マクノシタ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.8
+      },
+      {
+        "id": "マケンカニ",
+        "label": "マケンカニ",
+        "pokemon": [
+          "マケンカニ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.8
+      },
+      {
+        "id": "ムチュール",
+        "label": "ムチュール",
+        "pokemon": [
+          "ムチュール"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.8
+      },
+      {
+        "id": "メタモン",
+        "label": "メタモン",
+        "pokemon": [
+          "メタモン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.8
+      },
+      {
+        "id": "メテノ",
+        "label": "メテノ",
+        "pokemon": [
+          "メテノ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.8
+      },
+      {
+        "id": "モクロー",
+        "label": "モクロー",
+        "pokemon": [
+          "モクロー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.8
+      },
+      {
+        "id": "レジアイス",
+        "label": "レジアイス",
+        "pokemon": [
+          "レジアイス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.8
+      },
+      {
+        "id": "レジギガス",
+        "label": "レジギガス",
+        "pokemon": [
+          "レジギガス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.8
+      },
+      {
+        "id": "レジスチル",
+        "label": "レジスチル",
+        "pokemon": [
+          "レジスチル"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.8
+      },
+      {
+        "id": "レジロック",
+        "label": "レジロック",
+        "pokemon": [
+          "レジロック"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 3.8
+      },
+      {
+        "id": "exeggutor-family",
+        "label": "ナッシー系",
+        "pokemon": [
+          "ナッシー",
+          "アローラナッシー"
+        ],
+        "cover_count": 26,
+        "coverage_percent": 100.0
+      }
+    ],
+    "trivia": [
+      {
+        "id": "miyazaki-support-exeggutor",
+        "type": "support_pokemon",
+        "text": "南国のイメージに合うナッシーとアローラナッシーが、宮崎だいすきポケモンとして活動しています",
+        "source_type": "official",
+        "source_url": "https://local.pokemon.jp/municipality/miyazaki/",
+        "source_label": "ポケモンローカルActs",
+        "verified_at": "2026-06-13"
+      },
+      {
+        "id": "宮崎県-exeggutor-family-100",
+        "type": "pokemon_group_100",
+        "text": "県内26枚すべてにナッシー系が登場します",
+        "source_type": "dataset"
+      }
+    ]
   },
   {
-    "id": "okinawa-growlithe",
+    "prefecture": "鹿児島県",
+    "manhole_count": 9,
+    "municipality_count": 1,
+    "municipalities": [
+      "指宿"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "指宿",
+        "manhole_count": 9
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "イーブイ",
+        "label": "イーブイ",
+        "pokemon": [
+          "イーブイ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 11.1
+      },
+      {
+        "id": "エーフィ",
+        "label": "エーフィ",
+        "pokemon": [
+          "エーフィ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 11.1
+      },
+      {
+        "id": "グレイシア",
+        "label": "グレイシア",
+        "pokemon": [
+          "グレイシア"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 11.1
+      },
+      {
+        "id": "サンダース",
+        "label": "サンダース",
+        "pokemon": [
+          "サンダース"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 11.1
+      },
+      {
+        "id": "シャワーズ",
+        "label": "シャワーズ",
+        "pokemon": [
+          "シャワーズ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 11.1
+      },
+      {
+        "id": "ニンフィア",
+        "label": "ニンフィア",
+        "pokemon": [
+          "ニンフィア"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 11.1
+      },
+      {
+        "id": "ブラッキー",
+        "label": "ブラッキー",
+        "pokemon": [
+          "ブラッキー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 11.1
+      },
+      {
+        "id": "ブースター",
+        "label": "ブースター",
+        "pokemon": [
+          "ブースター"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 11.1
+      },
+      {
+        "id": "リーフィア",
+        "label": "リーフィア",
+        "pokemon": [
+          "リーフィア"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 11.1
+      }
+    ],
+    "trivia": [
+      {
+        "id": "kagoshima-ibusuki-eevee",
+        "type": "wordplay",
+        "text": "「イーブイすき」と「いぶすき」の語呂合わせをきっかけに、指宿へイーブイのポケふたが設置されました",
+        "source_type": "official",
+        "source_url": "https://www.city.ibusuki.lg.jp/main/info/page014900.html",
+        "source_label": "指宿市",
+        "verified_at": "2026-06-13"
+      },
+      {
+        "id": "鹿児島県-single-municipality",
+        "type": "single_municipality",
+        "text": "県内9枚のポケふたはすべて指宿にあります",
+        "source_type": "dataset"
+      }
+    ]
+  },
+  {
     "prefecture": "沖縄県",
-    "pokemon": "ガーディ",
-    "count": 5,
-    "title": "沖縄県の応援ポケモンはガーディ",
-    "summary": "沖縄の守り神・シーサーを思わせるガーディ。魔除けの獅子犬と炎のポケモンのイメージが重なり、県内各地に設置されています。",
-    "status": "ongoing",
-    "source_url": "https://local.pokemon.jp/",
-    "map_pref": "沖縄県",
-    "manhole_ids": [],
-    "links": []
+    "manhole_count": 17,
+    "municipality_count": 16,
+    "municipalities": [
+      "うるま",
+      "久米島",
+      "北谷",
+      "南城",
+      "名護",
+      "宜野湾",
+      "宮古島",
+      "座間味",
+      "本部",
+      "沖縄",
+      "浦添",
+      "渡嘉敷",
+      "石垣",
+      "糸満",
+      "豊見城",
+      "那覇"
+    ],
+    "municipality_distribution": [
+      {
+        "municipality": "那覇",
+        "manhole_count": 2
+      },
+      {
+        "municipality": "うるま",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "久米島",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "北谷",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "南城",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "名護",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "宜野湾",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "宮古島",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "座間味",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "本部",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "沖縄",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "浦添",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "渡嘉敷",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "石垣",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "糸満",
+        "manhole_count": 1
+      },
+      {
+        "municipality": "豊見城",
+        "manhole_count": 1
+      }
+    ],
+    "pokemon_coverage": [
+      {
+        "id": "ガーディ",
+        "label": "ガーディ",
+        "pokemon": [
+          "ガーディ"
+        ],
+        "cover_count": 5,
+        "coverage_percent": 29.4
+      },
+      {
+        "id": "ウインディ",
+        "label": "ウインディ",
+        "pokemon": [
+          "ウインディ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "ウデッポウ",
+        "label": "ウデッポウ",
+        "pokemon": [
+          "ウデッポウ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "エモンガ",
+        "label": "エモンガ",
+        "pokemon": [
+          "エモンガ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "カイオーガ",
+        "label": "カイオーガ",
+        "pokemon": [
+          "カイオーガ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "カメール",
+        "label": "カメール",
+        "pokemon": [
+          "カメール"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "キバゴ",
+        "label": "キバゴ",
+        "pokemon": [
+          "キバゴ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "ケンタロス",
+        "label": "ケンタロス",
+        "pokemon": [
+          "ケンタロス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "サニーゴ",
+        "label": "サニーゴ",
+        "pokemon": [
+          "サニーゴ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "ザングース",
+        "label": "ザングース",
+        "pokemon": [
+          "ザングース"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "ジャラコ",
+        "label": "ジャラコ",
+        "pokemon": [
+          "ジャラコ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "スナバァ",
+        "label": "スナバァ",
+        "pokemon": [
+          "スナバァ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "ソルロック",
+        "label": "ソルロック",
+        "pokemon": [
+          "ソルロック"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "ツツケラ",
+        "label": "ツツケラ",
+        "pokemon": [
+          "ツツケラ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "テッポウオ",
+        "label": "テッポウオ",
+        "pokemon": [
+          "テッポウオ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "ハブネーク",
+        "label": "ハブネーク",
+        "pokemon": [
+          "ハブネーク"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "バチンキー",
+        "label": "バチンキー",
+        "pokemon": [
+          "バチンキー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "ホエルオー",
+        "label": "ホエルオー",
+        "pokemon": [
+          "ホエルオー"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "ホエルコ",
+        "label": "ホエルコ",
+        "pokemon": [
+          "ホエルコ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "ポポッコ",
+        "label": "ポポッコ",
+        "pokemon": [
+          "ポポッコ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "マンタイン",
+        "label": "マンタイン",
+        "pokemon": [
+          "マンタイン"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "ヤトウモリ",
+        "label": "ヤトウモリ",
+        "pokemon": [
+          "ヤトウモリ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "ラブカス",
+        "label": "ラブカス",
+        "pokemon": [
+          "ラブカス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "ラランテス",
+        "label": "ラランテス",
+        "pokemon": [
+          "ラランテス"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      },
+      {
+        "id": "ルリリ",
+        "label": "ルリリ",
+        "pokemon": [
+          "ルリリ"
+        ],
+        "cover_count": 1,
+        "coverage_percent": 5.9
+      }
+    ],
+    "trivia": [
+      {
+        "id": "okinawa-support-growlithe",
+        "type": "support_pokemon",
+        "text": "沖縄県では、シーサーを思わせるガーディが沖縄応援ポケモンとして活動しています",
+        "source_type": "official",
+        "source_url": "https://local.pokemon.jp/municipality/okinawa/",
+        "source_label": "ポケモンローカルActs",
+        "verified_at": "2026-06-13"
+      },
+      {
+        "id": "沖縄県-top-pokemon",
+        "type": "top_pokemon",
+        "text": "最も多く登場するのはガーディで、5枚に描かれています",
+        "source_type": "dataset"
+      }
+    ]
   }
 ]

--- a/dataset/prefecture_trivia_sources.json
+++ b/dataset/prefecture_trivia_sources.json
@@ -1,0 +1,167 @@
+{
+  "_doc": "都道府県トリビアの手動マスタ。件数・自治体数・出現率は書かず、公式情報で確認した由来だけを管理する。",
+  "version": 1,
+  "pokemon_groups": [
+    {
+      "id": "vulpix-family",
+      "prefecture": "北海道",
+      "label": "ロコン系",
+      "pokemon": ["ロコン", "アローラロコン"]
+    },
+    {
+      "id": "sandshrew-family",
+      "prefecture": "鳥取県",
+      "label": "サンド系",
+      "pokemon": ["サンド", "アローラサンド"]
+    },
+    {
+      "id": "meowth-forms",
+      "prefecture": "佐賀県",
+      "label": "ニャース3種",
+      "pokemon": ["ニャース", "アローラニャース", "ガラルニャース"]
+    },
+    {
+      "id": "exeggutor-family",
+      "prefecture": "宮崎県",
+      "label": "ナッシー系",
+      "pokemon": ["ナッシー", "アローラナッシー"]
+    }
+  ],
+  "editorial_trivia": [
+    {
+      "id": "tokyo-pokepark-kanto-admission",
+      "prefecture": "東京都",
+      "type": "local_connection",
+      "text": "稲城市のポケパーク カントー内にも1枚あり、見るにはポケパーク カントーへの入場が必要です",
+      "source_url": "https://local.pokemon.jp/manhole/desc/448/",
+      "source_label": "ポケふた公式",
+      "verified_at": "2026-06-13"
+    },
+    {
+      "id": "hokkaido-support-vulpix",
+      "prefecture": "北海道",
+      "type": "support_pokemon",
+      "text": "北海道の推しポケモンは、雪景色にもなじむアローラロコンとロコンです",
+      "source_url": "https://local.pokemon.jp/municipality/hokkaido/",
+      "source_label": "ポケモンローカルActs",
+      "verified_at": "2026-06-13"
+    },
+    {
+      "id": "iwate-geodude-wordplay",
+      "prefecture": "岩手県",
+      "type": "wordplay",
+      "text": "岩タイプで「岩」に「手」が付いたイシツブテが、いわて応援ポケモンを務めています",
+      "source_url": "https://local.pokemon.jp/municipality/iwate/",
+      "source_label": "ポケモンローカルActs",
+      "verified_at": "2026-06-13"
+    },
+    {
+      "id": "miyagi-support-lapras",
+      "prefecture": "宮城県",
+      "type": "support_pokemon",
+      "text": "宮城県ではラプラスがみやぎ応援ポケモンとして地域の魅力を発信しています",
+      "source_url": "https://local.pokemon.jp/municipality/miyagi/",
+      "source_label": "ポケモンローカルActs",
+      "verified_at": "2026-06-13"
+    },
+    {
+      "id": "fukushima-support-chansey",
+      "prefecture": "福島県",
+      "type": "support_pokemon",
+      "text": "福島県では、幸せを運ぶといわれるラッキーがふくしま応援ポケモンを務めています",
+      "source_url": "https://local.pokemon.jp/municipality/fukushima/",
+      "source_label": "ポケモンローカルActs",
+      "verified_at": "2026-06-13"
+    },
+    {
+      "id": "niigata-ojiya-koi",
+      "prefecture": "新潟県",
+      "type": "local_connection",
+      "text": "錦鯉発祥の地として知られる小千谷にちなみ、コイキングのポケふたが設置されています",
+      "source_url": "https://www.city.ojiya.niigata.jp/site/kanko/pokemon.html",
+      "source_label": "小千谷市",
+      "verified_at": "2026-06-13"
+    },
+    {
+      "id": "fukui-support-dragonite",
+      "prefecture": "福井県",
+      "type": "support_pokemon",
+      "text": "福井県ではカイリューがふくい応援ポケモンとして地域を盛り上げています",
+      "source_url": "https://local.pokemon.jp/municipality/fukui/",
+      "source_label": "ポケモンローカルActs",
+      "verified_at": "2026-06-13"
+    },
+    {
+      "id": "mie-support-oshawott",
+      "prefecture": "三重県",
+      "type": "support_pokemon",
+      "text": "三重県ではミジュマルがみえ応援ポケモンとして地域の魅力を発信しています",
+      "source_url": "https://local.pokemon.jp/municipality/mie/",
+      "source_label": "ポケモンローカルActs",
+      "verified_at": "2026-06-13"
+    },
+    {
+      "id": "tottori-sand",
+      "prefecture": "鳥取県",
+      "type": "local_connection",
+      "text": "鳥取砂丘をはじめ砂で知られる鳥取県では、サンドとアローラサンドが推しポケモンです",
+      "source_url": "https://local.pokemon.jp/municipality/tottori/",
+      "source_label": "ポケモンローカルActs",
+      "verified_at": "2026-06-13"
+    },
+    {
+      "id": "kagawa-slowpoke-wordplay",
+      "prefecture": "香川県",
+      "type": "wordplay",
+      "text": "香川県では「うどん」と音の響きが似ているヤドンが推しポケモンです",
+      "source_url": "https://local.pokemon.jp/municipality/kagawa/",
+      "source_label": "ポケモンローカルActs",
+      "verified_at": "2026-06-13"
+    },
+    {
+      "id": "kochi-support-quagsire",
+      "prefecture": "高知県",
+      "type": "support_pokemon",
+      "text": "高知県では、水辺に生息するヌオーがこうちだいすきポケモンとして活動しています",
+      "source_url": "https://local.pokemon.jp/municipality/kochi/",
+      "source_label": "ポケモンローカルActs",
+      "verified_at": "2026-06-13"
+    },
+    {
+      "id": "nagasaki-support-ampharos",
+      "prefecture": "長崎県",
+      "type": "support_pokemon",
+      "text": "長崎県では、尻尾の光が遠くまで届くデンリュウがながさき未来応援ポケモンを務めています",
+      "source_url": "https://local.pokemon.jp/municipality/nagasaki/",
+      "source_label": "ポケモンローカルActs",
+      "verified_at": "2026-06-13"
+    },
+    {
+      "id": "miyazaki-support-exeggutor",
+      "prefecture": "宮崎県",
+      "type": "support_pokemon",
+      "text": "南国のイメージに合うナッシーとアローラナッシーが、宮崎だいすきポケモンとして活動しています",
+      "source_url": "https://local.pokemon.jp/municipality/miyazaki/",
+      "source_label": "ポケモンローカルActs",
+      "verified_at": "2026-06-13"
+    },
+    {
+      "id": "kagoshima-ibusuki-eevee",
+      "prefecture": "鹿児島県",
+      "type": "wordplay",
+      "text": "「イーブイすき」と「いぶすき」の語呂合わせをきっかけに、指宿へイーブイのポケふたが設置されました",
+      "source_url": "https://www.city.ibusuki.lg.jp/main/info/page014900.html",
+      "source_label": "指宿市",
+      "verified_at": "2026-06-13"
+    },
+    {
+      "id": "okinawa-support-growlithe",
+      "prefecture": "沖縄県",
+      "type": "support_pokemon",
+      "text": "沖縄県では、シーサーを思わせるガーディが沖縄応援ポケモンとして活動しています",
+      "source_url": "https://local.pokemon.jp/municipality/okinawa/",
+      "source_label": "ポケモンローカルActs",
+      "verified_at": "2026-06-13"
+    }
+  ]
+}

--- a/docs/social-post-candidates.json
+++ b/docs/social-post-candidates.json
@@ -1109,2963 +1109,6 @@
     }
   },
   {
-    "id": "michineki-04003",
-    "type": "michineki",
-    "title": "道の駅三本木周辺のポケふた（3枚）",
-    "url": "https://it-social.net/roadside_station/?04003",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "04003",
-      "station_name": "道の駅三本木",
-      "pref": "宮城県",
-      "lat": 38.521611,
-      "lng": 140.938388,
-      "manhole_count": 3,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "124",
-          "title": "宮城県/大崎市",
-          "city": "大崎",
-          "pokemons": [
-            "オニスズメ",
-            "ダグトリオ"
-          ],
-          "dist_km": 6.08,
-          "lat": 38.571356,
-          "lng": 140.967465
-        },
-        {
-          "id": "136",
-          "title": "宮城県/色麻町",
-          "city": "色麻",
-          "pokemons": [
-            "ハスブレロ",
-            "ラプラス"
-          ],
-          "dist_km": 6.76,
-          "lat": 38.530136,
-          "lng": 140.86142
-        },
-        {
-          "id": "135",
-          "title": "宮城県/大衡村",
-          "city": "大衡",
-          "pokemons": [
-            "プルリル",
-            "ラブカス"
-          ],
-          "dist_km": 7.16,
-          "lat": 38.46943814,
-          "lng": 140.8902292
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-04006",
-    "type": "michineki",
-    "title": "道の駅おおさと周辺のポケふた（4枚）",
-    "url": "https://it-social.net/roadside_station/?04006",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "04006",
-      "station_name": "道の駅おおさと",
-      "pref": "宮城県",
-      "lat": 38.424053,
-      "lng": 140.992791,
-      "manhole_count": 4,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "134",
-          "title": "宮城県/大郷町",
-          "city": "大郷",
-          "pokemons": [
-            "チュリネ",
-            "ラプラス"
-          ],
-          "dist_km": 0.01,
-          "lat": 38.424016,
-          "lng": 140.992673
-        },
-        {
-          "id": "49",
-          "title": "宮城県/松島町",
-          "city": "松島",
-          "pokemons": [
-            "ラプラス"
-          ],
-          "dist_km": 8.55,
-          "lat": 38.368987,
-          "lng": 141.061207
-        },
-        {
-          "id": "133",
-          "title": "宮城県/大和町",
-          "city": "大和",
-          "pokemons": [
-            "タマゲタケ",
-            "ドダイトス"
-          ],
-          "dist_km": 9.45,
-          "lat": 38.437364,
-          "lng": 140.885648
-        },
-        {
-          "id": "125",
-          "title": "宮城県/富谷市",
-          "city": "富谷",
-          "pokemons": [
-            "ブルー",
-            "ラプラス"
-          ],
-          "dist_km": 9.61,
-          "lat": 38.398336,
-          "lng": 140.8875
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-04012",
-    "type": "michineki",
-    "title": "道の駅村田周辺のポケふた（4枚）",
-    "url": "https://it-social.net/roadside_station/?04012",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "04012",
-      "station_name": "道の駅村田",
-      "pref": "宮城県",
-      "lat": 38.118639,
-      "lng": 140.717279,
-      "manhole_count": 4,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "129",
-          "title": "宮城県/村田町",
-          "city": "村田",
-          "pokemons": [
-            "ベロベルト",
-            "ラプラス"
-          ],
-          "dist_km": 0.07,
-          "lat": 38.119071,
-          "lng": 140.717821
-        },
-        {
-          "id": "130",
-          "title": "宮城県/柴田町",
-          "city": "柴田",
-          "pokemons": [
-            "フラベベ",
-            "ラプラス"
-          ],
-          "dist_km": 7.98,
-          "lat": 38.059143,
-          "lng": 140.768239
-        },
-        {
-          "id": "128",
-          "title": "宮城県/大河原町",
-          "city": "大河原",
-          "pokemons": [
-            "チェリム",
-            "ラプラス"
-          ],
-          "dist_km": 8.01,
-          "lat": 38.0485032,
-          "lng": 140.738089
-        },
-        {
-          "id": "131",
-          "title": "宮城県/川崎町",
-          "city": "川崎",
-          "pokemons": [
-            "ラプラス"
-          ],
-          "dist_km": 9.18,
-          "lat": 38.177534,
-          "lng": 140.643653
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-04015",
-    "type": "michineki",
-    "title": "道の駅かくだ周辺のポケふた（3枚）",
-    "url": "https://it-social.net/roadside_station/?04015",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "04015",
-      "station_name": "道の駅かくだ",
-      "pref": "宮城県",
-      "lat": 37.968556,
-      "lng": 140.807611,
-      "manhole_count": 3,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "121",
-          "title": "宮城県/角田市",
-          "city": "角田",
-          "pokemons": [
-            "ラティアス",
-            "ラプラス"
-          ],
-          "dist_km": 0.05,
-          "lat": 37.968694,
-          "lng": 140.807077
-        },
-        {
-          "id": "132",
-          "title": "宮城県/丸森町",
-          "city": "丸森",
-          "pokemons": [
-            "ニャスパー",
-            "ニャース"
-          ],
-          "dist_km": 7.25,
-          "lat": 37.913873,
-          "lng": 140.762531
-        },
-        {
-          "id": "58",
-          "title": "宮城県/山元町",
-          "city": "山元",
-          "pokemons": [
-            "ラッキー",
-            "ラプラス"
-          ],
-          "dist_km": 9.57,
-          "lat": 37.923988,
-          "lng": 140.900996
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-07010",
-    "type": "michineki",
-    "title": "道の駅会津柳津周辺のポケふた（3枚）",
-    "url": "https://it-social.net/roadside_station/?07010",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "07010",
-      "station_name": "道の駅会津柳津",
-      "pref": "福島県",
-      "lat": 37.527693,
-      "lng": 139.7221754,
-      "manhole_count": 3,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "251",
-          "title": "福島県/柳津町",
-          "city": "柳津",
-          "pokemons": [
-            "ピンプク",
-            "ラッキー"
-          ],
-          "dist_km": 0.07,
-          "lat": 37.528189,
-          "lng": 139.722662
-        },
-        {
-          "id": "369",
-          "title": "福島県/会津坂下町",
-          "city": "会津坂下",
-          "pokemons": [
-            "カイリキー",
-            "ラッキー"
-          ],
-          "dist_km": 9.46,
-          "lat": 37.56046,
-          "lng": 139.821186
-        },
-        {
-          "id": "457",
-          "title": "福島県/西会津町",
-          "city": "西会津",
-          "pokemons": [
-            "ピクシー",
-            "マシェード"
-          ],
-          "dist_km": 9.51,
-          "lat": 37.585568,
-          "lng": 139.642677
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-07014",
-    "type": "michineki",
-    "title": "道の駅たまかわ周辺のポケふた（3枚）",
-    "url": "https://it-social.net/roadside_station/?07014",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "07014",
-      "station_name": "道の駅たまかわ",
-      "pref": "福島県",
-      "lat": 37.2228324,
-      "lng": 140.4181372,
-      "manhole_count": 3,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "370",
-          "title": "福島県/鏡石町",
-          "city": "鏡石",
-          "pokemons": [
-            "ミルタンク",
-            "メリープ"
-          ],
-          "dist_km": 7.03,
-          "lat": 37.251117,
-          "lng": 140.347153
-        },
-        {
-          "id": "285",
-          "title": "福島県/矢吹町",
-          "city": "矢吹",
-          "pokemons": [
-            "ファイアロー",
-            "ラッキー"
-          ],
-          "dist_km": 7.32,
-          "lat": 37.21842,
-          "lng": 140.335635
-        },
-        {
-          "id": "454",
-          "title": "福島県/須賀川市",
-          "city": "須賀川",
-          "pokemons": [
-            "マフォクシー",
-            "ラッキー"
-          ],
-          "dist_km": 8.25,
-          "lat": 37.291536,
-          "lng": 140.382947
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-07023",
-    "type": "michineki",
-    "title": "道の駅季の里天栄周辺のポケふた（3枚）",
-    "url": "https://it-social.net/roadside_station/?07023",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "07023",
-      "station_name": "道の駅季の里天栄",
-      "pref": "福島県",
-      "lat": 37.2436603,
-      "lng": 140.2447857,
-      "manhole_count": 3,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "455",
-          "title": "福島県/天栄村",
-          "city": "天栄",
-          "pokemons": [
-            "イエッサン",
-            "ラッキー"
-          ],
-          "dist_km": 0.1,
-          "lat": 37.243406,
-          "lng": 140.243722
-        },
-        {
-          "id": "285",
-          "title": "福島県/矢吹町",
-          "city": "矢吹",
-          "pokemons": [
-            "ファイアロー",
-            "ラッキー"
-          ],
-          "dist_km": 8.52,
-          "lat": 37.21842,
-          "lng": 140.335635
-        },
-        {
-          "id": "370",
-          "title": "福島県/鏡石町",
-          "city": "鏡石",
-          "pokemons": [
-            "ミルタンク",
-            "メリープ"
-          ],
-          "dist_km": 9.1,
-          "lat": 37.251117,
-          "lng": 140.347153
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-07034",
-    "type": "michineki",
-    "title": "道の駅なみえ周辺のポケふた（3枚）",
-    "url": "https://it-social.net/roadside_station/?07034",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "07034",
-      "station_name": "道の駅なみえ",
-      "pref": "福島県",
-      "lat": 37.496278,
-      "lng": 141.000278,
-      "manhole_count": 3,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "91",
-          "title": "福島県/浪江町",
-          "city": "浪江",
-          "pokemons": [
-            "ラッキー"
-          ],
-          "dist_km": 0.06,
-          "lat": 37.496395,
-          "lng": 141.000919
-        },
-        {
-          "id": "253",
-          "title": "福島県/双葉町",
-          "city": "双葉",
-          "pokemons": [
-            "ヒマナッツ",
-            "ラッキー"
-          ],
-          "dist_km": 4.92,
-          "lat": 37.45745,
-          "lng": 141.02692
-        },
-        {
-          "id": "462",
-          "title": "福島県/大熊町",
-          "city": "大熊",
-          "pokemons": [
-            "キテルグマ",
-            "ヌイコグマ"
-          ],
-          "dist_km": 9.72,
-          "lat": 37.4099576,
-          "lng": 140.983206
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-08008",
-    "type": "michineki",
-    "title": "道の駅いたこ周辺のポケふた（3枚）",
-    "url": "https://it-social.net/roadside_station/?08008",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "08008",
-      "station_name": "道の駅いたこ",
-      "pref": "茨城県",
-      "lat": 35.9461322,
-      "lng": 140.5892448,
-      "manhole_count": 3,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "224",
-          "title": "千葉県/香取市",
-          "city": "香取",
-          "pokemons": [
-            "フラージェス",
-            "ヤヤコマ"
-          ],
-          "dist_km": 6.25,
-          "lat": 35.928206,
-          "lng": 140.523401
-        },
-        {
-          "id": "409",
-          "title": "茨城県/神栖市",
-          "city": "神栖",
-          "pokemons": [
-            "オトシドリ",
-            "マラカッチ"
-          ],
-          "dist_km": 7.65,
-          "lat": 35.897341,
-          "lng": 140.649095
-        },
-        {
-          "id": "225",
-          "title": "千葉県/香取市",
-          "city": "香取",
-          "pokemons": [
-            "タネボー",
-            "ハスボー"
-          ],
-          "dist_km": 9.3,
-          "lat": 35.896204,
-          "lng": 140.506419
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-12021",
-    "type": "michineki",
-    "title": "道の駅水の郷さわら周辺のポケふた（4枚）",
-    "url": "https://it-social.net/roadside_station/?12021",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "12021",
-      "station_name": "道の駅水の郷さわら",
-      "pref": "千葉県",
-      "lat": 35.896313,
-      "lng": 140.505908,
-      "manhole_count": 4,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "225",
-          "title": "千葉県/香取市",
-          "city": "香取",
-          "pokemons": [
-            "タネボー",
-            "ハスボー"
-          ],
-          "dist_km": 0.05,
-          "lat": 35.896204,
-          "lng": 140.506419
-        },
-        {
-          "id": "222",
-          "title": "千葉県/香取市",
-          "city": "香取",
-          "pokemons": [
-            "ガラルカモネギ"
-          ],
-          "dist_km": 1.1,
-          "lat": 35.894417,
-          "lng": 140.493902
-        },
-        {
-          "id": "223",
-          "title": "千葉県/香取市",
-          "city": "香取",
-          "pokemons": [
-            "ココガラ",
-            "タイレーツ"
-          ],
-          "dist_km": 1.16,
-          "lat": 35.888376,
-          "lng": 140.497568
-        },
-        {
-          "id": "224",
-          "title": "千葉県/香取市",
-          "city": "香取",
-          "pokemons": [
-            "フラージェス",
-            "ヤヤコマ"
-          ],
-          "dist_km": 3.88,
-          "lat": 35.928206,
-          "lng": 140.523401
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-15009",
-    "type": "michineki",
-    "title": "道の駅ちぢみの里おぢや周辺のポケふた（4枚）",
-    "url": "https://it-social.net/roadside_station/?15009",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "15009",
-      "station_name": "道の駅ちぢみの里おぢや",
-      "pref": "新潟県",
-      "lat": 37.305143,
-      "lng": 138.822908,
-      "manhole_count": 4,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "145",
-          "title": "新潟県/小千谷市",
-          "city": "小千谷",
-          "pokemons": [
-            "コイキング"
-          ],
-          "dist_km": 1.03,
-          "lat": 37.309883,
-          "lng": 138.812939
-        },
-        {
-          "id": "146",
-          "title": "新潟県/小千谷市",
-          "city": "小千谷",
-          "pokemons": [
-            "コイキング",
-            "ヒンバス"
-          ],
-          "dist_km": 2.5,
-          "lat": 37.311028,
-          "lng": 138.795653
-        },
-        {
-          "id": "144",
-          "title": "新潟県/小千谷市",
-          "city": "小千谷",
-          "pokemons": [
-            "コイキング"
-          ],
-          "dist_km": 2.68,
-          "lat": 37.314216,
-          "lng": 138.794792
-        },
-        {
-          "id": "147",
-          "title": "新潟県/小千谷市",
-          "city": "小千谷",
-          "pokemons": [
-            "コイキング",
-            "ピジョン"
-          ],
-          "dist_km": 3.63,
-          "lat": 37.314301,
-          "lng": 138.7835
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-15032",
-    "type": "michineki",
-    "title": "道の駅越後川口周辺のポケふた（4枚）",
-    "url": "https://it-social.net/roadside_station/?15032",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "15032",
-      "station_name": "道の駅越後川口",
-      "pref": "新潟県",
-      "lat": 37.2608955,
-      "lng": 138.8676387,
-      "manhole_count": 4,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "145",
-          "title": "新潟県/小千谷市",
-          "city": "小千谷",
-          "pokemons": [
-            "コイキング"
-          ],
-          "dist_km": 7.29,
-          "lat": 37.309883,
-          "lng": 138.812939
-        },
-        {
-          "id": "146",
-          "title": "新潟県/小千谷市",
-          "city": "小千谷",
-          "pokemons": [
-            "コイキング",
-            "ヒンバス"
-          ],
-          "dist_km": 8.46,
-          "lat": 37.311028,
-          "lng": 138.795653
-        },
-        {
-          "id": "144",
-          "title": "新潟県/小千谷市",
-          "city": "小千谷",
-          "pokemons": [
-            "コイキング"
-          ],
-          "dist_km": 8.76,
-          "lat": 37.314216,
-          "lng": 138.794792
-        },
-        {
-          "id": "147",
-          "title": "新潟県/小千谷市",
-          "city": "小千谷",
-          "pokemons": [
-            "コイキング",
-            "ピジョン"
-          ],
-          "dist_km": 9.52,
-          "lat": 37.314301,
-          "lng": 138.7835
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-18016",
-    "type": "michineki",
-    "title": "道の駅恐竜渓谷かつやま周辺のポケふた（3枚）",
-    "url": "https://it-social.net/roadside_station/?18016",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "18016",
-      "station_name": "道の駅恐竜渓谷かつやま",
-      "pref": "福井県",
-      "lat": 36.072056,
-      "lng": 136.47875,
-      "manhole_count": 3,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "336",
-          "title": "福井県/勝山市",
-          "city": "勝山",
-          "pokemons": [
-            "アーケン",
-            "カイリュー"
-          ],
-          "dist_km": 2.07,
-          "lat": 36.056787,
-          "lng": 136.492007
-        },
-        {
-          "id": "339",
-          "title": "福井県/永平寺町",
-          "city": "永平寺",
-          "pokemons": [
-            "カイリュー",
-            "ダクマ"
-          ],
-          "dist_km": 7.19,
-          "lat": 36.079891,
-          "lng": 136.399312
-        },
-        {
-          "id": "364",
-          "title": "福井県/大野市",
-          "city": "大野",
-          "pokemons": [
-            "カイリュー"
-          ],
-          "dist_km": 9.76,
-          "lat": 35.9845016,
-          "lng": 136.4859314
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-18019",
-    "type": "michineki",
-    "title": "道の駅越前たけふ周辺のポケふた（3枚）",
-    "url": "https://it-social.net/roadside_station/?18019",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "18019",
-      "station_name": "道の駅越前たけふ",
-      "pref": "福井県",
-      "lat": 35.895139,
-      "lng": 136.198111,
-      "manhole_count": 3,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "338",
-          "title": "福井県/越前市",
-          "city": "越前",
-          "pokemons": [
-            "エレズン",
-            "カイリュー"
-          ],
-          "dist_km": 0.06,
-          "lat": 35.895286,
-          "lng": 136.198727
-        },
-        {
-          "id": "419",
-          "title": "福井県/鯖江市",
-          "city": "鯖江",
-          "pokemons": [
-            "カイリュー",
-            "サッチムシ"
-          ],
-          "dist_km": 6.3,
-          "lat": 35.950098,
-          "lng": 136.181116
-        },
-        {
-          "id": "366",
-          "title": "福井県/南越前町",
-          "city": "南越前",
-          "pokemons": [
-            "カイリュー",
-            "バタフリー"
-          ],
-          "dist_km": 7.09,
-          "lat": 35.831454,
-          "lng": 136.201365
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-23017",
-    "type": "michineki",
-    "title": "道の駅とよはし周辺のポケふた（4枚）",
-    "url": "https://it-social.net/roadside_station/?23017",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "23017",
-      "station_name": "道の駅とよはし",
-      "pref": "愛知県",
-      "lat": 34.696222,
-      "lng": 137.414833,
-      "manhole_count": 4,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "273",
-          "title": "愛知県/豊橋市",
-          "city": "豊橋市",
-          "pokemons": [
-            "スターミー",
-            "デンヂムシ"
-          ],
-          "dist_km": 0.09,
-          "lat": 34.695901,
-          "lng": 137.413953
-        },
-        {
-          "id": "274",
-          "title": "愛知県/豊橋市",
-          "city": "豊橋市",
-          "pokemons": [
-            "カブト",
-            "クワガノン"
-          ],
-          "dist_km": 3.06,
-          "lat": 34.72096,
-          "lng": 137.429448
-        },
-        {
-          "id": "272",
-          "title": "愛知県/豊橋市",
-          "city": "豊橋市",
-          "pokemons": [
-            "アゴジムシ",
-            "アブリボン"
-          ],
-          "dist_km": 7.93,
-          "lat": 34.762599,
-          "lng": 137.382958
-        },
-        {
-          "id": "271",
-          "title": "愛知県/豊橋市",
-          "city": "豊橋市",
-          "pokemons": [
-            "バクフーン"
-          ],
-          "dist_km": 8.3,
-          "lat": 34.768863,
-          "lng": 137.393843
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-24014",
-    "type": "michineki",
-    "title": "道の駅あやま周辺のポケふた（3枚）",
-    "url": "https://it-social.net/roadside_station/?24014",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "24014",
-      "station_name": "道の駅あやま",
-      "pref": "三重県",
-      "lat": 34.8445672,
-      "lng": 136.1709955,
-      "manhole_count": 3,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "239",
-          "title": "滋賀県/甲賀市",
-          "city": "甲賀",
-          "pokemons": [
-            "ゲコガシラ",
-            "ゲッコウガ"
-          ],
-          "dist_km": 8.18,
-          "lat": 34.900437,
-          "lng": 136.229399
-        },
-        {
-          "id": "237",
-          "title": "滋賀県/甲賀市",
-          "city": "甲賀",
-          "pokemons": [
-            "ゲッコウガ"
-          ],
-          "dist_km": 8.34,
-          "lat": 34.919591,
-          "lng": 136.170196
-        },
-        {
-          "id": "246",
-          "title": "三重県/伊賀市",
-          "city": "伊賀市",
-          "pokemons": [
-            "アギルダー",
-            "ミジュマル"
-          ],
-          "dist_km": 9.34,
-          "lat": 34.767543,
-          "lng": 136.130081
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-24016",
-    "type": "michineki",
-    "title": "道の駅津かわげ周辺のポケふた（4枚）",
-    "url": "https://it-social.net/roadside_station/?24016",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "24016",
-      "station_name": "道の駅津かわげ",
-      "pref": "三重県",
-      "lat": 34.7967069,
-      "lng": 136.5179906,
-      "manhole_count": 4,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "415",
-          "title": "三重県/鈴鹿市",
-          "city": "鈴鹿",
-          "pokemons": [
-            "ミジュマル"
-          ],
-          "dist_km": 6.46,
-          "lat": 34.852227,
-          "lng": 136.538663
-        },
-        {
-          "id": "330",
-          "title": "三重県/鈴鹿市",
-          "city": "鈴鹿市",
-          "pokemons": [
-            "ミジュマル",
-            "モトトカゲ"
-          ],
-          "dist_km": 6.75,
-          "lat": 34.823065,
-          "lng": 136.584609
-        },
-        {
-          "id": "240",
-          "title": "三重県/津市",
-          "city": "津市",
-          "pokemons": [
-            "ミジュマル"
-          ],
-          "dist_km": 8.72,
-          "lat": 34.718493,
-          "lng": 136.5108
-        },
-        {
-          "id": "292",
-          "title": "三重県/亀山市",
-          "city": "亀山市",
-          "pokemons": [
-            "ドダイトス",
-            "ミジュマル"
-          ],
-          "dist_km": 9.49,
-          "lat": 34.8594415,
-          "lng": 136.4474608
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-28016",
-    "type": "michineki",
-    "title": "道の駅うずしお周辺のポケふた（3枚）",
-    "url": "https://it-social.net/roadside_station/?28016",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "28016",
-      "station_name": "道の駅うずしお",
-      "pref": "兵庫県",
-      "lat": 34.2420275,
-      "lng": 134.6597796,
-      "manhole_count": 3,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "327",
-          "title": "徳島県/鳴門市",
-          "city": "鳴門",
-          "pokemons": [
-            "スイクン"
-          ],
-          "dist_km": 2.94,
-          "lat": 34.224106,
-          "lng": 134.636196
-        },
-        {
-          "id": "328",
-          "title": "徳島県/鳴門市",
-          "city": "鳴門",
-          "pokemons": [
-            "キングドラ",
-            "シードラ"
-          ],
-          "dist_km": 8.55,
-          "lat": 34.181955,
-          "lng": 134.601709
-        },
-        {
-          "id": "329",
-          "title": "徳島県/鳴門市",
-          "city": "鳴門",
-          "pokemons": [
-            "ディグダ",
-            "ニョロゾ"
-          ],
-          "dist_km": 9.14,
-          "lat": 34.168084,
-          "lng": 134.616371
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-29005",
-    "type": "michineki",
-    "title": "道の駅ふたかみパーク當麻周辺のポケふた（4枚）",
-    "url": "https://it-social.net/roadside_station/?29005",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "29005",
-      "station_name": "道の駅ふたかみパーク當麻",
-      "pref": "奈良県",
-      "lat": 34.5265079,
-      "lng": 135.6932765,
-      "manhole_count": 4,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "148",
-          "title": "奈良県/斑鳩町",
-          "city": "斑鳩",
-          "pokemons": [
-            "ドータクン",
-            "バオッキー"
-          ],
-          "dist_km": 9.38,
-          "lat": 34.60189,
-          "lng": 135.73917
-        },
-        {
-          "id": "149",
-          "title": "奈良県/斑鳩町",
-          "city": "斑鳩",
-          "pokemons": [
-            "ガーディ",
-            "マダツボミ"
-          ],
-          "dist_km": 9.6,
-          "lat": 34.60474,
-          "lng": 135.7376
-        },
-        {
-          "id": "151",
-          "title": "奈良県/斑鳩町",
-          "city": "斑鳩",
-          "pokemons": [
-            "シキジカ",
-            "ヒノヤコマ"
-          ],
-          "dist_km": 9.95,
-          "lat": 34.60826,
-          "lng": 135.73755
-        },
-        {
-          "id": "150",
-          "title": "奈良県/斑鳩町",
-          "city": "斑鳩",
-          "pokemons": [
-            "チリーン",
-            "ブビィ"
-          ],
-          "dist_km": 9.96,
-          "lat": 34.60827,
-          "lng": 135.73769
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-29010",
-    "type": "michineki",
-    "title": "道の駅大和路へぐり周辺のポケふた（9枚）",
-    "url": "https://it-social.net/roadside_station/?29010",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "29010",
-      "station_name": "道の駅大和路へぐり",
-      "pref": "奈良県",
-      "lat": 34.6235384,
-      "lng": 135.7062481,
-      "manhole_count": 9,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "152",
-          "title": "奈良県/斑鳩町",
-          "city": "斑鳩",
-          "pokemons": [
-            "エンテイ"
-          ],
-          "dist_km": 3.06,
-          "lat": 34.60983,
-          "lng": 135.73529
-        },
-        {
-          "id": "151",
-          "title": "奈良県/斑鳩町",
-          "city": "斑鳩",
-          "pokemons": [
-            "シキジカ",
-            "ヒノヤコマ"
-          ],
-          "dist_km": 3.33,
-          "lat": 34.60826,
-          "lng": 135.73755
-        },
-        {
-          "id": "150",
-          "title": "奈良県/斑鳩町",
-          "city": "斑鳩",
-          "pokemons": [
-            "チリーン",
-            "ブビィ"
-          ],
-          "dist_km": 3.34,
-          "lat": 34.60827,
-          "lng": 135.73769
-        },
-        {
-          "id": "149",
-          "title": "奈良県/斑鳩町",
-          "city": "斑鳩",
-          "pokemons": [
-            "ガーディ",
-            "マダツボミ"
-          ],
-          "dist_km": 3.55,
-          "lat": 34.60474,
-          "lng": 135.7376
-        },
-        {
-          "id": "148",
-          "title": "奈良県/斑鳩町",
-          "city": "斑鳩",
-          "pokemons": [
-            "ドータクン",
-            "バオッキー"
-          ],
-          "dist_km": 3.86,
-          "lat": 34.60189,
-          "lng": 135.73917
-        },
-        {
-          "id": "207",
-          "title": "大阪府/東大阪市",
-          "city": "東大阪",
-          "pokemons": [
-            "ギアル",
-            "ギギアル"
-          ],
-          "dist_km": 7.81,
-          "lat": 34.66771,
-          "lng": 135.63989
-        },
-        {
-          "id": "208",
-          "title": "大阪府/東大阪市",
-          "city": "東大阪",
-          "pokemons": [
-            "エレキッド",
-            "クチート"
-          ],
-          "dist_km": 8.13,
-          "lat": 34.680678,
-          "lng": 135.650788
-        },
-        {
-          "id": "210",
-          "title": "大阪府/東大阪市",
-          "city": "東大阪",
-          "pokemons": [
-            "トゲデマル",
-            "ワンパチ"
-          ],
-          "dist_km": 8.6,
-          "lat": 34.669486,
-          "lng": 135.630586
-        },
-        {
-          "id": "209",
-          "title": "大阪府/東大阪市",
-          "city": "東大阪",
-          "pokemons": [
-            "ライコウ"
-          ],
-          "dist_km": 8.81,
-          "lat": 34.667678,
-          "lng": 135.626309
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-29014",
-    "type": "michineki",
-    "title": "道の駅レスティ 唐古・鍵周辺のポケふた（5枚）",
-    "url": "https://it-social.net/roadside_station/?29014",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "29014",
-      "station_name": "道の駅レスティ 唐古・鍵",
-      "pref": "奈良県",
-      "lat": 34.571407,
-      "lng": 135.797418,
-      "manhole_count": 5,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "148",
-          "title": "奈良県/斑鳩町",
-          "city": "斑鳩",
-          "pokemons": [
-            "ドータクン",
-            "バオッキー"
-          ],
-          "dist_km": 6.32,
-          "lat": 34.60189,
-          "lng": 135.73917
-        },
-        {
-          "id": "149",
-          "title": "奈良県/斑鳩町",
-          "city": "斑鳩",
-          "pokemons": [
-            "ガーディ",
-            "マダツボミ"
-          ],
-          "dist_km": 6.61,
-          "lat": 34.60474,
-          "lng": 135.7376
-        },
-        {
-          "id": "150",
-          "title": "奈良県/斑鳩町",
-          "city": "斑鳩",
-          "pokemons": [
-            "チリーン",
-            "ブビィ"
-          ],
-          "dist_km": 6.83,
-          "lat": 34.60827,
-          "lng": 135.73769
-        },
-        {
-          "id": "151",
-          "title": "奈良県/斑鳩町",
-          "city": "斑鳩",
-          "pokemons": [
-            "シキジカ",
-            "ヒノヤコマ"
-          ],
-          "dist_km": 6.84,
-          "lat": 34.60826,
-          "lng": 135.73755
-        },
-        {
-          "id": "152",
-          "title": "奈良県/斑鳩町",
-          "city": "斑鳩",
-          "pokemons": [
-            "エンテイ"
-          ],
-          "dist_km": 7.11,
-          "lat": 34.60983,
-          "lng": 135.73529
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-31001",
-    "type": "michineki",
-    "title": "道の駅大栄周辺のポケふた（3枚）",
-    "url": "https://it-social.net/roadside_station/?31001",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "31001",
-      "station_name": "道の駅大栄",
-      "pref": "鳥取県",
-      "lat": 35.4987404,
-      "lng": 133.7617796,
-      "manhole_count": 3,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "108",
-          "title": "鳥取県/北栄町",
-          "city": "北栄",
-          "pokemons": [
-            "アローラサンド",
-            "サンド"
-          ],
-          "dist_km": 5.08,
-          "lat": 35.49924,
-          "lng": 133.81794
-        },
-        {
-          "id": "82",
-          "title": "鳥取県/琴浦町",
-          "city": "琴浦",
-          "pokemons": [
-            "アローラサンド",
-            "サンド"
-          ],
-          "dist_km": 9.11,
-          "lat": 35.506942,
-          "lng": 133.661612
-        },
-        {
-          "id": "76",
-          "title": "鳥取県/倉吉市",
-          "city": "倉吉",
-          "pokemons": [
-            "アローラサンド",
-            "サンド"
-          ],
-          "dist_km": 9.4,
-          "lat": 35.454272,
-          "lng": 133.850116
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-31003",
-    "type": "michineki",
-    "title": "道の駅北条公園周辺のポケふた（3枚）",
-    "url": "https://it-social.net/roadside_station/?31003",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "31003",
-      "station_name": "道の駅北条公園",
-      "pref": "鳥取県",
-      "lat": 35.4981997,
-      "lng": 133.8199605,
-      "manhole_count": 3,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "108",
-          "title": "鳥取県/北栄町",
-          "city": "北栄",
-          "pokemons": [
-            "アローラサンド",
-            "サンド"
-          ],
-          "dist_km": 0.22,
-          "lat": 35.49924,
-          "lng": 133.81794
-        },
-        {
-          "id": "76",
-          "title": "鳥取県/倉吉市",
-          "city": "倉吉",
-          "pokemons": [
-            "アローラサンド",
-            "サンド"
-          ],
-          "dist_km": 5.6,
-          "lat": 35.454272,
-          "lng": 133.850116
-        },
-        {
-          "id": "81",
-          "title": "鳥取県/湯梨浜町",
-          "city": "湯梨浜",
-          "pokemons": [
-            "サンド",
-            "シェルダー"
-          ],
-          "dist_km": 6.21,
-          "lat": 35.478166,
-          "lng": 133.88401
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-31007",
-    "type": "michineki",
-    "title": "道の駅はわい周辺のポケふた（4枚）",
-    "url": "https://it-social.net/roadside_station/?31007",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "31007",
-      "station_name": "道の駅はわい",
-      "pref": "鳥取県",
-      "lat": 35.4942979,
-      "lng": 133.8904755,
-      "manhole_count": 4,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "81",
-          "title": "鳥取県/湯梨浜町",
-          "city": "湯梨浜",
-          "pokemons": [
-            "サンド",
-            "シェルダー"
-          ],
-          "dist_km": 1.89,
-          "lat": 35.478166,
-          "lng": 133.88401
-        },
-        {
-          "id": "76",
-          "title": "鳥取県/倉吉市",
-          "city": "倉吉",
-          "pokemons": [
-            "アローラサンド",
-            "サンド"
-          ],
-          "dist_km": 5.76,
-          "lat": 35.454272,
-          "lng": 133.850116
-        },
-        {
-          "id": "108",
-          "title": "鳥取県/北栄町",
-          "city": "北栄",
-          "pokemons": [
-            "アローラサンド",
-            "サンド"
-          ],
-          "dist_km": 6.59,
-          "lat": 35.49924,
-          "lng": 133.81794
-        },
-        {
-          "id": "80",
-          "title": "鳥取県/三朝町",
-          "city": "三朝",
-          "pokemons": [
-            "アローラサンド",
-            "ケロマツ"
-          ],
-          "dist_km": 9.46,
-          "lat": 35.409324,
-          "lng": 133.894397
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-31012",
-    "type": "michineki",
-    "title": "燕趙園周辺のポケふた（4枚）",
-    "url": "https://it-social.net/roadside_station/?31012",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "31012",
-      "station_name": "燕趙園",
-      "pref": "鳥取県",
-      "lat": 35.4646909,
-      "lng": 133.8926402,
-      "manhole_count": 4,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "81",
-          "title": "鳥取県/湯梨浜町",
-          "city": "湯梨浜",
-          "pokemons": [
-            "サンド",
-            "シェルダー"
-          ],
-          "dist_km": 1.69,
-          "lat": 35.478166,
-          "lng": 133.88401
-        },
-        {
-          "id": "76",
-          "title": "鳥取県/倉吉市",
-          "city": "倉吉",
-          "pokemons": [
-            "アローラサンド",
-            "サンド"
-          ],
-          "dist_km": 4.02,
-          "lat": 35.454272,
-          "lng": 133.850116
-        },
-        {
-          "id": "80",
-          "title": "鳥取県/三朝町",
-          "city": "三朝",
-          "pokemons": [
-            "アローラサンド",
-            "ケロマツ"
-          ],
-          "dist_km": 6.16,
-          "lat": 35.409324,
-          "lng": 133.894397
-        },
-        {
-          "id": "108",
-          "title": "鳥取県/北栄町",
-          "city": "北栄",
-          "pokemons": [
-            "アローラサンド",
-            "サンド"
-          ],
-          "dist_km": 7.78,
-          "lat": 35.49924,
-          "lng": 133.81794
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-31013",
-    "type": "michineki",
-    "title": "道の駅きなんせ岩美周辺のポケふた（3枚）",
-    "url": "https://it-social.net/roadside_station/?31013",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "31013",
-      "station_name": "道の駅きなんせ岩美",
-      "pref": "鳥取県",
-      "lat": 35.56741079,
-      "lng": 134.3259855,
-      "manhole_count": 3,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "78",
-          "title": "鳥取県/岩美町",
-          "city": "岩美",
-          "pokemons": [
-            "サンド",
-            "ネイティオ"
-          ],
-          "dist_km": 2.65,
-          "lat": 35.590938,
-          "lng": 134.321556
-        },
-        {
-          "id": "74",
-          "title": "鳥取県/鳥取市",
-          "city": "鳥取",
-          "pokemons": [
-            "アローラサンド",
-            "サンド"
-          ],
-          "dist_km": 8.6,
-          "lat": 35.539668,
-          "lng": 134.237266
-        },
-        {
-          "id": "300",
-          "title": "鳥取県/鳥取市",
-          "city": "鳥取",
-          "pokemons": [
-            "アローラサンド",
-            "サンド"
-          ],
-          "dist_km": 9.91,
-          "lat": 35.53395,
-          "lng": 134.224478
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-31014",
-    "type": "michineki",
-    "title": "道の駅奥大山周辺のポケふた（4枚）",
-    "url": "https://it-social.net/roadside_station/?31014",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "31014",
-      "station_name": "道の駅奥大山",
-      "pref": "鳥取県",
-      "lat": 35.2961102,
-      "lng": 133.4740758,
-      "manhole_count": 4,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "110",
-          "title": "鳥取県/江府町",
-          "city": "江府",
-          "pokemons": [
-            "アローラサンド",
-            "サンド"
-          ],
-          "dist_km": 0.03,
-          "lat": 35.295841,
-          "lng": 133.474089
-        },
-        {
-          "id": "87",
-          "title": "鳥取県/日野町",
-          "city": "日野",
-          "pokemons": [
-            "アローラサンド",
-            "サンド"
-          ],
-          "dist_km": 6.73,
-          "lat": 35.24192,
-          "lng": 133.441049
-        },
-        {
-          "id": "84",
-          "title": "鳥取県/南部町",
-          "city": "南部",
-          "pokemons": [
-            "アローラサンド",
-            "サンド"
-          ],
-          "dist_km": 7.33,
-          "lat": 35.347474,
-          "lng": 133.423398
-        },
-        {
-          "id": "85",
-          "title": "鳥取県/伯耆町",
-          "city": "伯耆",
-          "pokemons": [
-            "アローラサンド",
-            "オニゴーリ"
-          ],
-          "dist_km": 9.81,
-          "lat": 35.383395,
-          "lng": 133.458512
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-32027",
-    "type": "michineki",
-    "title": "道の駅あらエッサ周辺のポケふた（3枚）",
-    "url": "https://it-social.net/roadside_station/?32027",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "32027",
-      "station_name": "道の駅あらエッサ",
-      "pref": "島根県",
-      "lat": 35.4095485,
-      "lng": 133.3124056,
-      "manhole_count": 3,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "380",
-          "title": "島根県/安来市",
-          "city": "安来",
-          "pokemons": [
-            "ドジョッチ",
-            "バリヤード"
-          ],
-          "dist_km": 5.27,
-          "lat": 35.428407,
-          "lng": 133.259012
-        },
-        {
-          "id": "75",
-          "title": "鳥取県/米子市",
-          "city": "米子",
-          "pokemons": [
-            "カモネギ",
-            "サンド"
-          ],
-          "dist_km": 6.84,
-          "lat": 35.456258,
-          "lng": 133.361525
-        },
-        {
-          "id": "109",
-          "title": "鳥取県/日吉津村",
-          "city": "日吉津",
-          "pokemons": [
-            "サンド",
-            "メタモン"
-          ],
-          "dist_km": 7.03,
-          "lat": 35.441126,
-          "lng": 133.379578
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-36018",
-    "type": "michineki",
-    "title": "道の駅くるくる なると周辺のポケふた（3枚）",
-    "url": "https://it-social.net/roadside_station/?36018",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "36018",
-      "station_name": "道の駅くるくる なると",
-      "pref": "徳島県",
-      "lat": 34.158139,
-      "lng": 134.579889,
-      "manhole_count": 3,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "328",
-          "title": "徳島県/鳴門市",
-          "city": "鳴門",
-          "pokemons": [
-            "キングドラ",
-            "シードラ"
-          ],
-          "dist_km": 3.32,
-          "lat": 34.181955,
-          "lng": 134.601709
-        },
-        {
-          "id": "329",
-          "title": "徳島県/鳴門市",
-          "city": "鳴門",
-          "pokemons": [
-            "ディグダ",
-            "ニョロゾ"
-          ],
-          "dist_km": 3.53,
-          "lat": 34.168084,
-          "lng": 134.616371
-        },
-        {
-          "id": "327",
-          "title": "徳島県/鳴門市",
-          "city": "鳴門",
-          "pokemons": [
-            "スイクン"
-          ],
-          "dist_km": 8.98,
-          "lat": 34.224106,
-          "lng": 134.636196
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-37001",
-    "type": "michineki",
-    "title": "道の駅瀬戸大橋記念公園周辺のポケふた（4枚）",
-    "url": "https://it-social.net/roadside_station/?37001",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "37001",
-      "station_name": "道の駅瀬戸大橋記念公園",
-      "pref": "香川県",
-      "lat": 34.3526893,
-      "lng": 133.8261282,
-      "manhole_count": 4,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "97",
-          "title": "香川県/宇多津町",
-          "city": "宇多津",
-          "pokemons": [
-            "ガラルヤドン",
-            "ヌオー"
-          ],
-          "dist_km": 4.69,
-          "lat": 34.3134259,
-          "lng": 133.8075257
-        },
-        {
-          "id": "30",
-          "title": "香川県/坂出市",
-          "city": "坂出",
-          "pokemons": [
-            "ヤドン"
-          ],
-          "dist_km": 5.21,
-          "lat": 34.312992,
-          "lng": 133.856292
-        },
-        {
-          "id": "29",
-          "title": "香川県/丸亀市",
-          "city": "丸亀",
-          "pokemons": [
-            "ヤドン"
-          ],
-          "dist_km": 7.37,
-          "lat": 34.292014,
-          "lng": 133.793951
-        },
-        {
-          "id": "194",
-          "title": "岡山県/倉敷市",
-          "city": "倉敷",
-          "pokemons": [
-            "ルカリオ"
-          ],
-          "dist_km": 9.14,
-          "lat": 34.43427,
-          "lng": 133.81388
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-37004",
-    "type": "michineki",
-    "title": "道の駅ふれあいパークみの周辺のポケふた（5枚）",
-    "url": "https://it-social.net/roadside_station/?37004",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "37004",
-      "station_name": "道の駅ふれあいパークみの",
-      "pref": "香川県",
-      "lat": 34.2263483,
-      "lng": 133.7228554,
-      "manhole_count": 5,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "31",
-          "title": "香川県/善通寺市",
-          "city": "善通寺",
-          "pokemons": [
-            "ヤドラン",
-            "ヤドン"
-          ],
-          "dist_km": 5.01,
-          "lat": 34.22531,
-          "lng": 133.7773
-        },
-        {
-          "id": "42",
-          "title": "香川県/多度津町",
-          "city": "多度津",
-          "pokemons": [
-            "ヤドン"
-          ],
-          "dist_km": 6.01,
-          "lat": 34.272282,
-          "lng": 133.757247
-        },
-        {
-          "id": "35",
-          "title": "香川県/三豊市",
-          "city": "三豊",
-          "pokemons": [
-            "シェルダー",
-            "ヤドン"
-          ],
-          "dist_km": 9.57,
-          "lat": 34.2687992,
-          "lng": 133.6322219
-        },
-        {
-          "id": "29",
-          "title": "香川県/丸亀市",
-          "city": "丸亀",
-          "pokemons": [
-            "ヤドン"
-          ],
-          "dist_km": 9.8,
-          "lat": 34.292014,
-          "lng": 133.793951
-        },
-        {
-          "id": "41",
-          "title": "香川県/琴平町",
-          "city": "琴平",
-          "pokemons": [
-            "ヤドン"
-          ],
-          "dist_km": 9.9,
-          "lat": 34.187735,
-          "lng": 133.819896
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-37007",
-    "type": "michineki",
-    "title": "道の駅空の夢もみの木パーク周辺のポケふた（3枚）",
-    "url": "https://it-social.net/roadside_station/?37007",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "37007",
-      "station_name": "道の駅空の夢もみの木パーク",
-      "pref": "香川県",
-      "lat": 34.1548496,
-      "lng": 133.8215512,
-      "manhole_count": 3,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "41",
-          "title": "香川県/琴平町",
-          "city": "琴平",
-          "pokemons": [
-            "ヤドン"
-          ],
-          "dist_km": 3.66,
-          "lat": 34.187735,
-          "lng": 133.819896
-        },
-        {
-          "id": "43",
-          "title": "香川県/まんのう町",
-          "city": "まんのう",
-          "pokemons": [
-            "ヤドン"
-          ],
-          "dist_km": 5.03,
-          "lat": 34.173339,
-          "lng": 133.871387
-        },
-        {
-          "id": "31",
-          "title": "香川県/善通寺市",
-          "city": "善通寺",
-          "pokemons": [
-            "ヤドラン",
-            "ヤドン"
-          ],
-          "dist_km": 8.83,
-          "lat": 34.22531,
-          "lng": 133.7773
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-37008",
-    "type": "michineki",
-    "title": "道の駅みろく周辺のポケふた（3枚）",
-    "url": "https://it-social.net/roadside_station/?37008",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "37008",
-      "station_name": "道の駅みろく",
-      "pref": "香川県",
-      "lat": 34.25819,
-      "lng": 134.2424659,
-      "manhole_count": 3,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "34",
-          "title": "香川県/東かがわ市",
-          "city": "東かがわ",
-          "pokemons": [
-            "ヤドン"
-          ],
-          "dist_km": 8.4,
-          "lat": 34.251174,
-          "lng": 134.333457
-        },
-        {
-          "id": "33",
-          "title": "香川県/さぬき市",
-          "city": "さぬき",
-          "pokemons": [
-            "ピッピ",
-            "ヤドン"
-          ],
-          "dist_km": 9.47,
-          "lat": 34.321305,
-          "lng": 134.173241
-        },
-        {
-          "id": "38",
-          "title": "香川県/三木町",
-          "city": "三木",
-          "pokemons": [
-            "ヤドン"
-          ],
-          "dist_km": 9.98,
-          "lat": 34.268586,
-          "lng": 134.134567
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-37010",
-    "type": "michineki",
-    "title": "道の駅滝宮周辺のポケふた（4枚）",
-    "url": "https://it-social.net/roadside_station/?37010",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "37010",
-      "station_name": "道の駅滝宮",
-      "pref": "香川県",
-      "lat": 34.2497767902,
-      "lng": 133.917359488,
-      "manhole_count": 4,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "40",
-          "title": "香川県/綾川町",
-          "city": "綾川",
-          "pokemons": [
-            "ヤドン"
-          ],
-          "dist_km": 0.07,
-          "lat": 34.250399,
-          "lng": 133.917073
-        },
-        {
-          "id": "298",
-          "title": "香川県/綾川町",
-          "city": "綾川",
-          "pokemons": [
-            "ガラルヤドン",
-            "シェルダー"
-          ],
-          "dist_km": 1.44,
-          "lat": 34.247395,
-          "lng": 133.9327735
-        },
-        {
-          "id": "30",
-          "title": "香川県/坂出市",
-          "city": "坂出",
-          "pokemons": [
-            "ヤドン"
-          ],
-          "dist_km": 8.99,
-          "lat": 34.312992,
-          "lng": 133.856292
-        },
-        {
-          "id": "43",
-          "title": "香川県/まんのう町",
-          "city": "まんのう",
-          "pokemons": [
-            "ヤドン"
-          ],
-          "dist_km": 9.49,
-          "lat": 34.173339,
-          "lng": 133.871387
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-37012",
-    "type": "michineki",
-    "title": "道の駅恋人の聖地 うたづ臨海公園周辺のポケふた（4枚）",
-    "url": "https://it-social.net/roadside_station/?37012",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "37012",
-      "station_name": "道の駅恋人の聖地 うたづ臨海公園",
-      "pref": "香川県",
-      "lat": 34.31338818,
-      "lng": 133.807966,
-      "manhole_count": 4,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "97",
-          "title": "香川県/宇多津町",
-          "city": "宇多津",
-          "pokemons": [
-            "ガラルヤドン",
-            "ヌオー"
-          ],
-          "dist_km": 0.04,
-          "lat": 34.3134259,
-          "lng": 133.8075257
-        },
-        {
-          "id": "29",
-          "title": "香川県/丸亀市",
-          "city": "丸亀",
-          "pokemons": [
-            "ヤドン"
-          ],
-          "dist_km": 2.7,
-          "lat": 34.292014,
-          "lng": 133.793951
-        },
-        {
-          "id": "30",
-          "title": "香川県/坂出市",
-          "city": "坂出",
-          "pokemons": [
-            "ヤドン"
-          ],
-          "dist_km": 4.44,
-          "lat": 34.312992,
-          "lng": 133.856292
-        },
-        {
-          "id": "42",
-          "title": "香川県/多度津町",
-          "city": "多度津",
-          "pokemons": [
-            "ヤドン"
-          ],
-          "dist_km": 6.53,
-          "lat": 34.272282,
-          "lng": 133.757247
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-37018",
-    "type": "michineki",
-    "title": "道の駅源平の里むれ周辺のポケふた（3枚）",
-    "url": "https://it-social.net/roadside_station/?37018",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "37018",
-      "station_name": "道の駅源平の里むれ",
-      "pref": "香川県",
-      "lat": 34.3337252,
-      "lng": 134.1574969,
-      "manhole_count": 3,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "33",
-          "title": "香川県/さぬき市",
-          "city": "さぬき",
-          "pokemons": [
-            "ピッピ",
-            "ヤドン"
-          ],
-          "dist_km": 2.0,
-          "lat": 34.321305,
-          "lng": 134.173241
-        },
-        {
-          "id": "38",
-          "title": "香川県/三木町",
-          "city": "三木",
-          "pokemons": [
-            "ヤドン"
-          ],
-          "dist_km": 7.54,
-          "lat": 34.268586,
-          "lng": 134.134567
-        },
-        {
-          "id": "28",
-          "title": "香川県/高松市",
-          "city": "高松",
-          "pokemons": [
-            "ヤドン"
-          ],
-          "dist_km": 9.97,
-          "lat": 34.338888,
-          "lng": 134.049052
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-39012",
-    "type": "michineki",
-    "title": "道の駅大山周辺のポケふた（3枚）",
-    "url": "https://it-social.net/roadside_station/?39012",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "39012",
-      "station_name": "道の駅大山",
-      "pref": "高知県",
-      "lat": 33.47009977,
-      "lng": 133.9440693,
-      "manhole_count": 3,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "433",
-          "title": "高知県/安芸市",
-          "city": "安芸",
-          "pokemons": [
-            "ヌオー",
-            "ホーホー"
-          ],
-          "dist_km": 5.16,
-          "lat": 33.5043207,
-          "lng": 133.9065445
-        },
-        {
-          "id": "451",
-          "title": "高知県/安田町",
-          "city": "安田",
-          "pokemons": [
-            "ヌオー",
-            "メタモン"
-          ],
-          "dist_km": 5.28,
-          "lat": 33.47986,
-          "lng": 133.99983
-        },
-        {
-          "id": "391",
-          "title": "高知県/奈半利町",
-          "city": "奈半利",
-          "pokemons": [
-            "サニーゴ",
-            "ヌオー"
-          ],
-          "dist_km": 8.46,
-          "lat": 33.425249,
-          "lng": 134.017781
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-45013",
-    "type": "michineki",
-    "title": "道の駅高千穂周辺のポケふた（3枚）",
-    "url": "https://it-social.net/roadside_station/?45013",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "45013",
-      "station_name": "道の駅高千穂",
-      "pref": "宮崎県",
-      "lat": 32.7084429,
-      "lng": 131.3004346,
-      "manhole_count": 3,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "184",
-          "title": "宮崎県/高千穂町",
-          "city": "高千穂",
-          "pokemons": [
-            "ナッシー",
-            "レジギガス"
-          ],
-          "dist_km": 0.52,
-          "lat": 32.707748,
-          "lng": 131.305889
-        },
-        {
-          "id": "186",
-          "title": "宮崎県/五ヶ瀬町",
-          "city": "五ヶ瀬",
-          "pokemons": [
-            "ナッシー",
-            "レジアイス"
-          ],
-          "dist_km": 9.07,
-          "lat": 32.679051,
-          "lng": 131.210041
-        },
-        {
-          "id": "185",
-          "title": "宮崎県/日之影町",
-          "city": "日之影",
-          "pokemons": [
-            "ナッシー",
-            "レジスチル"
-          ],
-          "dist_km": 9.82,
-          "lat": 32.660643,
-          "lng": 131.388639
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-46015",
-    "type": "michineki",
-    "title": "道の駅いぶすき周辺のポケふた（7枚）",
-    "url": "https://it-social.net/roadside_station/?46015",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "46015",
-      "station_name": "道の駅いぶすき",
-      "pref": "鹿児島県",
-      "lat": 31.3022146,
-      "lng": 130.5900439,
-      "manhole_count": 7,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "3",
-          "title": "鹿児島県/指宿市",
-          "city": "指宿",
-          "pokemons": [
-            "サンダース"
-          ],
-          "dist_km": 7.56,
-          "lat": 31.255278,
-          "lng": 130.647639
-        },
-        {
-          "id": "7",
-          "title": "鹿児島県/指宿市",
-          "city": "指宿",
-          "pokemons": [
-            "リーフィア"
-          ],
-          "dist_km": 8.13,
-          "lat": 31.263889,
-          "lng": 130.662917
-        },
-        {
-          "id": "1",
-          "title": "鹿児島県/指宿市",
-          "city": "指宿",
-          "pokemons": [
-            "イーブイ"
-          ],
-          "dist_km": 8.8,
-          "lat": 31.237194,
-          "lng": 130.642861
-        },
-        {
-          "id": "6",
-          "title": "鹿児島県/指宿市",
-          "city": "指宿",
-          "pokemons": [
-            "ブラッキー"
-          ],
-          "dist_km": 8.8,
-          "lat": 31.236833,
-          "lng": 130.642188
-        },
-        {
-          "id": "5",
-          "title": "鹿児島県/指宿市",
-          "city": "指宿",
-          "pokemons": [
-            "エーフィ"
-          ],
-          "dist_km": 8.82,
-          "lat": 31.238278,
-          "lng": 130.645
-        },
-        {
-          "id": "9",
-          "title": "鹿児島県/指宿市",
-          "city": "指宿",
-          "pokemons": [
-            "ニンフィア"
-          ],
-          "dist_km": 8.88,
-          "lat": 31.235444,
-          "lng": 130.641389
-        },
-        {
-          "id": "8",
-          "title": "鹿児島県/指宿市",
-          "city": "指宿",
-          "pokemons": [
-            "グレイシア"
-          ],
-          "dist_km": 9.46,
-          "lat": 31.231056,
-          "lng": 130.644611
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-46019",
-    "type": "michineki",
-    "title": "道の駅山川港活お海道周辺のポケふた（9枚）",
-    "url": "https://it-social.net/roadside_station/?46019",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "46019",
-      "station_name": "道の駅山川港活お海道",
-      "pref": "鹿児島県",
-      "lat": 31.2030165,
-      "lng": 130.6349136,
-      "manhole_count": 9,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "8",
-          "title": "鹿児島県/指宿市",
-          "city": "指宿",
-          "pokemons": [
-            "グレイシア"
-          ],
-          "dist_km": 3.25,
-          "lat": 31.231056,
-          "lng": 130.644611
-        },
-        {
-          "id": "2",
-          "title": "鹿児島県/指宿市",
-          "city": "指宿",
-          "pokemons": [
-            "シャワーズ"
-          ],
-          "dist_km": 3.27,
-          "lat": 31.228,
-          "lng": 130.653028
-        },
-        {
-          "id": "4",
-          "title": "鹿児島県/指宿市",
-          "city": "指宿",
-          "pokemons": [
-            "ブースター"
-          ],
-          "dist_km": 3.35,
-          "lat": 31.229417,
-          "lng": 130.651972
-        },
-        {
-          "id": "9",
-          "title": "鹿児島県/指宿市",
-          "city": "指宿",
-          "pokemons": [
-            "ニンフィア"
-          ],
-          "dist_km": 3.66,
-          "lat": 31.235444,
-          "lng": 130.641389
-        },
-        {
-          "id": "6",
-          "title": "鹿児島県/指宿市",
-          "city": "指宿",
-          "pokemons": [
-            "ブラッキー"
-          ],
-          "dist_km": 3.82,
-          "lat": 31.236833,
-          "lng": 130.642188
-        },
-        {
-          "id": "1",
-          "title": "鹿児島県/指宿市",
-          "city": "指宿",
-          "pokemons": [
-            "イーブイ"
-          ],
-          "dist_km": 3.87,
-          "lat": 31.237194,
-          "lng": 130.642861
-        },
-        {
-          "id": "5",
-          "title": "鹿児島県/指宿市",
-          "city": "指宿",
-          "pokemons": [
-            "エーフィ"
-          ],
-          "dist_km": 4.04,
-          "lat": 31.238278,
-          "lng": 130.645
-        },
-        {
-          "id": "3",
-          "title": "鹿児島県/指宿市",
-          "city": "指宿",
-          "pokemons": [
-            "サンダース"
-          ],
-          "dist_km": 5.94,
-          "lat": 31.255278,
-          "lng": 130.647639
-        },
-        {
-          "id": "7",
-          "title": "鹿児島県/指宿市",
-          "city": "指宿",
-          "pokemons": [
-            "リーフィア"
-          ],
-          "dist_km": 7.27,
-          "lat": 31.263889,
-          "lng": 130.662917
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-47004",
-    "type": "michineki",
-    "title": "道の駅かでな周辺のポケふた（3枚）",
-    "url": "https://it-social.net/roadside_station/?47004",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "47004",
-      "station_name": "道の駅かでな",
-      "pref": "沖縄県",
-      "lat": 26.3681116,
-      "lng": 127.7741485,
-      "manhole_count": 3,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "176",
-          "title": "沖縄県/沖縄市",
-          "city": "沖縄",
-          "pokemons": [
-            "バチンキー",
-            "ラランテス"
-          ],
-          "dist_km": 5.34,
-          "lat": 26.32766,
-          "lng": 127.803001
-        },
-        {
-          "id": "422",
-          "title": "沖縄県/北谷町",
-          "city": "北谷",
-          "pokemons": [
-            "ガーディ"
-          ],
-          "dist_km": 6.17,
-          "lat": 26.315733,
-          "lng": 127.753613
-        },
-        {
-          "id": "177",
-          "title": "沖縄県/うるま市",
-          "city": "うるま",
-          "pokemons": [
-            "ケンタロス"
-          ],
-          "dist_km": 9.17,
-          "lat": 26.436181,
-          "lng": 127.826113
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-47005",
-    "type": "michineki",
-    "title": "道の駅喜名番所周辺のポケふた（3枚）",
-    "url": "https://it-social.net/roadside_station/?47005",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "47005",
-      "station_name": "道の駅喜名番所",
-      "pref": "沖縄県",
-      "lat": 26.3993416,
-      "lng": 127.758204,
-      "manhole_count": 3,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "177",
-          "title": "沖縄県/うるま市",
-          "city": "うるま",
-          "pokemons": [
-            "ケンタロス"
-          ],
-          "dist_km": 7.91,
-          "lat": 26.436181,
-          "lng": 127.826113
-        },
-        {
-          "id": "176",
-          "title": "沖縄県/沖縄市",
-          "city": "沖縄",
-          "pokemons": [
-            "バチンキー",
-            "ラランテス"
-          ],
-          "dist_km": 9.14,
-          "lat": 26.32766,
-          "lng": 127.803001
-        },
-        {
-          "id": "422",
-          "title": "沖縄県/北谷町",
-          "city": "北谷",
-          "pokemons": [
-            "ガーディ"
-          ],
-          "dist_km": 9.31,
-          "lat": 26.315733,
-          "lng": 127.753613
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-47006",
-    "type": "michineki",
-    "title": "道の駅豊崎周辺のポケふた（4枚）",
-    "url": "https://it-social.net/roadside_station/?47006",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "47006",
-      "station_name": "道の駅豊崎",
-      "pref": "沖縄県",
-      "lat": 26.1576946,
-      "lng": 127.6553335,
-      "manhole_count": 4,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "233",
-          "title": "沖縄県/豊見城市",
-          "city": "豊見城",
-          "pokemons": [
-            "キバゴ",
-            "ジャラコ"
-          ],
-          "dist_km": 0.08,
-          "lat": 26.15755646,
-          "lng": 127.656121
-        },
-        {
-          "id": "231",
-          "title": "沖縄県/糸満市",
-          "city": "糸満",
-          "pokemons": [
-            "カメール",
-            "スナバァ"
-          ],
-          "dist_km": 2.24,
-          "lat": 26.13828,
-          "lng": 127.661336
-        },
-        {
-          "id": "174",
-          "title": "沖縄県/那覇市",
-          "city": "那覇",
-          "pokemons": [
-            "ウインディ"
-          ],
-          "dist_km": 7.36,
-          "lat": 26.21641,
-          "lng": 127.68942
-        },
-        {
-          "id": "446",
-          "title": "沖縄県/那覇市",
-          "city": "那覇",
-          "pokemons": [
-            "ガーディ"
-          ],
-          "dist_km": 9.24,
-          "lat": 26.22005,
-          "lng": 127.71657
-        }
-      ]
-    }
-  },
-  {
-    "id": "michineki-47007",
-    "type": "michineki",
-    "title": "道の駅いとまん周辺のポケふた（3枚）",
-    "url": "https://it-social.net/roadside_station/?47007",
-    "hashtags": [
-      "#ポケふた",
-      "#ポケモンマンホール"
-    ],
-    "imageType": "michineki",
-    "source": "michineki",
-    "raw_data": {
-      "station_id": "47007",
-      "station_name": "道の駅いとまん",
-      "pref": "沖縄県",
-      "lat": 26.1384965,
-      "lng": 127.661156,
-      "manhole_count": 3,
-      "radius_km": 10,
-      "manholes": [
-        {
-          "id": "231",
-          "title": "沖縄県/糸満市",
-          "city": "糸満",
-          "pokemons": [
-            "カメール",
-            "スナバァ"
-          ],
-          "dist_km": 0.03,
-          "lat": 26.13828,
-          "lng": 127.661336
-        },
-        {
-          "id": "233",
-          "title": "沖縄県/豊見城市",
-          "city": "豊見城",
-          "pokemons": [
-            "キバゴ",
-            "ジャラコ"
-          ],
-          "dist_km": 2.18,
-          "lat": 26.15755646,
-          "lng": 127.656121
-        },
-        {
-          "id": "174",
-          "title": "沖縄県/那覇市",
-          "city": "那覇",
-          "pokemons": [
-            "ウインディ"
-          ],
-          "dist_km": 9.11,
-          "lat": 26.21641,
-          "lng": 127.68942
-        }
-      ]
-    }
-  },
-  {
     "id": "island-小笠原",
     "type": "remote_island",
     "title": "小笠原諸島のポケふた（4枚）",
@@ -4327,9 +1370,9 @@
     }
   },
   {
-    "id": "pref-trivia-hokkaido-vulpix",
+    "id": "pref-trivia-hokkaido-support-vulpix",
     "type": "pref_trivia",
-    "title": "北海道の応援ポケモンはロコン",
+    "title": "北海道のポケふたトリビア",
     "url": "https://data.pokefuta.com/summary/",
     "hashtags": [
       "#ポケふた",
@@ -4338,19 +1381,21 @@
     "imageType": "summary_trivia",
     "source": "pref_trivia",
     "raw_data": {
-      "fact_type": "pref_trivia",
+      "fact_type": "support_pokemon",
       "values": {
         "prefecture": "北海道",
-        "pokemon": "ロコン",
-        "summary": "雪国・北海道のイメージにぴったりのロコン。アローラロコンも設置されており、北の大地で2種類に出会えます。",
-        "map_pref": "北海道"
+        "manhole_count": 50,
+        "summary": "北海道の推しポケモンは、雪景色にもなじむアローラロコンとロコンです",
+        "map_pref": "北海道",
+        "source_type": "official",
+        "source_url": "https://local.pokemon.jp/municipality/hokkaido/"
       }
     }
   },
   {
-    "id": "pref-trivia-iwate-geodude",
+    "id": "pref-trivia-北海道-vulpix-family-100",
     "type": "pref_trivia",
-    "title": "岩手県の応援ポケモンはイシツブテ",
+    "title": "北海道のポケふたトリビア",
     "url": "https://data.pokefuta.com/summary/",
     "hashtags": [
       "#ポケふた",
@@ -4359,19 +1404,44 @@
     "imageType": "summary_trivia",
     "source": "pref_trivia",
     "raw_data": {
-      "fact_type": "pref_trivia",
+      "fact_type": "pokemon_group_100",
+      "values": {
+        "prefecture": "北海道",
+        "manhole_count": 50,
+        "summary": "県内50枚すべてにロコン系が登場します",
+        "map_pref": "北海道",
+        "source_type": "dataset",
+        "source_url": ""
+      }
+    }
+  },
+  {
+    "id": "pref-trivia-iwate-geodude-wordplay",
+    "type": "pref_trivia",
+    "title": "岩手県のポケふたトリビア",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "summary_trivia",
+    "source": "pref_trivia",
+    "raw_data": {
+      "fact_type": "wordplay",
       "values": {
         "prefecture": "岩手県",
-        "pokemon": "イシツブテ",
-        "summary": "「岩手」という地名とイシツブテの語呂合わせが縁。県内各地に設置されています。",
-        "map_pref": "岩手県"
+        "manhole_count": 36,
+        "summary": "岩タイプで「岩」に「手」が付いたイシツブテが、いわて応援ポケモンを務めています",
+        "map_pref": "岩手県",
+        "source_type": "official",
+        "source_url": "https://local.pokemon.jp/municipality/iwate/"
       }
     }
   },
   {
-    "id": "pref-trivia-miyagi-lapras",
+    "id": "pref-trivia-岩手県-top-pokemon",
     "type": "pref_trivia",
-    "title": "宮城県の応援ポケモンはラプラス",
+    "title": "岩手県のポケふたトリビア",
     "url": "https://data.pokefuta.com/summary/",
     "hashtags": [
       "#ポケふた",
@@ -4380,19 +1450,44 @@
     "imageType": "summary_trivia",
     "source": "pref_trivia",
     "raw_data": {
-      "fact_type": "pref_trivia",
+      "fact_type": "top_pokemon",
+      "values": {
+        "prefecture": "岩手県",
+        "manhole_count": 36,
+        "summary": "最も多く登場するのはイシツブテで、20枚に描かれています",
+        "map_pref": "岩手県",
+        "source_type": "dataset",
+        "source_url": ""
+      }
+    }
+  },
+  {
+    "id": "pref-trivia-miyagi-support-lapras",
+    "type": "pref_trivia",
+    "title": "宮城県のポケふたトリビア",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "summary_trivia",
+    "source": "pref_trivia",
+    "raw_data": {
+      "fact_type": "support_pokemon",
       "values": {
         "prefecture": "宮城県",
-        "pokemon": "ラプラス",
-        "summary": "松島の海をイメージしたラプラス。宮城の豊かな海辺の風景と重なります。",
-        "map_pref": "宮城県"
+        "manhole_count": 37,
+        "summary": "宮城県ではラプラスがみやぎ応援ポケモンとして地域の魅力を発信しています",
+        "map_pref": "宮城県",
+        "source_type": "official",
+        "source_url": "https://local.pokemon.jp/municipality/miyagi/"
       }
     }
   },
   {
-    "id": "pref-trivia-fukushima-chansey",
+    "id": "pref-trivia-宮城県-ラプラス-100",
     "type": "pref_trivia",
-    "title": "福島県の応援ポケモンはラッキー",
+    "title": "宮城県のポケふたトリビア",
     "url": "https://data.pokefuta.com/summary/",
     "hashtags": [
       "#ポケふた",
@@ -4401,19 +1496,44 @@
     "imageType": "summary_trivia",
     "source": "pref_trivia",
     "raw_data": {
-      "fact_type": "pref_trivia",
+      "fact_type": "pokemon_100",
+      "values": {
+        "prefecture": "宮城県",
+        "manhole_count": 37,
+        "summary": "県内37枚すべてにラプラスが登場します",
+        "map_pref": "宮城県",
+        "source_type": "dataset",
+        "source_url": ""
+      }
+    }
+  },
+  {
+    "id": "pref-trivia-fukushima-support-chansey",
+    "type": "pref_trivia",
+    "title": "福島県のポケふたトリビア",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "summary_trivia",
+    "source": "pref_trivia",
+    "raw_data": {
+      "fact_type": "support_pokemon",
       "values": {
         "prefecture": "福島県",
-        "pokemon": "ラッキー",
-        "summary": "「福」の字が縁で選ばれたラッキー。幸運を運ぶイメージが福島県とぴったりで、県内に多く設置されています。",
-        "map_pref": "福島県"
+        "manhole_count": 43,
+        "summary": "福島県では、幸せを運ぶといわれるラッキーがふくしま応援ポケモンを務めています",
+        "map_pref": "福島県",
+        "source_type": "official",
+        "source_url": "https://local.pokemon.jp/municipality/fukushima/"
       }
     }
   },
   {
-    "id": "pref-trivia-tottori-sandshrew",
+    "id": "pref-trivia-福島県-ラッキー-100",
     "type": "pref_trivia",
-    "title": "鳥取県の応援ポケモンはサンド",
+    "title": "福島県のポケふたトリビア",
     "url": "https://data.pokefuta.com/summary/",
     "hashtags": [
       "#ポケふた",
@@ -4422,19 +1542,21 @@
     "imageType": "summary_trivia",
     "source": "pref_trivia",
     "raw_data": {
-      "fact_type": "pref_trivia",
+      "fact_type": "pokemon_100",
       "values": {
-        "prefecture": "鳥取県",
-        "pokemon": "サンド",
-        "summary": "「砂丘のまち」鳥取ならではの選択。通常のすがたとアローラのすがたの2種が設置されており、鳥取砂丘との縁は一目瞭然です。",
-        "map_pref": "鳥取県"
+        "prefecture": "福島県",
+        "manhole_count": 43,
+        "summary": "県内43枚すべてにラッキーが登場します",
+        "map_pref": "福島県",
+        "source_type": "dataset",
+        "source_url": ""
       }
     }
   },
   {
-    "id": "pref-trivia-fukui-dragonite",
+    "id": "pref-trivia-栃木県-single-municipality",
     "type": "pref_trivia",
-    "title": "福井県の応援ポケモンはカイリュー",
+    "title": "栃木県のポケふたトリビア",
     "url": "https://data.pokefuta.com/summary/",
     "hashtags": [
       "#ポケふた",
@@ -4443,19 +1565,274 @@
     "imageType": "summary_trivia",
     "source": "pref_trivia",
     "raw_data": {
-      "fact_type": "pref_trivia",
+      "fact_type": "single_municipality",
+      "values": {
+        "prefecture": "栃木県",
+        "manhole_count": 3,
+        "summary": "県内3枚のポケふたはすべて宇都宮にあります",
+        "map_pref": "栃木県",
+        "source_type": "dataset",
+        "source_url": ""
+      }
+    }
+  },
+  {
+    "id": "pref-trivia-埼玉県-single-municipality",
+    "type": "pref_trivia",
+    "title": "埼玉県のポケふたトリビア",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "summary_trivia",
+    "source": "pref_trivia",
+    "raw_data": {
+      "fact_type": "single_municipality",
+      "values": {
+        "prefecture": "埼玉県",
+        "manhole_count": 3,
+        "summary": "県内3枚のポケふたはすべて所沢にあります",
+        "map_pref": "埼玉県",
+        "source_type": "dataset",
+        "source_url": ""
+      }
+    }
+  },
+  {
+    "id": "pref-trivia-千葉県-single-municipality",
+    "type": "pref_trivia",
+    "title": "千葉県のポケふたトリビア",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "summary_trivia",
+    "source": "pref_trivia",
+    "raw_data": {
+      "fact_type": "single_municipality",
+      "values": {
+        "prefecture": "千葉県",
+        "manhole_count": 4,
+        "summary": "県内4枚のポケふたはすべて香取にあります",
+        "map_pref": "千葉県",
+        "source_type": "dataset",
+        "source_url": ""
+      }
+    }
+  },
+  {
+    "id": "pref-trivia-tokyo-pokepark-kanto-admission",
+    "type": "pref_trivia",
+    "title": "東京都のポケふたトリビア",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "summary_trivia",
+    "source": "pref_trivia",
+    "raw_data": {
+      "fact_type": "local_connection",
+      "values": {
+        "prefecture": "東京都",
+        "manhole_count": 13,
+        "summary": "稲城市のポケパーク カントー内にも1枚あり、見るにはポケパーク カントーへの入場が必要です",
+        "map_pref": "東京都",
+        "source_type": "official",
+        "source_url": "https://local.pokemon.jp/manhole/desc/448/"
+      }
+    }
+  },
+  {
+    "id": "pref-trivia-東京都-municipality-concentration",
+    "type": "pref_trivia",
+    "title": "東京都のポケふたトリビア",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "summary_trivia",
+    "source": "pref_trivia",
+    "raw_data": {
+      "fact_type": "municipality_concentration",
+      "values": {
+        "prefecture": "東京都",
+        "manhole_count": 13,
+        "summary": "最多は町田の6枚で、次いで小笠原の4枚です",
+        "map_pref": "東京都",
+        "source_type": "dataset",
+        "source_url": ""
+      }
+    }
+  },
+  {
+    "id": "pref-trivia-神奈川県-single-municipality",
+    "type": "pref_trivia",
+    "title": "神奈川県のポケふたトリビア",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "summary_trivia",
+    "source": "pref_trivia",
+    "raw_data": {
+      "fact_type": "single_municipality",
+      "values": {
+        "prefecture": "神奈川県",
+        "manhole_count": 5,
+        "summary": "県内5枚のポケふたはすべて横浜にあります",
+        "map_pref": "神奈川県",
+        "source_type": "dataset",
+        "source_url": ""
+      }
+    }
+  },
+  {
+    "id": "pref-trivia-神奈川県-ピカチュウ-100",
+    "type": "pref_trivia",
+    "title": "神奈川県のポケふたトリビア",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "summary_trivia",
+    "source": "pref_trivia",
+    "raw_data": {
+      "fact_type": "pokemon_100",
+      "values": {
+        "prefecture": "神奈川県",
+        "manhole_count": 5,
+        "summary": "県内5枚すべてにピカチュウが登場します",
+        "map_pref": "神奈川県",
+        "source_type": "dataset",
+        "source_url": ""
+      }
+    }
+  },
+  {
+    "id": "pref-trivia-niigata-ojiya-koi",
+    "type": "pref_trivia",
+    "title": "新潟県のポケふたトリビア",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "summary_trivia",
+    "source": "pref_trivia",
+    "raw_data": {
+      "fact_type": "local_connection",
+      "values": {
+        "prefecture": "新潟県",
+        "manhole_count": 4,
+        "summary": "錦鯉発祥の地として知られる小千谷にちなみ、コイキングのポケふたが設置されています",
+        "map_pref": "新潟県",
+        "source_type": "official",
+        "source_url": "https://www.city.ojiya.niigata.jp/site/kanko/pokemon.html"
+      }
+    }
+  },
+  {
+    "id": "pref-trivia-新潟県-single-municipality",
+    "type": "pref_trivia",
+    "title": "新潟県のポケふたトリビア",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "summary_trivia",
+    "source": "pref_trivia",
+    "raw_data": {
+      "fact_type": "single_municipality",
+      "values": {
+        "prefecture": "新潟県",
+        "manhole_count": 4,
+        "summary": "県内4枚のポケふたはすべて小千谷にあります",
+        "map_pref": "新潟県",
+        "source_type": "dataset",
+        "source_url": ""
+      }
+    }
+  },
+  {
+    "id": "pref-trivia-新潟県-コイキング-100",
+    "type": "pref_trivia",
+    "title": "新潟県のポケふたトリビア",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "summary_trivia",
+    "source": "pref_trivia",
+    "raw_data": {
+      "fact_type": "pokemon_100",
+      "values": {
+        "prefecture": "新潟県",
+        "manhole_count": 4,
+        "summary": "県内4枚すべてにコイキングが登場します",
+        "map_pref": "新潟県",
+        "source_type": "dataset",
+        "source_url": ""
+      }
+    }
+  },
+  {
+    "id": "pref-trivia-富山県-single-municipality",
+    "type": "pref_trivia",
+    "title": "富山県のポケふたトリビア",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "summary_trivia",
+    "source": "pref_trivia",
+    "raw_data": {
+      "fact_type": "single_municipality",
+      "values": {
+        "prefecture": "富山県",
+        "manhole_count": 3,
+        "summary": "県内3枚のポケふたはすべて富山にあります",
+        "map_pref": "富山県",
+        "source_type": "dataset",
+        "source_url": ""
+      }
+    }
+  },
+  {
+    "id": "pref-trivia-fukui-support-dragonite",
+    "type": "pref_trivia",
+    "title": "福井県のポケふたトリビア",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "summary_trivia",
+    "source": "pref_trivia",
+    "raw_data": {
+      "fact_type": "support_pokemon",
       "values": {
         "prefecture": "福井県",
-        "pokemon": "カイリュー",
-        "summary": "九頭竜川をはじめ「竜」の地名が多い福井。カイリューは県内17枚すべてに登場するほど定着しています。",
-        "map_pref": "福井県"
+        "manhole_count": 17,
+        "summary": "福井県ではカイリューがふくい応援ポケモンとして地域を盛り上げています",
+        "map_pref": "福井県",
+        "source_type": "official",
+        "source_url": "https://local.pokemon.jp/municipality/fukui/"
       }
     }
   },
   {
-    "id": "pref-trivia-kagawa-slowpoke",
+    "id": "pref-trivia-福井県-カイリュー-100",
     "type": "pref_trivia",
-    "title": "香川県の応援ポケモンはヤドン",
+    "title": "福井県のポケふたトリビア",
     "url": "https://data.pokefuta.com/summary/",
     "hashtags": [
       "#ポケふた",
@@ -4464,19 +1841,21 @@
     "imageType": "summary_trivia",
     "source": "pref_trivia",
     "raw_data": {
-      "fact_type": "pref_trivia",
+      "fact_type": "pokemon_100",
       "values": {
-        "prefecture": "香川県",
-        "pokemon": "ヤドン",
-        "summary": "香川県は2021年に公式で「ヤドン県」を一時採用した実績あり。冗談ではなく公式です。その縁で県内各地にヤドンのポケふたが設置されています。",
-        "map_pref": "香川県"
+        "prefecture": "福井県",
+        "manhole_count": 17,
+        "summary": "県内17枚すべてにカイリューが登場します",
+        "map_pref": "福井県",
+        "source_type": "dataset",
+        "source_url": ""
       }
     }
   },
   {
-    "id": "pref-trivia-kochi-quagsire",
+    "id": "pref-trivia-愛知県-municipality-concentration",
     "type": "pref_trivia",
-    "title": "高知県の応援ポケモンはヌオー",
+    "title": "愛知県のポケふたトリビア",
     "url": "https://data.pokefuta.com/summary/",
     "hashtags": [
       "#ポケふた",
@@ -4485,19 +1864,21 @@
     "imageType": "summary_trivia",
     "source": "pref_trivia",
     "raw_data": {
-      "fact_type": "pref_trivia",
+      "fact_type": "municipality_concentration",
       "values": {
-        "prefecture": "高知県",
-        "pokemon": "ヌオー",
-        "summary": "日本最後の清流・四万十川をイメージしたヌオー。水辺をのんびり過ごすイメージが高知の川文化と重なります。県内18枚すべてにヌオーが登場します。",
-        "map_pref": "高知県"
+        "prefecture": "愛知県",
+        "manhole_count": 9,
+        "summary": "豊橋市に4枚が集まり、ほかの5自治体は各1枚です",
+        "map_pref": "愛知県",
+        "source_type": "dataset",
+        "source_url": ""
       }
     }
   },
   {
-    "id": "pref-trivia-mie-oshawott",
+    "id": "pref-trivia-mie-support-oshawott",
     "type": "pref_trivia",
-    "title": "三重県の応援ポケモンはミジュマル",
+    "title": "三重県のポケふたトリビア",
     "url": "https://data.pokefuta.com/summary/",
     "hashtags": [
       "#ポケふた",
@@ -4506,19 +1887,21 @@
     "imageType": "summary_trivia",
     "source": "pref_trivia",
     "raw_data": {
-      "fact_type": "pref_trivia",
+      "fact_type": "support_pokemon",
       "values": {
         "prefecture": "三重県",
-        "pokemon": "ミジュマル",
-        "summary": "「みえ」と「みず」のイメージが重なるミジュマル。伊勢志摩の海の雰囲気とも相性が良く、県内各地に設置されています。",
-        "map_pref": "三重県"
+        "manhole_count": 31,
+        "summary": "三重県ではミジュマルがみえ応援ポケモンとして地域の魅力を発信しています",
+        "map_pref": "三重県",
+        "source_type": "official",
+        "source_url": "https://local.pokemon.jp/municipality/mie/"
       }
     }
   },
   {
-    "id": "pref-trivia-nagasaki-ampharos",
+    "id": "pref-trivia-三重県-ミジュマル-100",
     "type": "pref_trivia",
-    "title": "長崎県の応援ポケモンはデンリュウ",
+    "title": "三重県のポケふたトリビア",
     "url": "https://data.pokefuta.com/summary/",
     "hashtags": [
       "#ポケふた",
@@ -4527,19 +1910,481 @@
     "imageType": "summary_trivia",
     "source": "pref_trivia",
     "raw_data": {
-      "fact_type": "pref_trivia",
+      "fact_type": "pokemon_100",
+      "values": {
+        "prefecture": "三重県",
+        "manhole_count": 31,
+        "summary": "県内31枚すべてにミジュマルが登場します",
+        "map_pref": "三重県",
+        "source_type": "dataset",
+        "source_url": ""
+      }
+    }
+  },
+  {
+    "id": "pref-trivia-滋賀県-municipality-concentration",
+    "type": "pref_trivia",
+    "title": "滋賀県のポケふたトリビア",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "summary_trivia",
+    "source": "pref_trivia",
+    "raw_data": {
+      "fact_type": "municipality_concentration",
+      "values": {
+        "prefecture": "滋賀県",
+        "manhole_count": 5,
+        "summary": "最多は甲賀の3枚で、次いで大津の2枚です",
+        "map_pref": "滋賀県",
+        "source_type": "dataset",
+        "source_url": ""
+      }
+    }
+  },
+  {
+    "id": "pref-trivia-滋賀県-top-pokemon",
+    "type": "pref_trivia",
+    "title": "滋賀県のポケふたトリビア",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "summary_trivia",
+    "source": "pref_trivia",
+    "raw_data": {
+      "fact_type": "top_pokemon",
+      "values": {
+        "prefecture": "滋賀県",
+        "manhole_count": 5,
+        "summary": "最も多く登場するのはゲッコウガで、3枚に描かれています",
+        "map_pref": "滋賀県",
+        "source_type": "dataset",
+        "source_url": ""
+      }
+    }
+  },
+  {
+    "id": "pref-trivia-京都府-municipality-concentration",
+    "type": "pref_trivia",
+    "title": "京都府のポケふたトリビア",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "summary_trivia",
+    "source": "pref_trivia",
+    "raw_data": {
+      "fact_type": "municipality_concentration",
+      "values": {
+        "prefecture": "京都府",
+        "manhole_count": 8,
+        "summary": "最多は京都の5枚で、次いで宇治の3枚です",
+        "map_pref": "京都府",
+        "source_type": "dataset",
+        "source_url": ""
+      }
+    }
+  },
+  {
+    "id": "pref-trivia-大阪府-single-municipality",
+    "type": "pref_trivia",
+    "title": "大阪府のポケふたトリビア",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "summary_trivia",
+    "source": "pref_trivia",
+    "raw_data": {
+      "fact_type": "single_municipality",
+      "values": {
+        "prefecture": "大阪府",
+        "manhole_count": 5,
+        "summary": "県内5枚のポケふたはすべて東大阪にあります",
+        "map_pref": "大阪府",
+        "source_type": "dataset",
+        "source_url": ""
+      }
+    }
+  },
+  {
+    "id": "pref-trivia-兵庫県-single-municipality",
+    "type": "pref_trivia",
+    "title": "兵庫県のポケふたトリビア",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "summary_trivia",
+    "source": "pref_trivia",
+    "raw_data": {
+      "fact_type": "single_municipality",
+      "values": {
+        "prefecture": "兵庫県",
+        "manhole_count": 3,
+        "summary": "県内3枚のポケふたはすべて淡路にあります",
+        "map_pref": "兵庫県",
+        "source_type": "dataset",
+        "source_url": ""
+      }
+    }
+  },
+  {
+    "id": "pref-trivia-奈良県-single-municipality",
+    "type": "pref_trivia",
+    "title": "奈良県のポケふたトリビア",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "summary_trivia",
+    "source": "pref_trivia",
+    "raw_data": {
+      "fact_type": "single_municipality",
+      "values": {
+        "prefecture": "奈良県",
+        "manhole_count": 5,
+        "summary": "県内5枚のポケふたはすべて斑鳩にあります",
+        "map_pref": "奈良県",
+        "source_type": "dataset",
+        "source_url": ""
+      }
+    }
+  },
+  {
+    "id": "pref-trivia-tottori-sand",
+    "type": "pref_trivia",
+    "title": "鳥取県のポケふたトリビア",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "summary_trivia",
+    "source": "pref_trivia",
+    "raw_data": {
+      "fact_type": "local_connection",
+      "values": {
+        "prefecture": "鳥取県",
+        "manhole_count": 20,
+        "summary": "鳥取砂丘をはじめ砂で知られる鳥取県では、サンドとアローラサンドが推しポケモンです",
+        "map_pref": "鳥取県",
+        "source_type": "official",
+        "source_url": "https://local.pokemon.jp/municipality/tottori/"
+      }
+    }
+  },
+  {
+    "id": "pref-trivia-鳥取県-sandshrew-family-100",
+    "type": "pref_trivia",
+    "title": "鳥取県のポケふたトリビア",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "summary_trivia",
+    "source": "pref_trivia",
+    "raw_data": {
+      "fact_type": "pokemon_group_100",
+      "values": {
+        "prefecture": "鳥取県",
+        "manhole_count": 20,
+        "summary": "県内20枚すべてにサンド系が登場します",
+        "map_pref": "鳥取県",
+        "source_type": "dataset",
+        "source_url": ""
+      }
+    }
+  },
+  {
+    "id": "pref-trivia-岡山県-single-municipality",
+    "type": "pref_trivia",
+    "title": "岡山県のポケふたトリビア",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "summary_trivia",
+    "source": "pref_trivia",
+    "raw_data": {
+      "fact_type": "single_municipality",
+      "values": {
+        "prefecture": "岡山県",
+        "manhole_count": 4,
+        "summary": "県内4枚のポケふたはすべて倉敷にあります",
+        "map_pref": "岡山県",
+        "source_type": "dataset",
+        "source_url": ""
+      }
+    }
+  },
+  {
+    "id": "pref-trivia-山口県-single-municipality",
+    "type": "pref_trivia",
+    "title": "山口県のポケふたトリビア",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "summary_trivia",
+    "source": "pref_trivia",
+    "raw_data": {
+      "fact_type": "single_municipality",
+      "values": {
+        "prefecture": "山口県",
+        "manhole_count": 4,
+        "summary": "県内4枚のポケふたはすべて下関にあります",
+        "map_pref": "山口県",
+        "source_type": "dataset",
+        "source_url": ""
+      }
+    }
+  },
+  {
+    "id": "pref-trivia-徳島県-single-municipality",
+    "type": "pref_trivia",
+    "title": "徳島県のポケふたトリビア",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "summary_trivia",
+    "source": "pref_trivia",
+    "raw_data": {
+      "fact_type": "single_municipality",
+      "values": {
+        "prefecture": "徳島県",
+        "manhole_count": 3,
+        "summary": "県内3枚のポケふたはすべて鳴門にあります",
+        "map_pref": "徳島県",
+        "source_type": "dataset",
+        "source_url": ""
+      }
+    }
+  },
+  {
+    "id": "pref-trivia-kagawa-slowpoke-wordplay",
+    "type": "pref_trivia",
+    "title": "香川県のポケふたトリビア",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "summary_trivia",
+    "source": "pref_trivia",
+    "raw_data": {
+      "fact_type": "wordplay",
+      "values": {
+        "prefecture": "香川県",
+        "manhole_count": 18,
+        "summary": "香川県では「うどん」と音の響きが似ているヤドンが推しポケモンです",
+        "map_pref": "香川県",
+        "source_type": "official",
+        "source_url": "https://local.pokemon.jp/municipality/kagawa/"
+      }
+    }
+  },
+  {
+    "id": "pref-trivia-香川県-top-pokemon",
+    "type": "pref_trivia",
+    "title": "香川県のポケふたトリビア",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "summary_trivia",
+    "source": "pref_trivia",
+    "raw_data": {
+      "fact_type": "top_pokemon",
+      "values": {
+        "prefecture": "香川県",
+        "manhole_count": 18,
+        "summary": "最も多く登場するのはヤドンで、17枚に描かれています",
+        "map_pref": "香川県",
+        "source_type": "dataset",
+        "source_url": ""
+      }
+    }
+  },
+  {
+    "id": "pref-trivia-愛媛県-single-municipality",
+    "type": "pref_trivia",
+    "title": "愛媛県のポケふたトリビア",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "summary_trivia",
+    "source": "pref_trivia",
+    "raw_data": {
+      "fact_type": "single_municipality",
+      "values": {
+        "prefecture": "愛媛県",
+        "manhole_count": 2,
+        "summary": "県内2枚のポケふたはすべて松山にあります",
+        "map_pref": "愛媛県",
+        "source_type": "dataset",
+        "source_url": ""
+      }
+    }
+  },
+  {
+    "id": "pref-trivia-kochi-support-quagsire",
+    "type": "pref_trivia",
+    "title": "高知県のポケふたトリビア",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "summary_trivia",
+    "source": "pref_trivia",
+    "raw_data": {
+      "fact_type": "support_pokemon",
+      "values": {
+        "prefecture": "高知県",
+        "manhole_count": 18,
+        "summary": "高知県では、水辺に生息するヌオーがこうちだいすきポケモンとして活動しています",
+        "map_pref": "高知県",
+        "source_type": "official",
+        "source_url": "https://local.pokemon.jp/municipality/kochi/"
+      }
+    }
+  },
+  {
+    "id": "pref-trivia-高知県-ヌオー-100",
+    "type": "pref_trivia",
+    "title": "高知県のポケふたトリビア",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "summary_trivia",
+    "source": "pref_trivia",
+    "raw_data": {
+      "fact_type": "pokemon_100",
+      "values": {
+        "prefecture": "高知県",
+        "manhole_count": 18,
+        "summary": "県内18枚すべてにヌオーが登場します",
+        "map_pref": "高知県",
+        "source_type": "dataset",
+        "source_url": ""
+      }
+    }
+  },
+  {
+    "id": "pref-trivia-福岡県-municipality-concentration",
+    "type": "pref_trivia",
+    "title": "福岡県のポケふたトリビア",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "summary_trivia",
+    "source": "pref_trivia",
+    "raw_data": {
+      "fact_type": "municipality_concentration",
+      "values": {
+        "prefecture": "福岡県",
+        "manhole_count": 8,
+        "summary": "最多は北九州の5枚で、次いで太宰府の3枚です",
+        "map_pref": "福岡県",
+        "source_type": "dataset",
+        "source_url": ""
+      }
+    }
+  },
+  {
+    "id": "pref-trivia-佐賀県-single-municipality",
+    "type": "pref_trivia",
+    "title": "佐賀県のポケふたトリビア",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "summary_trivia",
+    "source": "pref_trivia",
+    "raw_data": {
+      "fact_type": "single_municipality",
+      "values": {
+        "prefecture": "佐賀県",
+        "manhole_count": 3,
+        "summary": "県内3枚のポケふたはすべて佐賀にあります",
+        "map_pref": "佐賀県",
+        "source_type": "dataset",
+        "source_url": ""
+      }
+    }
+  },
+  {
+    "id": "pref-trivia-佐賀県-meowth-forms-100",
+    "type": "pref_trivia",
+    "title": "佐賀県のポケふたトリビア",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "summary_trivia",
+    "source": "pref_trivia",
+    "raw_data": {
+      "fact_type": "pokemon_group_100",
+      "values": {
+        "prefecture": "佐賀県",
+        "manhole_count": 3,
+        "summary": "県内3枚すべてにニャース3種が登場します",
+        "map_pref": "佐賀県",
+        "source_type": "dataset",
+        "source_url": ""
+      }
+    }
+  },
+  {
+    "id": "pref-trivia-nagasaki-support-ampharos",
+    "type": "pref_trivia",
+    "title": "長崎県のポケふたトリビア",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "summary_trivia",
+    "source": "pref_trivia",
+    "raw_data": {
+      "fact_type": "support_pokemon",
       "values": {
         "prefecture": "長崎県",
-        "pokemon": "デンリュウ",
-        "summary": "「灯台のポケモン」デンリュウが選ばれた長崎。港町・長崎の灯台文化と重なり、県内10枚すべてにデンリュウが登場します。",
-        "map_pref": "長崎県"
+        "manhole_count": 10,
+        "summary": "長崎県では、尻尾の光が遠くまで届くデンリュウがながさき未来応援ポケモンを務めています",
+        "map_pref": "長崎県",
+        "source_type": "official",
+        "source_url": "https://local.pokemon.jp/municipality/nagasaki/"
       }
     }
   },
   {
-    "id": "pref-trivia-miyazaki-exeggutor",
+    "id": "pref-trivia-長崎県-デンリュウ-100",
     "type": "pref_trivia",
-    "title": "宮崎県の応援ポケモンはナッシー",
+    "title": "長崎県のポケふたトリビア",
     "url": "https://data.pokefuta.com/summary/",
     "hashtags": [
       "#ポケふた",
@@ -4548,19 +2393,44 @@
     "imageType": "summary_trivia",
     "source": "pref_trivia",
     "raw_data": {
-      "fact_type": "pref_trivia",
+      "fact_type": "pokemon_100",
+      "values": {
+        "prefecture": "長崎県",
+        "manhole_count": 10,
+        "summary": "県内10枚すべてにデンリュウが登場します",
+        "map_pref": "長崎県",
+        "source_type": "dataset",
+        "source_url": ""
+      }
+    }
+  },
+  {
+    "id": "pref-trivia-miyazaki-support-exeggutor",
+    "type": "pref_trivia",
+    "title": "宮崎県のポケふたトリビア",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "summary_trivia",
+    "source": "pref_trivia",
+    "raw_data": {
+      "fact_type": "support_pokemon",
       "values": {
         "prefecture": "宮崎県",
-        "pokemon": "ナッシー",
-        "summary": "温暖な南国・宮崎の雰囲気にぴったりのナッシー。県木のフェニックス（ヤシ科）とも相性抜群で、南国感あふれる設置地点が多いです。",
-        "map_pref": "宮崎県"
+        "manhole_count": 26,
+        "summary": "南国のイメージに合うナッシーとアローラナッシーが、宮崎だいすきポケモンとして活動しています",
+        "map_pref": "宮崎県",
+        "source_type": "official",
+        "source_url": "https://local.pokemon.jp/municipality/miyazaki/"
       }
     }
   },
   {
-    "id": "pref-trivia-okinawa-growlithe",
+    "id": "pref-trivia-宮崎県-exeggutor-family-100",
     "type": "pref_trivia",
-    "title": "沖縄県の応援ポケモンはガーディ",
+    "title": "宮崎県のポケふたトリビア",
     "url": "https://data.pokefuta.com/summary/",
     "hashtags": [
       "#ポケふた",
@@ -4569,12 +2439,106 @@
     "imageType": "summary_trivia",
     "source": "pref_trivia",
     "raw_data": {
-      "fact_type": "pref_trivia",
+      "fact_type": "pokemon_group_100",
+      "values": {
+        "prefecture": "宮崎県",
+        "manhole_count": 26,
+        "summary": "県内26枚すべてにナッシー系が登場します",
+        "map_pref": "宮崎県",
+        "source_type": "dataset",
+        "source_url": ""
+      }
+    }
+  },
+  {
+    "id": "pref-trivia-kagoshima-ibusuki-eevee",
+    "type": "pref_trivia",
+    "title": "鹿児島県のポケふたトリビア",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "summary_trivia",
+    "source": "pref_trivia",
+    "raw_data": {
+      "fact_type": "wordplay",
+      "values": {
+        "prefecture": "鹿児島県",
+        "manhole_count": 9,
+        "summary": "「イーブイすき」と「いぶすき」の語呂合わせをきっかけに、指宿へイーブイのポケふたが設置されました",
+        "map_pref": "鹿児島県",
+        "source_type": "official",
+        "source_url": "https://www.city.ibusuki.lg.jp/main/info/page014900.html"
+      }
+    }
+  },
+  {
+    "id": "pref-trivia-鹿児島県-single-municipality",
+    "type": "pref_trivia",
+    "title": "鹿児島県のポケふたトリビア",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "summary_trivia",
+    "source": "pref_trivia",
+    "raw_data": {
+      "fact_type": "single_municipality",
+      "values": {
+        "prefecture": "鹿児島県",
+        "manhole_count": 9,
+        "summary": "県内9枚のポケふたはすべて指宿にあります",
+        "map_pref": "鹿児島県",
+        "source_type": "dataset",
+        "source_url": ""
+      }
+    }
+  },
+  {
+    "id": "pref-trivia-okinawa-support-growlithe",
+    "type": "pref_trivia",
+    "title": "沖縄県のポケふたトリビア",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "summary_trivia",
+    "source": "pref_trivia",
+    "raw_data": {
+      "fact_type": "support_pokemon",
       "values": {
         "prefecture": "沖縄県",
-        "pokemon": "ガーディ",
-        "summary": "沖縄の守り神・シーサーを思わせるガーディ。魔除けの獅子犬と炎のポケモンのイメージが重なり、県内各地に設置されています。",
-        "map_pref": "沖縄県"
+        "manhole_count": 17,
+        "summary": "沖縄県では、シーサーを思わせるガーディが沖縄応援ポケモンとして活動しています",
+        "map_pref": "沖縄県",
+        "source_type": "official",
+        "source_url": "https://local.pokemon.jp/municipality/okinawa/"
+      }
+    }
+  },
+  {
+    "id": "pref-trivia-沖縄県-top-pokemon",
+    "type": "pref_trivia",
+    "title": "沖縄県のポケふたトリビア",
+    "url": "https://data.pokefuta.com/summary/",
+    "hashtags": [
+      "#ポケふた",
+      "#ポケモンマンホール"
+    ],
+    "imageType": "summary_trivia",
+    "source": "pref_trivia",
+    "raw_data": {
+      "fact_type": "top_pokemon",
+      "values": {
+        "prefecture": "沖縄県",
+        "manhole_count": 17,
+        "summary": "最も多く登場するのはガーディで、5枚に描かれています",
+        "map_pref": "沖縄県",
+        "source_type": "dataset",
+        "source_url": ""
       }
     }
   }


### PR DESCRIPTION
## 概要

`docs/pokefuta.ndjson` を正として、都道府県ごとの自治体分布・ポケモン出現率・100%出現を自動集計する生成処理を追加します。地域との由来や語呂合わせは、公式URLと確認日を持つ手動マスタへ分離しました。

## 変更内容

- `generate_prefecture_trivia.py` を追加し、47都道府県のトリビアJSONを再現可能に生成
- 1自治体集中、自治体別集中度、単体／グループ100%出現、有意なトップポケモンを自動判定
- 公式由来のトリビアを `prefecture_trivia_sources.json` で管理
- summary日本語カードに優先度順で最大3件を表示
- 各トリビアをX投稿候補へ展開
- 日次更新でトリビアとSNS候補を再生成し、Pagesビルドで生成物の鮮度を検証
- 佐賀・指宿の旧固定文をsummary生成コードから除外

## 表示上の調整

- 愛知県は「豊橋市に4枚が集まり、ほかの5自治体は各1枚」と表示
- 東京はポケパーク カントー内のポケふたに入場が必要な点を公式出典付きで表示
- 全ポケモンが各1枚の県では、不自然な「最多」文を生成しない
- 100%出現と同じ内容になる「最多」文を抑制
- ポケモン名に意味がないカードは「自治体分布」「1自治体に集中」へ置換

## 確認してほしい点

- 自治体集中トリビアの閾値: 単独首位、3枚以上、県内30%以上
- summaryカードの最大3件と優先順位
- 手動マスタの文面と公式出典
- 生成物をリポジトリ管理し、CIで `--check` する運用

## 検証

- `python3 apps/scraper/generate_prefecture_trivia.py --check`
- `python3 -m unittest apps.scraper.test_generate_prefecture_trivia`
- `python3 apps/scraper/generate_summary_pages.py`
- `python3 apps/scraper/generate_social_posts.py`
- `python3 -m py_compile apps/scraper/generate_prefecture_trivia.py apps/scraper/generate_summary_pages.py apps/scraper/generate_social_posts.py`
- `git diff --check`

すべて成功しています。
