### PR TITLE
[codex] Add prefecture map summaries

### DIFF
--- a/apps/web/assets/pokefuta-map.css
+++ b/apps/web/assets/pokefuta-map.css
@@ -987,6 +987,10 @@ body.pokefuta-map-page {
   border: 0;
 }
 
+.pokefuta-map-page .travel-popup-actions--has-photo {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
 .pokefuta-map-page .travel-popup-action {
   display: inline-flex;
   align-items: center;
@@ -1012,6 +1016,10 @@ body.pokefuta-map-page {
   background: linear-gradient(135deg, #7e5bb8, #6b4aa2);
   color: #fff;
   box-shadow: 0 8px 18px rgba(76, 45, 130, .2);
+}
+
+.pokefuta-map-page .travel-popup-actions--has-photo .travel-popup-action--primary {
+  grid-column: auto;
 }
 
 .pokefuta-map-page .travel-popup-action--upload {
@@ -1200,6 +1208,37 @@ body.pokefuta-map-page {
 
 .pokefuta-cluster--large span {
   font-size: 1.2rem;
+}
+
+.prefecture-overview-marker {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 42px !important;
+  height: 42px !important;
+  margin: -21px 0 0 -21px !important;
+  border: 2px solid rgba(255, 255, 255, .94);
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 30%, #9374c8, #624095 76%);
+  color: #fff;
+  box-shadow: 0 4px 12px rgba(67, 38, 111, .32);
+  font-weight: 850;
+  white-space: nowrap;
+}
+
+.prefecture-overview-name {
+  max-width: 36px;
+  overflow: hidden;
+  font-size: .58rem;
+  line-height: 1;
+  text-overflow: clip;
+}
+
+.prefecture-overview-count {
+  margin-top: 2px;
+  font-size: .9rem;
+  line-height: 1;
 }
 
 @media (min-width: 760px) {

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -297,7 +297,7 @@
     integrity="sha384-pmjIAcz2bAn0xukfxADbZIb3t8oRT9Sv0rvO+BR5Csr6Dhqq+nZs59P0pPKQJkEV" crossorigin="" />
   <link rel="stylesheet" href="./assets/theme.css" />
   <link rel="stylesheet" href="./assets/map.css" />
-  <link rel="stylesheet" href="./assets/pokefuta-map.css?v=20260613-popup-actions" />
+  <link rel="stylesheet" href="./assets/pokefuta-map.css?v=20260613-popup-actions-grid" />
   <link rel="icon" href="./assets/pokefuta-marker.svg" type="image/svg+xml" />
   <!-- Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-K18NR4GZG2"></script>
@@ -552,6 +552,7 @@
     var allMarkers = [];
     var allData = [];
     var markerLayer = null;
+    var prefectureOverviewLayer = L.layerGroup();
     var userLocationMarker = null;
     var latestPhotoMeta = {};
     var prefectureCounts = {};
@@ -566,6 +567,7 @@
     var prefectureBounds = {};  // 都道府県ごとのbounding box（グローバルスコープ）
     var prefectureMarkerCounts = {};  // 都道府県ごとのマンホール数（グローバルスコープ）
     const PREFECTURE_BOUNDS_OFFSET = 0.5;  // 都道府県 bounding box のオフセット（度）
+    const PREFECTURE_OVERVIEW_MAX_ZOOM = 6;
     const OVERALL_PANEL_MEDIA_QUERY = '(max-width: 759px)';
     var isInitialPageLoad = true;  // Track if this is initial page load to prevent duplicate page_views
     var activeTagFilter = null;  // タグフィルタ（null = 全件）
@@ -858,7 +860,7 @@
             ${d.building ? `<p class="travel-popup-building">📍 ${escapeHtml(d.building)}</p>` : ''}
             ${titleBadgesHtml}
             <div class="travel-popup-pokemon-list" aria-label="登場ポケモン">${pokemonsHtml}</div>
-            <div class="popup-actions travel-popup-actions">
+            <div class="popup-actions travel-popup-actions${hasPhoto ? ' travel-popup-actions--has-photo' : ''}">
               ${primaryAction}
               ${mapsAction}
               ${detailLink}
@@ -1183,6 +1185,7 @@
         updateRecentSummary();
         renderRecentAdded();
         syncExploreSections();
+        refreshMapMarkerLayers();
         // URL パラメータから初期表示を選択
         const initialManholeId = getInitialManholeIdFromURL();
         if (initialManholeId) {
@@ -1217,6 +1220,8 @@
       }
 
       if (markerLayer && !markerLayer.hasLayer(marker)) markerLayer.addLayer(marker);
+      if (prefectureOverviewLayer && map.hasLayer(prefectureOverviewLayer)) map.removeLayer(prefectureOverviewLayer);
+      if (markerLayer && !map.hasLayer(markerLayer)) markerLayer.addTo(map);
       const data = marker.pokefutaData;
       window.applyManholePageMeta(data);
       window.history.replaceState({ manhole: data.id }, '', window.buildManholeCanonicalPath(data.id));
@@ -1265,6 +1270,71 @@
       }
       markerLayer.addTo(map);
     }
+
+    function markerMatchesActiveFilters(marker) {
+      const d = marker.pokefutaData;
+      if (selectedPrefecture && d.prefecture !== selectedPrefecture) return false;
+      if (filterRecent && !isWithinLastDays(d._addedDate, 30)) return false;
+      if (activeTagFilter && (!Array.isArray(d.tags) || !d.tags.includes(activeTagFilter))) return false;
+      return true;
+    }
+
+    function rebuildPrefectureOverviewLayer() {
+      prefectureOverviewLayer.clearLayers();
+      const summaries = {};
+
+      allMarkers.forEach(marker => {
+        if (!markerMatchesActiveFilters(marker)) return;
+        const d = marker.pokefutaData;
+        const prefecture = d.prefecture || '不明';
+        if (!summaries[prefecture]) summaries[prefecture] = { count: 0, lat: 0, lng: 0 };
+        summaries[prefecture].count++;
+        summaries[prefecture].lat += Number(d.lat);
+        summaries[prefecture].lng += Number(d.lng);
+      });
+
+      Object.entries(summaries).forEach(([prefecture, summary]) => {
+        const center = prefectureCenterCoords[prefecture] || [
+          summary.lat / summary.count,
+          summary.lng / summary.count
+        ];
+        const shortPrefecture = prefecture === '北海道'
+          ? prefecture
+          : prefecture.replace(/[都府県]$/, '');
+        const icon = L.divIcon({
+          html: `<span class="prefecture-overview-name">${escapeHtml(shortPrefecture)}</span><span class="prefecture-overview-count">${summary.count}</span>`,
+          className: 'prefecture-overview-marker',
+          iconSize: null
+        });
+        const marker = L.marker(center, {
+          icon,
+          title: `${prefecture}: ${summary.count}枚`,
+          keyboard: true
+        });
+        marker.on('click', () => {
+          zoomToPrefecture(prefecture);
+          if (map.getZoom() <= PREFECTURE_OVERVIEW_MAX_ZOOM) {
+            map.setZoom(PREFECTURE_OVERVIEW_MAX_ZOOM + 1, { animate: false });
+          }
+        });
+        prefectureOverviewLayer.addLayer(marker);
+      });
+    }
+
+    function refreshMapMarkerLayers() {
+      if (!markerLayer) return;
+      const showPrefectureOverview = map.getZoom() <= PREFECTURE_OVERVIEW_MAX_ZOOM;
+      if (showPrefectureOverview) {
+        rebuildPrefectureOverviewLayer();
+        if (map.hasLayer(markerLayer)) map.removeLayer(markerLayer);
+        if (!map.hasLayer(prefectureOverviewLayer)) prefectureOverviewLayer.addTo(map);
+      } else {
+        if (map.hasLayer(prefectureOverviewLayer)) map.removeLayer(prefectureOverviewLayer);
+        if (!map.hasLayer(markerLayer)) markerLayer.addTo(map);
+      }
+    }
+
+    map.on('zoomend', refreshMapMarkerLayers);
 
     function initRecentFilter() {
       const toggle = document.getElementById('recent-toggle');
@@ -1453,11 +1523,7 @@
     function recomputeVisibility() {
       let visibleCount = 0;
       allMarkers.forEach(marker => {
-        const d = marker.pokefutaData;
-        let show = true;
-        if (selectedPrefecture) show = show && d.prefecture === selectedPrefecture;
-        if (filterRecent) show = show && isWithinLastDays(d._addedDate, 30);
-        if (activeTagFilter) show = show && Array.isArray(d.tags) && d.tags.includes(activeTagFilter);
+        const show = markerMatchesActiveFilters(marker);
         if (show) {
           if (markerLayer && !markerLayer.hasLayer(marker)) markerLayer.addLayer(marker);
           visibleCount++;
@@ -1465,6 +1531,7 @@
           if (markerLayer && markerLayer.hasLayer(marker)) markerLayer.removeLayer(marker);
         }
       });
+      refreshMapMarkerLayers();
       updateStats(visibleCount);
     }
 

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1312,10 +1312,7 @@
           keyboard: true
         });
         marker.on('click', () => {
-          zoomToPrefecture(prefecture);
-          if (map.getZoom() <= PREFECTURE_OVERVIEW_MAX_ZOOM) {
-            map.setZoom(PREFECTURE_OVERVIEW_MAX_ZOOM + 1, { animate: false });
-          }
+          zoomToPrefecture(prefecture, PREFECTURE_OVERVIEW_MAX_ZOOM + 1);
         });
         prefectureOverviewLayer.addLayer(marker);
       });
@@ -2016,7 +2013,7 @@
     // Leafletの機能を使って都道府県のポケふたにズームする関数
     // マンホール2件以上: マンホール全て入る最小縮尺（maxZoom:13で過度な拡大を防止）
     // マンホール1件以下: 実マーカー座標 or Gist中心座標 ±0.5度で統一スケール
-    function zoomToPrefecture(prefecture) {
+    function zoomToPrefecture(prefecture, minimumZoom = null) {
       const markerCount = prefectureMarkerCounts[prefecture] || 0;
       console.log(`Zooming to prefecture: ${prefecture}, marker count: ${markerCount}, prefectureBounds available: ${!!prefectureBounds[prefecture]}`);
       
@@ -2025,7 +2022,7 @@
         console.warn(`No bounds found for prefecture: ${prefecture}`);
         const center = prefectureCenterCoords[prefecture];
         if (center) {
-          map.setView(center, 8);
+          map.setView(center, Math.max(8, minimumZoom || 0), { animate: minimumZoom === null });
         }
         return;
       }
@@ -2037,16 +2034,21 @@
           // マンホール2件以上: マンホール全て入る最小縮尺でズーム（maxZoom: 13で過度な拡大を防止）
           map.fitBounds(bounds, {
             padding: [50, 50],
-            maxZoom: 13
+            maxZoom: 13,
+            animate: minimumZoom === null
           });
           console.log(`Zoomed to ${prefecture} with ${markerCount} markers (fit all data with zoom cap)`);
         } else {
           // マンホール1件以下: Gist中心座標±0.5度で統一スケール (padding: 50px, maxZoom: 13)
           map.fitBounds(bounds, {
             padding: [50, 50],
-            maxZoom: 13
+            maxZoom: 13,
+            animate: minimumZoom === null
           });
           console.log(`Zoomed to ${prefecture} with ${markerCount} markers (unified scale)`);
+        }
+        if (minimumZoom !== null && map.getZoom() < minimumZoom) {
+          map.setZoom(minimumZoom, { animate: false });
         }
         
       } catch (error) {
@@ -2054,7 +2056,7 @@
         // エラーの場合は都道府県の中心座標にフォールバック
         const center = prefectureCenterCoords[prefecture];
         if (center) {
-          map.setView(center, 8);
+          map.setView(center, Math.max(8, minimumZoom || 0), { animate: minimumZoom === null });
         }
       }
     }

--- a/apps/web/index.template.html
+++ b/apps/web/index.template.html
@@ -309,7 +309,7 @@
     integrity="sha384-pmjIAcz2bAn0xukfxADbZIb3t8oRT9Sv0rvO+BR5Csr6Dhqq+nZs59P0pPKQJkEV" crossorigin="" />
   <link rel="stylesheet" href="%%BASE_PATH%%assets/theme.css" />
   <link rel="stylesheet" href="%%BASE_PATH%%assets/map.css" />
-  <link rel="stylesheet" href="%%BASE_PATH%%assets/pokefuta-map.css?v=20260613-popup-actions" />
+  <link rel="stylesheet" href="%%BASE_PATH%%assets/pokefuta-map.css?v=20260613-popup-actions-grid" />
   <link rel="icon" href="%%BASE_PATH%%assets/pokefuta-marker.svg" type="image/svg+xml" />
   <!-- Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-K18NR4GZG2"></script>
@@ -564,6 +564,7 @@
     var allMarkers = [];
     var allData = [];
     var markerLayer = null;
+    var prefectureOverviewLayer = L.layerGroup();
     var userLocationMarker = null;
     var latestPhotoMeta = {};
     var prefectureCounts = {};
@@ -578,6 +579,7 @@
     var prefectureBounds = {};  // 都道府県ごとのbounding box（グローバルスコープ）
     var prefectureMarkerCounts = {};  // 都道府県ごとのマンホール数（グローバルスコープ）
     const PREFECTURE_BOUNDS_OFFSET = 0.5;  // 都道府県 bounding box のオフセット（度）
+    const PREFECTURE_OVERVIEW_MAX_ZOOM = 6;
     const OVERALL_PANEL_MEDIA_QUERY = '(max-width: 759px)';
     var isInitialPageLoad = true;  // Track if this is initial page load to prevent duplicate page_views
     var activeTagFilter = null;  // タグフィルタ（null = 全件）
@@ -845,7 +847,7 @@
             ${d.building ? `<p class="travel-popup-building">📍 ${escapeHtml(d.building)}</p>` : ''}
             ${titleBadgesHtml}
             <div class="travel-popup-pokemon-list" aria-label="${I.pokemonListAria}">${pokemonsHtml}</div>
-            <div class="popup-actions travel-popup-actions">
+            <div class="popup-actions travel-popup-actions${hasPhoto ? ' travel-popup-actions--has-photo' : ''}">
               ${primaryAction}
               ${mapsAction}
               ${detailLink}
@@ -1186,6 +1188,7 @@
         updateRecentSummary();
         renderRecentAdded();
         syncExploreSections();
+        refreshMapMarkerLayers();
         // URL パラメータから初期表示を選択
         const initialManholeId = getInitialManholeIdFromURL();
         if (initialManholeId) {
@@ -1220,6 +1223,8 @@
       }
 
       if (markerLayer && !markerLayer.hasLayer(marker)) markerLayer.addLayer(marker);
+      if (prefectureOverviewLayer && map.hasLayer(prefectureOverviewLayer)) map.removeLayer(prefectureOverviewLayer);
+      if (markerLayer && !map.hasLayer(markerLayer)) markerLayer.addTo(map);
       const data = marker.pokefutaData;
       window.applyManholePageMeta(data);
       window.history.replaceState({ manhole: data.id }, '', window.buildManholeCanonicalPath(data.id));
@@ -1268,6 +1273,71 @@
       }
       markerLayer.addTo(map);
     }
+
+    function markerMatchesActiveFilters(marker) {
+      const d = marker.pokefutaData;
+      if (selectedPrefecture && d.prefecture !== selectedPrefecture) return false;
+      if (filterRecent && !isWithinLastDays(d._addedDate, 30)) return false;
+      if (activeTagFilter && (!Array.isArray(d.tags) || !d.tags.includes(activeTagFilter))) return false;
+      return true;
+    }
+
+    function rebuildPrefectureOverviewLayer() {
+      prefectureOverviewLayer.clearLayers();
+      const summaries = {};
+
+      allMarkers.forEach(marker => {
+        if (!markerMatchesActiveFilters(marker)) return;
+        const d = marker.pokefutaData;
+        const prefecture = d.prefecture || '不明';
+        if (!summaries[prefecture]) summaries[prefecture] = { count: 0, lat: 0, lng: 0 };
+        summaries[prefecture].count++;
+        summaries[prefecture].lat += Number(d.lat);
+        summaries[prefecture].lng += Number(d.lng);
+      });
+
+      Object.entries(summaries).forEach(([prefecture, summary]) => {
+        const center = prefectureCenterCoords[prefecture] || [
+          summary.lat / summary.count,
+          summary.lng / summary.count
+        ];
+        const shortPrefecture = prefecture === '北海道'
+          ? prefecture
+          : prefecture.replace(/[都府県]$/, '');
+        const icon = L.divIcon({
+          html: `<span class="prefecture-overview-name">${escapeHtml(shortPrefecture)}</span><span class="prefecture-overview-count">${summary.count}</span>`,
+          className: 'prefecture-overview-marker',
+          iconSize: null
+        });
+        const marker = L.marker(center, {
+          icon,
+          title: `${prefecture}: ${summary.count}枚`,
+          keyboard: true
+        });
+        marker.on('click', () => {
+          zoomToPrefecture(prefecture);
+          if (map.getZoom() <= PREFECTURE_OVERVIEW_MAX_ZOOM) {
+            map.setZoom(PREFECTURE_OVERVIEW_MAX_ZOOM + 1, { animate: false });
+          }
+        });
+        prefectureOverviewLayer.addLayer(marker);
+      });
+    }
+
+    function refreshMapMarkerLayers() {
+      if (!markerLayer) return;
+      const showPrefectureOverview = map.getZoom() <= PREFECTURE_OVERVIEW_MAX_ZOOM;
+      if (showPrefectureOverview) {
+        rebuildPrefectureOverviewLayer();
+        if (map.hasLayer(markerLayer)) map.removeLayer(markerLayer);
+        if (!map.hasLayer(prefectureOverviewLayer)) prefectureOverviewLayer.addTo(map);
+      } else {
+        if (map.hasLayer(prefectureOverviewLayer)) map.removeLayer(prefectureOverviewLayer);
+        if (!map.hasLayer(markerLayer)) markerLayer.addTo(map);
+      }
+    }
+
+    map.on('zoomend', refreshMapMarkerLayers);
 
     function initRecentFilter() {
       const toggle = document.getElementById('recent-toggle');
@@ -1456,11 +1526,7 @@
     function recomputeVisibility() {
       let visibleCount = 0;
       allMarkers.forEach(marker => {
-        const d = marker.pokefutaData;
-        let show = true;
-        if (selectedPrefecture) show = show && d.prefecture === selectedPrefecture;
-        if (filterRecent) show = show && isWithinLastDays(d._addedDate, 30);
-        if (activeTagFilter) show = show && Array.isArray(d.tags) && d.tags.includes(activeTagFilter);
+        const show = markerMatchesActiveFilters(marker);
         if (show) {
           if (markerLayer && !markerLayer.hasLayer(marker)) markerLayer.addLayer(marker);
           visibleCount++;
@@ -1468,6 +1534,7 @@
           if (markerLayer && markerLayer.hasLayer(marker)) markerLayer.removeLayer(marker);
         }
       });
+      refreshMapMarkerLayers();
       updateStats(visibleCount);
     }
 

--- a/apps/web/index.template.html
+++ b/apps/web/index.template.html
@@ -1315,10 +1315,7 @@
           keyboard: true
         });
         marker.on('click', () => {
-          zoomToPrefecture(prefecture);
-          if (map.getZoom() <= PREFECTURE_OVERVIEW_MAX_ZOOM) {
-            map.setZoom(PREFECTURE_OVERVIEW_MAX_ZOOM + 1, { animate: false });
-          }
+          zoomToPrefecture(prefecture, PREFECTURE_OVERVIEW_MAX_ZOOM + 1);
         });
         prefectureOverviewLayer.addLayer(marker);
       });
@@ -2018,7 +2015,7 @@
     // Leafletの機能を使って都道府県のポケふたにズームする関数
     // マンホール2件以上: マンホール全て入る最小縮尺（maxZoom:13で過度な拡大を防止）
     // マンホール1件以下: 実マーカー座標 or Gist中心座標 ±0.5度で統一スケール
-    function zoomToPrefecture(prefecture) {
+    function zoomToPrefecture(prefecture, minimumZoom = null) {
       const markerCount = prefectureMarkerCounts[prefecture] || 0;
       console.log(`Zooming to prefecture: ${prefecture}, marker count: ${markerCount}, prefectureBounds available: ${!!prefectureBounds[prefecture]}`);
       
@@ -2027,7 +2024,7 @@
         console.warn(`No bounds found for prefecture: ${prefecture}`);
         const center = prefectureCenterCoords[prefecture];
         if (center) {
-          map.setView(center, 8);
+          map.setView(center, Math.max(8, minimumZoom || 0), { animate: minimumZoom === null });
         }
         return;
       }
@@ -2039,16 +2036,21 @@
           // マンホール2件以上: マンホール全て入る最小縮尺でズーム（maxZoom: 13で過度な拡大を防止）
           map.fitBounds(bounds, {
             padding: [50, 50],
-            maxZoom: 13
+            maxZoom: 13,
+            animate: minimumZoom === null
           });
           console.log(`Zoomed to ${prefecture} with ${markerCount} markers (fit all data with zoom cap)`);
         } else {
           // マンホール1件以下: Gist中心座標±0.5度で統一スケール (padding: 50px, maxZoom: 13)
           map.fitBounds(bounds, {
             padding: [50, 50],
-            maxZoom: 13
+            maxZoom: 13,
+            animate: minimumZoom === null
           });
           console.log(`Zoomed to ${prefecture} with ${markerCount} markers (unified scale)`);
+        }
+        if (minimumZoom !== null && map.getZoom() < minimumZoom) {
+          map.setZoom(minimumZoom, { animate: false });
         }
         
       } catch (error) {
@@ -2056,7 +2058,7 @@
         // エラーの場合は都道府県の中心座標にフォールバック
         const center = prefectureCenterCoords[prefecture];
         if (center) {
-          map.setView(center, 8);
+          map.setView(center, Math.max(8, minimumZoom || 0), { animate: minimumZoom === null });
         }
       }
     }


### PR DESCRIPTION
## Summary
- show one count marker per prefecture at zoom level 6 and below
- switch back to the existing marker clustering at zoom level 7 and above
- keep prefecture counts synchronized with active filters
- display the photo, Google Maps, and detail actions in a single three-column row when a popup has a photo

## Why
The existing low-zoom clustering grouped nearby locations geographically, which made it difficult to understand totals by prefecture. The popup actions also used two rows despite having three equally important destinations when a photo exists.

## Impact
Users can compare prefecture totals directly from the nationwide map and open a prefecture marker to continue into the existing detailed cluster view. Photo-enabled popups now present all three actions in one compact row.

## Validation
- parsed all 7 inline scripts in `apps/web/index.html`
- ran `git diff --check`
- verified 41 prefecture markers at the initial nationwide zoom
- verified clicking a prefecture switches to the existing marker cluster layer
- verified the three popup actions have equal widths and the same top position
- verified no browser warnings or errors during these flows

## Note
The photo import helper could not download images because local R2 credentials are not configured. Older local photo metadata from the configured copy source was intentionally excluded from this PR.
