### PR TITLE
[codex] Redesign homepage as a discovery hub

### DIFF
--- a/apps/scraper/generate_summary_pages.py
+++ b/apps/scraper/generate_summary_pages.py
@@ -143,6 +143,13 @@ SUMMARY_STRINGS: dict[str, dict] = {
         "popular_pokemon": {
             "h2": "人気ポケモンのポケふた",
         },
+        "discovery_hubs": {
+            "travel_h2": "旅のテーマから探す", "travel_note": "行き先の雰囲気から、次に会いに行くポケふたを探せます。",
+            "rare_h2": "レアなポケふたを探す", "rare_note": "全国でここだけのポケモンや、日本の四端、秘境の一枚を集めました。",
+            "details": "このテーマのポケふたを見る", "count": "{count}枚", "unique_count": "{count}種",
+            "travel": {"remote_island": "離島", "roadside": "道の駅", "station_front": "駅前", "world_heritage": "世界遺産"},
+            "rare": {"unique": "全国1枚しかないポケモン", "extremes": "日本の四端", "lone": "秘境・ぽつんと一枚"},
+        },
         "latest_photos": {
             "h2": "最新追加写真",
             "note": "ユーザーが投稿した最新のポケふた写真です。タップするとポケふた詳細ページへ移動します。",
@@ -232,6 +239,13 @@ SUMMARY_STRINGS: dict[str, dict] = {
         "popular_pokemon": {
             "h2": "Popular Pokémon on Pokéfuta",
         },
+        "discovery_hubs": {
+            "travel_h2": "Explore by travel theme", "travel_note": "Choose your next Pokéfuta destination by the kind of journey you want.",
+            "rare_h2": "Find rare Pokéfuta", "rare_note": "Discover one-of-a-kind Pokémon, Japan's four extremes, and remote locations.",
+            "details": "View Pokéfuta in this theme", "count": "{count} Pokéfuta", "unique_count": "{count} Pokémon",
+            "travel": {"remote_island": "Remote islands", "roadside": "Roadside stations", "station_front": "Train stations", "world_heritage": "World Heritage"},
+            "rare": {"unique": "Pokémon found on only one Pokéfuta", "extremes": "Japan's four extremes", "lone": "Remote and solitary"},
+        },
         "pokemon_ranking": {
             "h2": "Pokémon Rankings",
             "h3_count": "By Pokéfuta Count",
@@ -311,6 +325,13 @@ SUMMARY_STRINGS: dict[str, dict] = {
         },
         "popular_pokemon": {
             "h2": "热门宝可梦井盖",
+        },
+        "discovery_hubs": {
+            "travel_h2": "按旅行主题探索", "travel_note": "从想去的风景出发，寻找下一个 Pokéfuta。",
+            "rare_h2": "寻找稀有 Pokéfuta", "rare_note": "探索全国唯一、日本四端与秘境中的 Pokéfuta。",
+            "details": "查看此主题的 Pokéfuta", "count": "{count} 枚", "unique_count": "{count} 种宝可梦",
+            "travel": {"remote_island": "离岛", "roadside": "道之驿", "station_front": "车站前", "world_heritage": "世界遗产"},
+            "rare": {"unique": "全国仅一枚的宝可梦", "extremes": "日本四端", "lone": "秘境与孤立地点"},
         },
         "pokemon_ranking": {
             "h2": "宝可梦排行榜",
@@ -392,6 +413,13 @@ SUMMARY_STRINGS: dict[str, dict] = {
         "popular_pokemon": {
             "h2": "熱門寶可夢人孔蓋",
         },
+        "discovery_hubs": {
+            "travel_h2": "依旅行主題探索", "travel_note": "從想去的風景出發，尋找下一個 Pokéfuta。",
+            "rare_h2": "尋找稀有 Pokéfuta", "rare_note": "探索全國唯一、日本四端與秘境中的 Pokéfuta。",
+            "details": "查看此主題的 Pokéfuta", "count": "{count} 枚", "unique_count": "{count} 種寶可夢",
+            "travel": {"remote_island": "離島", "roadside": "道之驛", "station_front": "車站前", "world_heritage": "世界遺產"},
+            "rare": {"unique": "全國僅一枚的寶可夢", "extremes": "日本四端", "lone": "秘境與孤立地點"},
+        },
         "pokemon_ranking": {
             "h2": "寶可夢排行榜",
             "h3_count": "按人孔蓋數量排名",
@@ -471,6 +499,13 @@ SUMMARY_STRINGS: dict[str, dict] = {
         },
         "popular_pokemon": {
             "h2": "인기 포켓몬 포케후타",
+        },
+        "discovery_hubs": {
+            "travel_h2": "여행 테마로 찾기", "travel_note": "가고 싶은 풍경에서 다음 포케후타 여행지를 찾아보세요.",
+            "rare_h2": "희귀 포케후타 찾기", "rare_note": "일본 전국 유일, 사방 끝, 비경의 포케후타를 만나보세요.",
+            "details": "이 테마의 포케후타 보기", "count": "{count}개", "unique_count": "포켓몬 {count}종",
+            "travel": {"remote_island": "외딴섬", "roadside": "미치노에키", "station_front": "역 앞", "world_heritage": "세계유산"},
+            "rare": {"unique": "전국에 하나뿐인 포켓몬", "extremes": "일본 사방 끝", "lone": "비경과 외딴 장소"},
         },
         "pokemon_ranking": {
             "h2": "포켓몬 랭킹",
@@ -929,6 +964,69 @@ _CSS = """\
     .photo-card-meta {
       font-size: .76rem;
       color: #716154;
+    }
+
+    .discovery-hub-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 12px;
+      margin-top: 14px;
+    }
+
+    .discovery-hub-card {
+      display: flex;
+      flex-direction: column;
+      gap: 9px;
+      min-width: 0;
+      overflow: hidden;
+      border: 1px solid rgba(93, 67, 35, .14);
+      border-radius: 12px;
+      background: #fffdf7;
+    }
+
+    .discovery-hub-card img {
+      width: 100%;
+      aspect-ratio: 16 / 9;
+      object-fit: cover;
+      background: #fffaf0;
+    }
+
+    .discovery-hub-copy {
+      display: grid;
+      gap: 7px;
+      padding: 4px 14px 14px;
+    }
+
+    .discovery-hub-copy h3 {
+      margin: 0;
+      font-size: 1.05rem;
+    }
+
+    .discovery-hub-count {
+      color: #176f68;
+      font-size: 1.45rem;
+      font-weight: 950;
+      line-height: 1.1;
+    }
+
+    .discovery-hub-links {
+      display: grid;
+      gap: 4px;
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .discovery-hub-links a {
+      color: #176f68;
+      font-size: .84rem;
+      font-weight: 850;
+      text-decoration: none;
+    }
+
+    #travel-discovery,
+    #rare-discovery {
+      scroll-margin-top: 16px;
     }
 
     .pokemon-ranking-cols {
@@ -2659,6 +2757,9 @@ def _build_tracking_script(s: dict) -> str:
         fact_id: target.dataset.factId || '',
         fact_title: target.dataset.factTitle || '',
         image_type: target.dataset.imageType || '',
+        content_type: target.dataset.contentType || '',
+        content_id: target.dataset.contentId || '',
+        destination_hub: target.dataset.destinationHub || '',
         target_url: target.dataset.targetUrl || target.href || ''
       });
     });
@@ -3025,6 +3126,110 @@ def _build_popular_pokemon_section(s: dict, pokemon_stats: dict) -> str:
     )
 
 
+def _has_title(record: dict, key: str) -> bool:
+    keys = {title.get("key") for title in record.get("titles", [])}
+    return bool(keys & {"lone", "lone_100"}) if key == "lone" else key in keys
+
+
+def _localized_pokemon_name(name: str, s: dict, pokemon_metadata: dict) -> str:
+    if s["pref_key"] == "ja":
+        return name
+    names = pokemon_metadata.get(name, {}).get("names", {})
+    return names.get(s["pref_key"]) or names.get("en") or name
+
+
+def _build_discovery_hub_sections(
+    s: dict, records_by_id: dict, pokemon_metadata: dict
+) -> str:
+    copy = s.get("discovery_hubs")
+    if not copy:
+        return ""
+    records = list(records_by_id.values())
+
+    def image_url(record: dict) -> str:
+        mid = str(record.get("id", ""))
+        if not mid or not (IMAGE_DIR / f"{mid}_latest.jpeg").exists():
+            return ""
+        return f"/manhole/image/{quote(mid, safe='')}_latest.jpeg"
+
+    def record_label(record: dict) -> str:
+        pokemon = next(
+            (name for name in record.get("pokemons", []) if "ローカルActs" not in name),
+            record.get("title", ""),
+        )
+        display = _localized_pokemon_name(pokemon, s, pokemon_metadata)
+        place = " ".join(filter(None, [record.get("prefecture"), record.get("city")]))
+        return f"{display} · {place}" if place else display
+
+    def card(title: str, count_text: str, candidates: list[dict], content_id: str) -> str:
+        candidates = sorted(
+            candidates,
+            key=lambda record: str(record.get("id", "")).zfill(8),
+        )
+        pictured = [record for record in candidates if image_url(record)]
+        representative = pictured[0] if pictured else (candidates[0] if candidates else {})
+        image = image_url(representative)
+        image_html = (
+            f'<img src="{escape(image)}" alt="{escape(record_label(representative))}" '
+            f'loading="lazy" decoding="async">'
+            if image else ""
+        )
+        links = "".join(
+            f'<li><a href="/manholes/{quote(str(record.get("id", "")), safe="")}/" '
+            f'data-summary-event="summary_discovery_detail_click" '
+            f'data-content-type="discovery_detail" data-content-id="{escape(content_id)}" '
+            f'data-destination-hub="manhole_detail">{escape(record_label(record))}</a></li>'
+            for record in (pictured or candidates)[:3]
+        )
+        return (
+            f'<article class="discovery-hub-card">{image_html}'
+            f'<div class="discovery-hub-copy"><h3>{escape(title)}</h3>'
+            f'<strong class="discovery-hub-count">{escape(count_text)}</strong>'
+            f'<span>{escape(copy["details"])}</span>'
+            f'<ul class="discovery-hub-links">{links}</ul></div></article>'
+        )
+
+    travel_cards = []
+    for key in ("remote_island", "roadside", "station_front", "world_heritage"):
+        candidates = [record for record in records if _has_title(record, key)]
+        travel_cards.append(card(
+            copy["travel"][key],
+            copy["count"].format(count=len(candidates)),
+            candidates,
+            key,
+        ))
+
+    pokemon_records: dict[str, list[dict]] = {}
+    for record in records:
+        for pokemon in set(record.get("pokemons", [])):
+            if pokemon and "ローカルActs" not in pokemon:
+                pokemon_records.setdefault(pokemon, []).append(record)
+    unique_records = [items[0] for items in pokemon_records.values() if len(items) == 1]
+    extreme_records = [
+        record for record in records
+        if any(_has_title(record, key) for key in ("north_end", "south_end", "east_end", "west_end"))
+    ]
+    lone_records = [record for record in records if _has_title(record, "lone")]
+    rare_cards = [
+        card(copy["rare"]["unique"], copy["unique_count"].format(count=len(unique_records)), unique_records, "unique_pokemon"),
+        card(copy["rare"]["extremes"], copy["count"].format(count=len(extreme_records)), extreme_records, "extremes"),
+        card(copy["rare"]["lone"], copy["count"].format(count=len(lone_records)), lone_records, "lone"),
+    ]
+
+    return (
+        f'\n    <section id="travel-discovery" class="summary-section" aria-labelledby="travel-discovery-heading">'
+        f'\n      <h2 id="travel-discovery-heading">{escape(copy["travel_h2"])}</h2>'
+        f'\n      <p class="section-note">{escape(copy["travel_note"])}</p>'
+        f'\n      <div class="discovery-hub-grid">{"".join(travel_cards)}</div>'
+        f'\n    </section>'
+        f'\n    <section id="rare-discovery" class="summary-section" aria-labelledby="rare-discovery-heading">'
+        f'\n      <h2 id="rare-discovery-heading">{escape(copy["rare_h2"])}</h2>'
+        f'\n      <p class="section-note">{escape(copy["rare_note"])}</p>'
+        f'\n      <div class="discovery-hub-grid">{"".join(rare_cards)}</div>'
+        f'\n    </section>\n'
+    )
+
+
 def _build_latest_photos_section(
     s: dict, records_by_id: dict, photos_data: dict
 ) -> str:
@@ -3166,7 +3371,7 @@ def _build_pokemon_ranking_section(s: dict, pokemon_stats: dict) -> str:
     )
 
 
-def render_page(s: dict, stats: dict, pref_names: dict, pokemon_stats: dict, records_by_id: dict, photos_data: dict, pref_trivia_data: list[dict] | None = None) -> str:
+def render_page(s: dict, stats: dict, pref_names: dict, pokemon_stats: dict, records_by_id: dict, photos_data: dict, pokemon_metadata: dict, pref_trivia_data: list[dict] | None = None) -> str:
     pref_key = s["pref_key"]
 
     def tr(ja_name: str) -> str:
@@ -3192,6 +3397,7 @@ def render_page(s: dict, stats: dict, pref_names: dict, pokemon_stats: dict, rec
     )
     popular_pokemon_html = _build_popular_pokemon_section(s, pokemon_stats)
     latest_photos_html = _build_latest_photos_section(s, records_by_id, photos_data)
+    discovery_hubs_html = _build_discovery_hub_sections(s, records_by_id, pokemon_metadata)
     no_photos_html = _build_no_photos_section(s, records_by_id, photos_data)
     pokemon_ranking_html = _build_pokemon_ranking_section(s, pokemon_stats)
 
@@ -3281,6 +3487,7 @@ def render_page(s: dict, stats: dict, pref_names: dict, pokemon_stats: dict, rec
     {daily_fact_html}
     {search_hub_html}
     {latest_photos_html}
+    {discovery_hubs_html}
     {fact_list_html}
     {popular_pokemon_html}
     <section class="summary-stats" aria-label="{escape(s['stats_aria'])}">
@@ -3360,7 +3567,7 @@ def main() -> None:
     print(f"[INFO] {len(pref_trivia_data)} prefecture trivia entries")
 
     for lang, s in SUMMARY_STRINGS.items():
-        html = render_page(s, stats, pref_names, pokemon_stats, records_by_id, photos_data, pref_trivia_data)
+        html = render_page(s, stats, pref_names, pokemon_stats, records_by_id, photos_data, pokemon_metadata, pref_trivia_data)
         out = DIST / s["out_path"]
         out.parent.mkdir(parents=True, exist_ok=True)
         out.write_text(html, encoding="utf-8")

--- a/apps/scraper/test_generate_summary_pages.py
+++ b/apps/scraper/test_generate_summary_pages.py
@@ -1,0 +1,68 @@
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).with_name("generate_summary_pages.py")
+SPEC = importlib.util.spec_from_file_location("generate_summary_pages", MODULE_PATH)
+summary = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(summary)
+
+
+class DiscoveryHubTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.records = [
+            record
+            for record in summary.load_records(summary.NDJSON)
+            if record.get("status", "active") == "active"
+        ]
+        cls.records_by_id = {str(record["id"]): record for record in cls.records}
+        cls.metadata = summary.load_pokemon_metadata_with_slugs(summary.POKEMON_METADATA_JSON)
+
+    def test_summary_hubs_exist_in_every_language(self):
+        for language, strings in summary.SUMMARY_STRINGS.items():
+            with self.subTest(language=language):
+                html = summary._build_discovery_hub_sections(
+                    strings, self.records_by_id, self.metadata
+                )
+                self.assertIn('id="travel-discovery"', html)
+                self.assertIn('id="rare-discovery"', html)
+                self.assertGreaterEqual(html.count("discovery-hub-card"), 7)
+                self.assertIn('data-destination-hub="manhole_detail"', html)
+
+    def test_travel_counts_match_title_data(self):
+        html = summary._build_discovery_hub_sections(
+            summary.SUMMARY_STRINGS["ja"], self.records_by_id, self.metadata
+        )
+        for key in ("remote_island", "roadside", "station_front", "world_heritage"):
+            count = sum(summary._has_title(record, key) for record in self.records)
+            self.assertIn(f">{count}枚</strong>", html)
+
+    def test_hero_uses_popup_and_summary_hubs(self):
+        source = (summary.ROOT / "apps/web/index.html").read_text(encoding="utf-8")
+        self.assertIn("click_hero_new_photo", source)
+        self.assertIn("openManholePopup(recommendation.manhole.id)", source)
+        self.assertIn("'travel-discovery'", source)
+        self.assertIn("'rare-discovery'", source)
+        self.assertIn("destination_hub: recommendation.destinationHub", source)
+        self.assertIn("getDailyRotationIndex", source)
+
+    def test_i18n_hero_strings_have_all_destinations(self):
+        i18n_dir = summary.ROOT / "apps/web/i18n"
+        for language in ("ja", "en", "zh-CN", "zh-TW", "ko"):
+            with self.subTest(language=language):
+                data = json.loads(
+                    (i18n_dir / f"strings.{language}.json").read_text(encoding="utf-8")
+                )
+                hero = data["I18N_OBJECT"]["heroDiscovery"]
+                self.assertEqual(set(hero["ctas"]), {"fresh", "travel", "rare"})
+                self.assertEqual(
+                    set(hero["travelThemes"]),
+                    {"remote_island", "roadside", "station_front", "world_heritage"},
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/scraper/test_generate_summary_pages.py
+++ b/apps/scraper/test_generate_summary_pages.py
@@ -51,6 +51,9 @@ class DiscoveryHubTests(unittest.TestCase):
         self.assertIn("getHeroThemeCount(themeKey)", source)
         self.assertIn("getUniqueHeroPokemon(manhole)", source)
         self.assertIn("window.I18N?.intlLocale || 'ja-JP'", source)
+        self.assertIn("const pokemonMetadataPromise = loadPokemonMetadata();", source)
+        self.assertIn("marker.setPopupContent(buildPokefutaPopup(marker.pokefutaData))", source)
+        self.assertNotIn("await loadPokemonMetadata();", source)
         self.assertNotIn("countTemplate.replace('{count}', candidates.length)", source)
         self.assertNotIn("pokemon: reason", source)
 

--- a/apps/scraper/test_generate_summary_pages.py
+++ b/apps/scraper/test_generate_summary_pages.py
@@ -48,6 +48,25 @@ class DiscoveryHubTests(unittest.TestCase):
         self.assertIn("'rare-discovery'", source)
         self.assertIn("destination_hub: recommendation.destinationHub", source)
         self.assertIn("getDailyRotationIndex", source)
+        self.assertIn("getHeroThemeCount(themeKey)", source)
+        self.assertIn("getUniqueHeroPokemon(manhole)", source)
+        self.assertNotIn("countTemplate.replace('{count}', candidates.length)", source)
+        self.assertNotIn("pokemon: reason", source)
+
+    def test_generated_template_keeps_popup_copy_localized(self):
+        template = (summary.ROOT / "apps/web/index.template.html").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("const UI_TEXT = window.I18N.UI;", template)
+        self.assertIn("${I.photoWanted}", template)
+        self.assertIn("${I.photoMissing}", template)
+        self.assertIn("${I.photoViewCta}", template)
+        self.assertIn("${I.firstPhotoUploadCta}", template)
+        self.assertIn("${I.googleMapsCta}", template)
+        self.assertIn("anchor.textContent = UI_TEXT.detailPageCta;", template)
+        self.assertIn("getHeroPokemonDisplayName(pokemon)", template)
+        self.assertNotIn("getPokemonDisplayName(pokemon)", template)
+        self.assertNotIn("const UI_TEXT = {", template)
 
     def test_i18n_hero_strings_have_all_destinations(self):
         i18n_dir = summary.ROOT / "apps/web/i18n"

--- a/apps/scraper/test_generate_summary_pages.py
+++ b/apps/scraper/test_generate_summary_pages.py
@@ -50,6 +50,7 @@ class DiscoveryHubTests(unittest.TestCase):
         self.assertIn("getDailyRotationIndex", source)
         self.assertIn("getHeroThemeCount(themeKey)", source)
         self.assertIn("getUniqueHeroPokemon(manhole)", source)
+        self.assertIn("window.I18N?.intlLocale || 'ja-JP'", source)
         self.assertNotIn("countTemplate.replace('{count}', candidates.length)", source)
         self.assertNotIn("pokemon: reason", source)
 

--- a/apps/web/assets/pokefuta-map.css
+++ b/apps/web/assets/pokefuta-map.css
@@ -54,6 +54,11 @@ body.pokefuta-map-page {
   backdrop-filter: blur(10px);
 }
 
+.pokefuta-map-page .hero-fallback[hidden],
+.pokefuta-map-page .hero-discovery[hidden] {
+  display: none;
+}
+
 .pokefuta-map-page .map-hero-card h1 {
   margin: 0;
   font-size: 1.72rem;
@@ -87,6 +92,143 @@ body.pokefuta-map-page {
 .pokefuta-map-page .map-hero-card .hero-pokemon-link:focus-visible {
   text-decoration: underline;
   color: #4a3080;
+}
+
+.pokefuta-map-page .hero-discovery-heading {
+  margin: 0 0 9px;
+  color: #594a3e;
+  font-size: .72rem;
+  font-weight: 900;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+
+.pokefuta-map-page .hero-feature {
+  display: grid;
+  grid-template-columns: 116px minmax(0, 1fr);
+  min-height: 122px;
+  border-radius: 13px;
+  background: #fffdf7;
+  color: #1f1b18;
+  box-shadow: 0 7px 18px rgba(66, 43, 18, .13);
+  overflow: hidden;
+  text-decoration: none;
+  transition: transform .16s ease, box-shadow .16s ease;
+}
+
+.pokefuta-map-page .hero-feature:hover,
+.pokefuta-map-page .hero-feature:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 22px rgba(66, 43, 18, .18);
+}
+
+.pokefuta-map-page .hero-feature-media {
+  min-height: 122px;
+  background: linear-gradient(145deg, #d9c7a7, #f2e6cc);
+}
+
+.pokefuta-map-page .hero-feature-media img {
+  width: 100%;
+  height: 100%;
+  min-height: 122px;
+  object-fit: cover;
+}
+
+.pokefuta-map-page .hero-feature.is-image-missing {
+  grid-template-columns: 1fr;
+}
+
+.pokefuta-map-page .hero-feature.is-image-missing .hero-feature-media {
+  display: none;
+}
+
+.pokefuta-map-page .hero-feature-copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 10px 12px;
+}
+
+.pokefuta-map-page .hero-feature-eyebrow,
+.pokefuta-map-page .hero-discovery-link-label {
+  color: #7654aa;
+  font-size: .66rem;
+  font-weight: 900;
+}
+
+.pokefuta-map-page .hero-feature-title {
+  display: -webkit-box;
+  margin-top: 3px;
+  overflow: hidden;
+  font-size: 1rem;
+  line-height: 1.25;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.pokefuta-map-page .hero-feature-place,
+.pokefuta-map-page .hero-discovery-link-place {
+  margin-top: 3px;
+  color: #6d6259;
+  font-size: .68rem;
+  font-weight: 750;
+}
+
+.pokefuta-map-page .hero-feature-reason {
+  display: -webkit-box;
+  margin-top: 5px;
+  overflow: hidden;
+  color: #3f3730;
+  font-size: .7rem;
+  font-weight: 750;
+  line-height: 1.35;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.pokefuta-map-page .hero-feature-cta {
+  margin-top: 7px;
+  color: #7654aa;
+  font-size: .7rem;
+  font-weight: 900;
+}
+
+.pokefuta-map-page .hero-discovery-links {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 7px;
+  margin-top: 8px;
+}
+
+.pokefuta-map-page .hero-discovery-link {
+  display: flex;
+  min-width: 0;
+  min-height: 62px;
+  flex-direction: column;
+  justify-content: center;
+  padding: 8px 10px;
+  border: 1px solid rgba(110, 80, 44, .13);
+  border-radius: 11px;
+  background: rgba(255, 253, 247, .82);
+  color: #1f1b18;
+  text-decoration: none;
+}
+
+.pokefuta-map-page .hero-discovery-link:hover,
+.pokefuta-map-page .hero-discovery-link:focus-visible {
+  border-color: rgba(118, 84, 170, .45);
+  background: #fffdf7;
+}
+
+.pokefuta-map-page .hero-discovery-link strong {
+  margin-top: 2px;
+  overflow: hidden;
+  font-size: .76rem;
+  line-height: 1.2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .pokefuta-map-page #controls {
@@ -1260,13 +1402,13 @@ body.pokefuta-map-page {
     top: 28px;
     left: 28px;
     right: auto;
-    width: min(360px, calc(100vw - 500px));
-    min-width: 300px;
+    width: min(390px, calc(100vw - 500px));
+    min-width: 330px;
     padding: 20px 22px;
   }
 
   .pokefuta-map-page .leaflet-top.leaflet-left {
-    top: 180px;
+    top: 344px;
   }
 
   .pokefuta-map-page .map-hero-card h1 {
@@ -1383,7 +1525,7 @@ body.pokefuta-map-page {
   .pokefuta-map-page .map-hero-card {
     left: 14px;
     right: 14px;
-    padding: 12px 14px;
+    padding: 10px 12px;
     transition: opacity .16s ease, transform .16s ease, visibility .16s ease;
   }
 
@@ -1394,13 +1536,65 @@ body.pokefuta-map-page {
   }
 
   .pokefuta-map-page .leaflet-top.leaflet-left {
-    top: 154px;
+    top: 270px;
   }
 
   .pokefuta-map-page .map-hero-card p {
     margin-top: 7px;
     font-size: .74rem;
     line-height: 1.5;
+  }
+
+  .pokefuta-map-page .hero-discovery-heading {
+    margin-bottom: 6px;
+    font-size: .64rem;
+  }
+
+  .pokefuta-map-page .hero-feature {
+    grid-template-columns: 94px minmax(0, 1fr);
+    min-height: 98px;
+  }
+
+  .pokefuta-map-page .hero-feature-media,
+  .pokefuta-map-page .hero-feature-media img {
+    min-height: 98px;
+  }
+
+  .pokefuta-map-page .hero-feature-copy {
+    padding: 7px 9px;
+  }
+
+  .pokefuta-map-page .hero-feature-title {
+    font-size: .86rem;
+  }
+
+  .pokefuta-map-page .hero-feature-reason {
+    margin-top: 3px;
+    font-size: .64rem;
+    -webkit-line-clamp: 1;
+  }
+
+  .pokefuta-map-page .hero-feature-cta {
+    margin-top: 4px;
+    font-size: .64rem;
+  }
+
+  .pokefuta-map-page .hero-discovery-links {
+    gap: 5px;
+    margin-top: 6px;
+  }
+
+  .pokefuta-map-page .hero-discovery-link {
+    min-height: 48px;
+    padding: 6px 8px;
+  }
+
+  .pokefuta-map-page .hero-discovery-link strong {
+    font-size: .7rem;
+  }
+
+  .pokefuta-map-page .hero-discovery-link-place {
+    font-size: .6rem;
   }
 
   .pokefuta-map-page.popup-open .map-hero-card {

--- a/apps/web/i18n/strings.en.json
+++ b/apps/web/i18n/strings.en.json
@@ -94,6 +94,18 @@
     "recentDisabledTitle": "Not available (no date field in data)",
     "panelOpenLabel": "Open main panel",
     "panelCloseLabel": "Close main panel",
+    "heroDiscovery": {
+      "heading": "Which Pokéfuta will you meet today?",
+      "freshDate": "A new photo from {date}",
+      "countTemplate": "{count} across Japan",
+      "uniqueTemplate": "{pokemon} appears on only one Pokéfuta in Japan",
+      "ctas": {"fresh": "View on the map →", "travel": "Explore the feature →", "rare": "View the ranking →"},
+      "categories": {
+        "travel": {"label": "Start a journey"}, "rare": {"label": "Find a rarity"}, "fresh": {"label": "Fresh discovery"}
+      },
+      "travelThemes": {"remote_island": "Pokéfuta on remote islands", "roadside": "Pokéfuta at roadside stations", "station_front": "Pokéfuta by train stations", "world_heritage": "Pokéfuta near World Heritage sites"},
+      "rareThemes": {"unique_pokemon": "Found only here in Japan", "north_end": "Japan's northernmost Pokéfuta", "south_end": "Japan's southernmost Pokéfuta", "east_end": "Japan's easternmost Pokéfuta", "west_end": "Japan's westernmost Pokéfuta", "lone": "Pokéfuta in far-flung places"}
+    },
     "titleLabels": {
       "north_end": "Northernmost Pokéfuta in Japan",
       "south_end": "Southernmost Pokéfuta in Japan",

--- a/apps/web/i18n/strings.ja.json
+++ b/apps/web/i18n/strings.ja.json
@@ -94,6 +94,18 @@
     "recentDisabledTitle": "データに日付フィールド (added_at / first_seen / last_seen / source_last_checked / last_updated / date) が無いため利用できません",
     "panelOpenLabel": "全体パネルを開く",
     "panelCloseLabel": "全体パネルを閉じる",
+    "heroDiscovery": {
+      "heading": "今日、どのポケふたに会いに行く？",
+      "freshDate": "{date}に届いた一枚",
+      "countTemplate": "全国{count}枚",
+      "uniqueTemplate": "{pokemon}のポケふたは全国1枚",
+      "ctas": {"fresh": "地図で写真を見る →", "travel": "特集を見る →", "rare": "ランキングを見る →"},
+      "categories": {
+        "travel": {"label": "旅に出る"}, "rare": {"label": "レアを探す"}, "fresh": {"label": "新しい一枚"}
+      },
+      "travelThemes": {"remote_island": "離島にあるポケふた", "roadside": "道の駅にあるポケふた", "station_front": "駅前にあるポケふた", "world_heritage": "世界遺産の近くにあるポケふた"},
+      "rareThemes": {"unique_pokemon": "全国でここだけ", "north_end": "日本最北端のポケふた", "south_end": "日本最南端のポケふた", "east_end": "日本最東端のポケふた", "west_end": "日本最西端のポケふた", "lone": "ぽつんと離れた秘境のポケふた"}
+    },
     "UI": {
       "recentLabel": "🆕 直近1ヶ月",
       "prefectureFilter": "都道府県で絞り込み",

--- a/apps/web/i18n/strings.ko.json
+++ b/apps/web/i18n/strings.ko.json
@@ -94,6 +94,18 @@
     "recentDisabledTitle": "사용 불가 (데이터에 날짜 필드 없음)",
     "panelOpenLabel": "전체 패널 열기",
     "panelCloseLabel": "전체 패널 닫기",
+    "heroDiscovery": {
+      "heading": "오늘은 어떤 포케후타를 만나러 갈까요?",
+      "freshDate": "{date}에 도착한 새 사진",
+      "countTemplate": "일본 전국 {count}개",
+      "uniqueTemplate": "{pokemon} 포케후타는 일본 전국에 1개",
+      "ctas": {"fresh": "지도에서 사진 보기 →", "travel": "특집 보기 →", "rare": "랭킹 보기 →"},
+      "categories": {
+        "travel": {"label": "여행 떠나기"}, "rare": {"label": "희귀 포케후타"}, "fresh": {"label": "새로운 발견"}
+      },
+      "travelThemes": {"remote_island": "외딴섬의 포케후타", "roadside": "미치노에키의 포케후타", "station_front": "역 앞의 포케후타", "world_heritage": "세계유산 근처의 포케후타"},
+      "rareThemes": {"unique_pokemon": "일본에서 오직 이곳뿐", "north_end": "일본 최북단 포케후타", "south_end": "일본 최남단 포케후타", "east_end": "일본 최동단 포케후타", "west_end": "일본 최서단 포케후타", "lone": "외딴 비경의 포케후타"}
+    },
     "titleLabels": {
       "north_end": "일본 최북단 포케후타",
       "south_end": "일본 최남단 포케후타",

--- a/apps/web/i18n/strings.zh-CN.json
+++ b/apps/web/i18n/strings.zh-CN.json
@@ -94,6 +94,18 @@
     "recentDisabledTitle": "无法使用（数据中没有日期字段）",
     "panelOpenLabel": "开启总面板",
     "panelCloseLabel": "关闭总面板",
+    "heroDiscovery": {
+      "heading": "今天想去遇见哪一个 Pokéfuta？",
+      "freshDate": "{date} 收到的新照片",
+      "countTemplate": "日本全国共 {count} 枚",
+      "uniqueTemplate": "{pokemon} 的 Pokéfuta 在日本全国仅此一枚",
+      "ctas": {"fresh": "在地图上看照片 →", "travel": "查看专题 →", "rare": "查看排行 →"},
+      "categories": {
+        "travel": {"label": "踏上旅程"}, "rare": {"label": "寻找稀有"}, "fresh": {"label": "最新发现"}
+      },
+      "travelThemes": {"remote_island": "离岛上的 Pokéfuta", "roadside": "道之驿的 Pokéfuta", "station_front": "车站前的 Pokéfuta", "world_heritage": "世界遗产附近的 Pokéfuta"},
+      "rareThemes": {"unique_pokemon": "日本全国仅此一处", "north_end": "日本最北的 Pokéfuta", "south_end": "日本最南的 Pokéfuta", "east_end": "日本最东的 Pokéfuta", "west_end": "日本最西的 Pokéfuta", "lone": "秘境中的 Pokéfuta"}
+    },
     "titleLabels": {
       "north_end": "日本最北 Pokéfuta",
       "south_end": "日本最南 Pokéfuta",

--- a/apps/web/i18n/strings.zh-TW.json
+++ b/apps/web/i18n/strings.zh-TW.json
@@ -94,6 +94,18 @@
     "recentDisabledTitle": "無法使用（資料中沒有日期欄位）",
     "panelOpenLabel": "開啟總面板",
     "panelCloseLabel": "關閉總面板",
+    "heroDiscovery": {
+      "heading": "今天想去遇見哪一個 Pokéfuta？",
+      "freshDate": "{date} 收到的新照片",
+      "countTemplate": "日本全國共 {count} 枚",
+      "uniqueTemplate": "{pokemon} 的 Pokéfuta 在日本全國僅此一枚",
+      "ctas": {"fresh": "在地圖上看照片 →", "travel": "查看特輯 →", "rare": "查看排行 →"},
+      "categories": {
+        "travel": {"label": "踏上旅程"}, "rare": {"label": "尋找稀有"}, "fresh": {"label": "最新發現"}
+      },
+      "travelThemes": {"remote_island": "離島上的 Pokéfuta", "roadside": "道之驛的 Pokéfuta", "station_front": "車站前的 Pokéfuta", "world_heritage": "世界遺產附近的 Pokéfuta"},
+      "rareThemes": {"unique_pokemon": "日本全國僅此一處", "north_end": "日本最北的 Pokéfuta", "south_end": "日本最南的 Pokéfuta", "east_end": "日本最東的 Pokéfuta", "west_end": "日本最西的 Pokéfuta", "lone": "秘境中的 Pokéfuta"}
+    },
     "titleLabels": {
       "north_end": "日本最北 Pokéfuta",
       "south_end": "日本最南 Pokéfuta",

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -881,6 +881,22 @@
         .sort((a, b) => String(a.id).localeCompare(String(b.id), 'en', { numeric: true }));
     }
 
+    function getHeroThemeCount(themeKey) {
+      return allData.filter(manhole => hasHeroTitle(manhole, themeKey)).length;
+    }
+
+    function getUniqueHeroPokemon(manhole) {
+      const pokemonCounts = new Map();
+      allData.forEach(item => {
+        new Set(item.pokemons || []).forEach(name => {
+          if (name && !name.includes('ローカルActs')) {
+            pokemonCounts.set(name, (pokemonCounts.get(name) || 0) + 1);
+          }
+        });
+      });
+      return (manhole.pokemons || []).find(name => pokemonCounts.get(name) === 1) || '';
+    }
+
     function getSummaryHubUrl(anchor) {
       const lang = window.I18N?.lang || 'ja';
       const prefix = lang === 'ja' ? '/' : `/${lang}/`;
@@ -904,9 +920,10 @@
         manhole,
         category: 'fresh',
         categoryLabel: strings.categories.fresh.label,
-        pokemon: getHeroPokemonText(manhole),
+        title: getHeroPokemonText(manhole),
         place: [manhole.prefecture, manhole.city].filter(Boolean).join(' ') || window.I18N?.unknownPref || '不明',
         reason: photoDate ? strings.freshDate.replace('{date}', photoDate) : strings.categories.fresh.label,
+        imageAlt: getHeroPokemonText(manhole),
         imageUrl: getLocalManholeImageUrl(manhole.id),
         destinationUrl: getManholePageUrl(manhole.id),
         destinationHub: 'map_popup',
@@ -921,21 +938,27 @@
       if (!candidates.length) return null;
       const manhole = candidates[stableHash(`${dateKey}:${category}:${themeKey}:representative`) % candidates.length];
       const strings = HERO_DISCOVERY_TEXT;
+      let title = '';
       let reason = '';
       if (category === 'travel') {
-        reason = `${strings.travelThemes[themeKey]} ${strings.countTemplate.replace('{count}', candidates.length)}`;
+        title = strings.travelThemes[themeKey];
+        reason = strings.countTemplate.replace('{count}', getHeroThemeCount(themeKey));
       } else if (themeKey === 'unique_pokemon') {
-        reason = strings.uniqueTemplate.replace('{pokemon}', getHeroPokemonText(manhole));
+        const uniquePokemon = getUniqueHeroPokemon(manhole);
+        title = uniquePokemon ? getHeroPokemonDisplayName(uniquePokemon) : strings.rareThemes[themeKey];
+        reason = strings.uniqueTemplate.replace('{pokemon}', title);
       } else {
-        reason = strings.rareThemes[themeKey];
+        title = strings.rareThemes[themeKey];
+        reason = getHeroPokemonText(manhole);
       }
       return {
         manhole,
         category,
         categoryLabel: strings.categories[category].label,
-        pokemon: reason,
+        title,
         place: [manhole.prefecture, manhole.city].filter(Boolean).join(' ') || window.I18N?.unknownPref || '不明',
         reason,
+        imageAlt: getHeroPokemonText(manhole),
         imageUrl: getLocalManholeImageUrl(manhole.id),
         destinationUrl: getSummaryHubUrl(category === 'travel' ? 'travel-discovery' : 'rare-discovery'),
         destinationHub: category === 'travel' ? 'summary_travel' : 'summary_rare',
@@ -965,19 +988,19 @@
       if (featured) {
         const image = link.querySelector('.hero-feature-media img');
         image.src = recommendation.imageUrl;
-        image.alt = `${recommendation.place} ${recommendation.pokemon}${window.I18N?.photoAltSuffix || 'の写真'}`;
+        image.alt = `${recommendation.place} ${recommendation.imageAlt}${window.I18N?.photoAltSuffix || 'の写真'}`;
         image.addEventListener('error', () => {
           link.classList.add('is-image-missing');
           image.remove();
         }, { once: true });
         link.querySelector('.hero-feature-eyebrow').textContent = recommendation.categoryLabel;
-        link.querySelector('.hero-feature-title').textContent = recommendation.pokemon;
+        link.querySelector('.hero-feature-title').textContent = recommendation.title;
         link.querySelector('.hero-feature-place').textContent = recommendation.place;
         link.querySelector('.hero-feature-reason').textContent = recommendation.reason;
         link.querySelector('.hero-feature-cta').textContent = HERO_DISCOVERY_TEXT.ctas[recommendation.category];
       } else {
         link.querySelector('.hero-discovery-link-label').textContent = recommendation.categoryLabel;
-        link.querySelector('strong').textContent = recommendation.pokemon;
+        link.querySelector('strong').textContent = recommendation.title;
         link.querySelector('.hero-discovery-link-place').textContent =
           `${recommendation.place} · ${HERO_DISCOVERY_TEXT.ctas[recommendation.category]}`;
       }

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1387,9 +1387,8 @@
           const raw = d.added_at || d.first_seen || d.last_seen || d.source_last_checked || d.last_updated || d.date;
           d._addedDate = normalizeDateString(raw);
         });
+        const pokemonMetadataPromise = loadPokemonMetadata();
         await loadLatestPhotoMeta();
-        await loadPokemonMetadata();
-        renderHeroDiscovery();
         initMarkerLayer();
         // Build markers
         allMarkers = [];
@@ -1420,6 +1419,12 @@
           marker.pokefutaData = d; marker.pokefutaData.prefectureCode = prefectureCode;
           allMarkers.push(marker);
           markerLayer.addLayer(marker);
+        });
+        pokemonMetadataPromise.then(() => {
+          allMarkers.forEach(marker => {
+            marker.setPopupContent(buildPokefutaPopup(marker.pokefutaData));
+          });
+          renderHeroDiscovery();
         });
         
         // 都道府県ごとのマンホール数と bounding box マップを構築（グローバル変数を使用）

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -297,7 +297,7 @@
     integrity="sha384-pmjIAcz2bAn0xukfxADbZIb3t8oRT9Sv0rvO+BR5Csr6Dhqq+nZs59P0pPKQJkEV" crossorigin="" />
   <link rel="stylesheet" href="./assets/theme.css" />
   <link rel="stylesheet" href="./assets/map.css" />
-  <link rel="stylesheet" href="./assets/pokefuta-map.css?v=20260613-popup-actions-grid" />
+  <link rel="stylesheet" href="./assets/pokefuta-map.css?v=20260613-discovery-hub" />
   <link rel="icon" href="./assets/pokefuta-marker.svg" type="image/svg+xml" />
   <!-- Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-K18NR4GZG2"></script>
@@ -350,9 +350,38 @@
   <main class="map-stage" aria-label="ポケふた探索マップ">
     <div id="map"></div>
     <section class="map-hero-card" aria-labelledby="hero-title">
-      <h1 id="hero-title">全国のポケふた・ポケモンマンホールマップ</h1>
-      <p>旅行やお出かけのついでに、ご当地マンホール「ポケふた」を見つけよう</p>
-      <a href="/pokemon/" class="hero-pokemon-link" onclick="if(window.trackEvent){window.trackEvent('click_pokemon_lp_hero',{event_category:'navigation',event_label:'hero_card'})}">好きなポケモンのポケふたを探す →</a>
+      <div id="hero-fallback" class="hero-fallback">
+        <h1 id="hero-title">全国のポケふた・ポケモンマンホールマップ</h1>
+        <p>旅行やお出かけのついでに、ご当地マンホール「ポケふた」を見つけよう</p>
+        <a href="/pokemon/" class="hero-pokemon-link" onclick="if(window.trackEvent){window.trackEvent('click_pokemon_lp_hero',{event_category:'navigation',event_label:'hero_card'})}">好きなポケモンのポケふたを探す →</a>
+      </div>
+      <div id="hero-discovery" class="hero-discovery" hidden>
+        <p class="hero-discovery-heading"></p>
+        <a class="hero-feature" href="">
+          <span class="hero-feature-media">
+            <img src="" alt="" decoding="async">
+          </span>
+          <span class="hero-feature-copy">
+            <span class="hero-feature-eyebrow"></span>
+            <strong class="hero-feature-title"></strong>
+            <span class="hero-feature-place"></span>
+            <span class="hero-feature-reason"></span>
+            <span class="hero-feature-cta"></span>
+          </span>
+        </a>
+        <div class="hero-discovery-links" aria-label="今日の発見">
+          <a class="hero-discovery-link" href="" data-position="secondary_1">
+            <span class="hero-discovery-link-label"></span>
+            <strong></strong>
+            <span class="hero-discovery-link-place"></span>
+          </a>
+          <a class="hero-discovery-link" href="" data-position="secondary_2">
+            <span class="hero-discovery-link-label"></span>
+            <strong></strong>
+            <span class="hero-discovery-link-place"></span>
+          </a>
+        </div>
+      </div>
       <a id="i18n-notice" href="" hidden
          style="display:block; margin-top:8px; padding-top:8px; border-top:1px solid rgba(110,80,44,.12); font-size:0.78rem; font-weight:700; color:#4a7c59; text-decoration:none;"
       ></a>
@@ -687,6 +716,36 @@
       detailPageCta: '詳細ページを見る',
       prefectureSite: 'サイト'
     };
+    const HERO_DISCOVERY_TEXT = {
+      heading: '今日、どのポケふたに会いに行く？',
+      freshDate: '{date}に届いた一枚',
+      countTemplate: '全国{count}枚',
+      uniqueTemplate: '{pokemon}のポケふたは全国1枚',
+      ctas: {
+        fresh: '地図で写真を見る →',
+        travel: '特集を見る →',
+        rare: 'ランキングを見る →'
+      },
+      categories: {
+        travel: { label: '旅に出る' },
+        rare: { label: 'レアを探す' },
+        fresh: { label: '新しい一枚' }
+      },
+      travelThemes: {
+        remote_island: '離島にあるポケふた',
+        roadside: '道の駅にあるポケふた',
+        station_front: '駅前にあるポケふた',
+        world_heritage: '世界遺産の近くにあるポケふた'
+      },
+      rareThemes: {
+        unique_pokemon: '全国でここだけ',
+        north_end: '日本最北端のポケふた',
+        south_end: '日本最南端のポケふた',
+        east_end: '日本最東端のポケふた',
+        west_end: '日本最西端のポケふた',
+        lone: 'ぽつんと離れた秘境のポケふた'
+      }
+    };
 
     // 初期テキストは既に HTML に記述しているため updateUIText は不要
     function updateUIText() { /* no-op (多言語削除) */ }
@@ -745,7 +804,8 @@
       if (!rawDate) return '';
       const date = new Date(rawDate);
       if (Number.isNaN(date.getTime())) return '';
-      return new Intl.DateTimeFormat('ja-JP', {
+      return new Intl.DateTimeFormat(window.I18N?.lang || 'ja-JP', {
+        timeZone: 'Asia/Tokyo',
         year: 'numeric',
         month: 'long',
         day: 'numeric'
@@ -760,6 +820,222 @@
     function getPhotoTakenDate(id) {
       const meta = getLatestPhotoMeta(id);
       return formatPhotoDate(meta?.shot_at || meta?.created_at);
+    }
+
+    const HERO_TRAVEL_THEME_KEYS = ['remote_island', 'roadside', 'station_front', 'world_heritage'];
+    const HERO_RARE_THEME_KEYS = ['unique_pokemon', 'north_end', 'south_end', 'east_end', 'west_end', 'lone'];
+
+    function getJapanDateKey(date = new Date()) {
+      return new Intl.DateTimeFormat('en-CA', {
+        timeZone: 'Asia/Tokyo',
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit'
+      }).format(date);
+    }
+
+    function stableHash(value) {
+      let hash = 2166136261;
+      for (let index = 0; index < value.length; index += 1) {
+        hash ^= value.charCodeAt(index);
+        hash = Math.imul(hash, 16777619);
+      }
+      return hash >>> 0;
+    }
+
+    function getDailyRotationIndex(dateKey, itemCount, offset = 0) {
+      const dayNumber = Math.floor(Date.parse(`${dateKey}T00:00:00Z`) / 86400000);
+      return (dayNumber + offset) % itemCount;
+    }
+
+    function hasHeroTitle(manhole, key) {
+      if (key === 'lone') {
+        return (manhole.titles || []).some(title => title.key === 'lone' || title.key === 'lone_100');
+      }
+      return (manhole.titles || []).some(title => title.key === key);
+    }
+
+    function getHeroPokemonDisplayName(nameJa) {
+      const names = getPokemonMetadata(nameJa)?.names;
+      const lang = window.I18N?.lang || 'ja';
+      return {
+        en: names?.en,
+        ko: names?.ko,
+        'zh-TW': names?.['zh-Hant'],
+        'zh-CN': names?.['zh-Hans']
+      }[lang] || nameJa;
+    }
+
+    function getHeroPokemonText(manhole) {
+      const pokemons = Array.isArray(manhole.pokemons)
+        ? manhole.pokemons.filter(name => name && !name.includes('ローカルActs')).slice(0, 2)
+        : [];
+      return pokemons.length
+        ? pokemons.map(getHeroPokemonDisplayName).join(window.I18N?.pokemonJoiner || '・')
+        : (manhole.title || window.I18N?.manholeTitle || 'ポケふた');
+    }
+
+    function getHeroThemeCandidates(themeKey) {
+      return allData
+        .filter(manhole => getLatestPhotoMeta(manhole.id) && hasHeroTitle(manhole, themeKey))
+        .sort((a, b) => String(a.id).localeCompare(String(b.id), 'en', { numeric: true }));
+    }
+
+    function getSummaryHubUrl(anchor) {
+      const lang = window.I18N?.lang || 'ja';
+      const prefix = lang === 'ja' ? '/' : `/${lang}/`;
+      return `${prefix}summary/#${anchor}`;
+    }
+
+    function buildFreshHeroRecommendation() {
+      const manhole = allData
+        .filter(item => getLatestPhotoMeta(item.id))
+        .sort((a, b) => {
+          const aPhoto = getLatestPhotoMeta(a.id);
+          const bPhoto = getLatestPhotoMeta(b.id);
+          return (Date.parse(bPhoto?.created_at || bPhoto?.shot_at || '') || 0)
+            - (Date.parse(aPhoto?.created_at || aPhoto?.shot_at || '') || 0);
+        })[0];
+      if (!manhole) return null;
+      const strings = HERO_DISCOVERY_TEXT;
+      const photo = getLatestPhotoMeta(manhole.id);
+      const photoDate = formatPhotoDate(photo?.created_at);
+      return {
+        manhole,
+        category: 'fresh',
+        categoryLabel: strings.categories.fresh.label,
+        pokemon: getHeroPokemonText(manhole),
+        place: [manhole.prefecture, manhole.city].filter(Boolean).join(' ') || window.I18N?.unknownPref || '不明',
+        reason: photoDate ? strings.freshDate.replace('{date}', photoDate) : strings.categories.fresh.label,
+        imageUrl: getLocalManholeImageUrl(manhole.id),
+        destinationUrl: getManholePageUrl(manhole.id),
+        destinationHub: 'map_popup',
+        contentType: 'latest_photo',
+        contentId: photo?.photo_id || String(manhole.id),
+        photo
+      };
+    }
+
+    function buildThemeHeroRecommendation(category, themeKey, dateKey) {
+      const candidates = getHeroThemeCandidates(themeKey);
+      if (!candidates.length) return null;
+      const manhole = candidates[stableHash(`${dateKey}:${category}:${themeKey}:representative`) % candidates.length];
+      const strings = HERO_DISCOVERY_TEXT;
+      let reason = '';
+      if (category === 'travel') {
+        reason = `${strings.travelThemes[themeKey]} ${strings.countTemplate.replace('{count}', candidates.length)}`;
+      } else if (themeKey === 'unique_pokemon') {
+        reason = strings.uniqueTemplate.replace('{pokemon}', getHeroPokemonText(manhole));
+      } else {
+        reason = strings.rareThemes[themeKey];
+      }
+      return {
+        manhole,
+        category,
+        categoryLabel: strings.categories[category].label,
+        pokemon: reason,
+        place: [manhole.prefecture, manhole.city].filter(Boolean).join(' ') || window.I18N?.unknownPref || '不明',
+        reason,
+        imageUrl: getLocalManholeImageUrl(manhole.id),
+        destinationUrl: getSummaryHubUrl(category === 'travel' ? 'travel-discovery' : 'rare-discovery'),
+        destinationHub: category === 'travel' ? 'summary_travel' : 'summary_rare',
+        contentType: category === 'travel' ? 'travel_theme' : 'rare_fact',
+        contentId: themeKey
+      };
+    }
+
+    function trackHeroRecommendation(action, recommendation, position) {
+      if (!window.trackEvent || !recommendation) return;
+      window.trackEvent(action, {
+        event_category: 'hero_discovery',
+        event_label: recommendation.category,
+        recommendation_type: recommendation.category,
+        manhole_id: recommendation.manhole.id,
+        content_type: recommendation.contentType,
+        content_id: recommendation.contentId,
+        destination_hub: recommendation.destinationHub,
+        position,
+        site_type: 'map',
+        page_type: window.currentGA4PageType || 'map_top'
+      });
+    }
+
+    function configureHeroLink(link, recommendation, position, featured = false) {
+      link.href = recommendation.destinationUrl;
+      if (featured) {
+        const image = link.querySelector('.hero-feature-media img');
+        image.src = recommendation.imageUrl;
+        image.alt = `${recommendation.place} ${recommendation.pokemon}${window.I18N?.photoAltSuffix || 'の写真'}`;
+        image.addEventListener('error', () => {
+          link.classList.add('is-image-missing');
+          image.remove();
+        }, { once: true });
+        link.querySelector('.hero-feature-eyebrow').textContent = recommendation.categoryLabel;
+        link.querySelector('.hero-feature-title').textContent = recommendation.pokemon;
+        link.querySelector('.hero-feature-place').textContent = recommendation.place;
+        link.querySelector('.hero-feature-reason').textContent = recommendation.reason;
+        link.querySelector('.hero-feature-cta').textContent = HERO_DISCOVERY_TEXT.ctas[recommendation.category];
+      } else {
+        link.querySelector('.hero-discovery-link-label').textContent = recommendation.categoryLabel;
+        link.querySelector('strong').textContent = recommendation.pokemon;
+        link.querySelector('.hero-discovery-link-place').textContent =
+          `${recommendation.place} · ${HERO_DISCOVERY_TEXT.ctas[recommendation.category]}`;
+      }
+      link.addEventListener('click', event => {
+        if (recommendation.category === 'fresh') {
+          event.preventDefault();
+          trackHeroRecommendation('click_hero_new_photo', recommendation, position);
+          collapseBottomSheet();
+          openManholePopup(recommendation.manhole.id);
+          return;
+        }
+        trackHeroRecommendation('click_hero_discovery', recommendation, position);
+      });
+    }
+
+    function renderHeroDiscovery() {
+      const discovery = document.getElementById('hero-discovery');
+      const fallback = document.getElementById('hero-fallback');
+      if (!discovery || !fallback) return;
+
+      const dateKey = getJapanDateKey();
+      const availableTravelKeys = HERO_TRAVEL_THEME_KEYS.filter(key => getHeroThemeCandidates(key).length);
+      const availableRareKeys = HERO_RARE_THEME_KEYS.filter(key => getHeroThemeCandidates(key).length);
+      if (!availableTravelKeys.length || !availableRareKeys.length) return;
+      const travelKey = availableTravelKeys[getDailyRotationIndex(dateKey, availableTravelKeys.length)];
+      const rareKey = availableRareKeys[getDailyRotationIndex(dateKey, availableRareKeys.length, 2)];
+      const byCategory = {
+        fresh: buildFreshHeroRecommendation(),
+        travel: buildThemeHeroRecommendation('travel', travelKey, dateKey),
+        rare: buildThemeHeroRecommendation('rare', rareKey, dateKey)
+      };
+      const categories = ['travel', 'rare', 'fresh'];
+      const featuredIndex = getDailyRotationIndex(dateKey, categories.length, 1);
+      const orderedCategories = [
+        categories[featuredIndex],
+        categories[(featuredIndex + 1) % categories.length],
+        categories[(featuredIndex + 2) % categories.length]
+      ];
+      const recommendations = orderedCategories.map(category => byCategory[category]).filter(Boolean);
+      if (recommendations.length < 3) return;
+
+      const [featured, ...secondary] = recommendations;
+      const heroCard = discovery.closest('.map-hero-card');
+      const featureLink = discovery.querySelector('.hero-feature');
+      heroCard?.removeAttribute('aria-labelledby');
+      heroCard?.setAttribute('aria-label', HERO_DISCOVERY_TEXT.heading);
+      discovery.querySelector('.hero-discovery-heading').textContent = HERO_DISCOVERY_TEXT.heading;
+      discovery.querySelector('.hero-discovery-links').setAttribute('aria-label', HERO_DISCOVERY_TEXT.heading);
+      configureHeroLink(featureLink, featured, 'featured', true);
+
+      discovery.querySelectorAll('.hero-discovery-link').forEach((link, index) => {
+        const recommendation = secondary[index];
+        configureHeroLink(link, recommendation, link.dataset.position);
+      });
+
+      fallback.hidden = true;
+      discovery.hidden = false;
+      trackHeroRecommendation('view_hero_recommendation', featured, 'featured');
     }
 
     function handlePopupImageError(img) {
@@ -1089,8 +1365,8 @@
           d._addedDate = normalizeDateString(raw);
         });
         await loadLatestPhotoMeta();
-        // Load Pokemon metadata asynchronously (non-blocking)
-        loadPokemonMetadata().catch(err => console.warn('Pokemon metadata loading failed', err));
+        await loadPokemonMetadata();
+        renderHeroDiscovery();
         initMarkerLayer();
         // Build markers
         allMarkers = [];

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -804,7 +804,7 @@
       if (!rawDate) return '';
       const date = new Date(rawDate);
       if (Number.isNaN(date.getTime())) return '';
-      return new Intl.DateTimeFormat(window.I18N?.lang || 'ja-JP', {
+      return new Intl.DateTimeFormat(window.I18N?.intlLocale || 'ja-JP', {
         timeZone: 'Asia/Tokyo',
         year: 'numeric',
         month: 'long',

--- a/apps/web/index.template.html
+++ b/apps/web/index.template.html
@@ -1351,9 +1351,8 @@
           const raw = d.added_at || d.first_seen || d.last_seen || d.source_last_checked || d.last_updated || d.date;
           d._addedDate = normalizeDateString(raw);
         });
+        const pokemonMetadataPromise = loadPokemonMetadata();
         await loadLatestPhotoMeta();
-        await loadPokemonMetadata();
-        renderHeroDiscovery();
         initMarkerLayer();
         // Build markers
         allMarkers = [];
@@ -1384,6 +1383,12 @@
           marker.pokefutaData = d; marker.pokefutaData.prefectureCode = prefectureCode;
           allMarkers.push(marker);
           markerLayer.addLayer(marker);
+        });
+        pokemonMetadataPromise.then(() => {
+          allMarkers.forEach(marker => {
+            marker.setPopupContent(buildPokefutaPopup(marker.pokefutaData));
+          });
+          renderHeroDiscovery();
         });
         
         // 都道府県ごとのマンホール数と bounding box マップを構築（グローバル変数を使用）

--- a/apps/web/index.template.html
+++ b/apps/web/index.template.html
@@ -309,7 +309,7 @@
     integrity="sha384-pmjIAcz2bAn0xukfxADbZIb3t8oRT9Sv0rvO+BR5Csr6Dhqq+nZs59P0pPKQJkEV" crossorigin="" />
   <link rel="stylesheet" href="%%BASE_PATH%%assets/theme.css" />
   <link rel="stylesheet" href="%%BASE_PATH%%assets/map.css" />
-  <link rel="stylesheet" href="%%BASE_PATH%%assets/pokefuta-map.css?v=20260613-popup-actions-grid" />
+  <link rel="stylesheet" href="%%BASE_PATH%%assets/pokefuta-map.css?v=20260613-discovery-hub" />
   <link rel="icon" href="%%BASE_PATH%%assets/pokefuta-marker.svg" type="image/svg+xml" />
   <!-- Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-K18NR4GZG2"></script>
@@ -362,9 +362,38 @@
   <main class="map-stage" aria-label="%%MAP_ARIA%%">
     <div id="map"></div>
     <section class="map-hero-card" aria-labelledby="hero-title">
-      <h1 id="hero-title">%%HERO_TITLE%%</h1>
-      <p>%%HERO_SUBTITLE%%</p>
-      <a href="/pokemon/" class="hero-pokemon-link" onclick="if(window.trackEvent){window.trackEvent('click_pokemon_lp_hero',{event_category:'navigation',event_label:'hero_card'})}">好きなポケモンのポケふたを探す →</a>
+      <div id="hero-fallback" class="hero-fallback">
+        <h1 id="hero-title">%%HERO_TITLE%%</h1>
+        <p>%%HERO_SUBTITLE%%</p>
+        <a href="/pokemon/" class="hero-pokemon-link" onclick="if(window.trackEvent){window.trackEvent('click_pokemon_lp_hero',{event_category:'navigation',event_label:'hero_card'})}">好きなポケモンのポケふたを探す →</a>
+      </div>
+      <div id="hero-discovery" class="hero-discovery" hidden>
+        <p class="hero-discovery-heading"></p>
+        <a class="hero-feature" href="">
+          <span class="hero-feature-media">
+            <img src="" alt="" decoding="async">
+          </span>
+          <span class="hero-feature-copy">
+            <span class="hero-feature-eyebrow"></span>
+            <strong class="hero-feature-title"></strong>
+            <span class="hero-feature-place"></span>
+            <span class="hero-feature-reason"></span>
+            <span class="hero-feature-cta"></span>
+          </span>
+        </a>
+        <div class="hero-discovery-links" aria-label="今日の発見">
+          <a class="hero-discovery-link" href="" data-position="secondary_1">
+            <span class="hero-discovery-link-label"></span>
+            <strong></strong>
+            <span class="hero-discovery-link-place"></span>
+          </a>
+          <a class="hero-discovery-link" href="" data-position="secondary_2">
+            <span class="hero-discovery-link-label"></span>
+            <strong></strong>
+            <span class="hero-discovery-link-place"></span>
+          </a>
+        </div>
+      </div>
       <a id="i18n-notice" href="" hidden
          style="display:block; margin-top:8px; padding-top:8px; border-top:1px solid rgba(110,80,44,.12); font-size:0.78rem; font-weight:700; color:#4a7c59; text-decoration:none;"
       ></a>
@@ -586,6 +615,7 @@
     var showTagDirectory = false;
     const TAG_DIRECTORY_MIN_COUNT = 5;  // この件数未満のタグはチップに表示しない
     const TAG_PRIORITY = ['roadside', 'world_heritage', 'remote_island', 'seaside', 'tourism', 'station_front', 'food', 'museum', 'history', 'rail_access_good'];
+    const FEATURED_TAGS = ['roadside', 'remote_island', 'station_front', 'world_heritage', 'seaside'];
 
     const TAG_META = {
       seaside:          { emoji: '🌊', label: '海沿い' },
@@ -671,10 +701,37 @@
       SECONDARY_TAG_KEYS.map(k => [k, TAG_META[k]?.label]).filter(([,v]) => v)
     ));
 
-    // UI labels: sourced from build-time injected window.I18N.UI
-    const UI_TEXT = window.I18N.UI;
+    // ==== 単一言語 (日本語) 用 UI ラベル定数 ====
+    const UI_TEXT = {
+      recentLabel: '🆕 直近1ヶ月',
+      prefectureFilter: '都道府県で絞り込み',
+      allPrefectures: 'すべての都道府県',
+      prefectureCount: '都道府県別ポケふた数',
+      searchPrefecture: '都道府県を検索...',
+      codeHeader: 'コード',
+      prefectureHeader: '都道府県',
+      countHeader: 'ポケふた数',
+      siteHeader: 'サイト',
+      pokemonFilter: 'ポケモンで絞り込み',
+      searchPokemon: 'ポケモンを検索...',
+      showAll: '🔄 すべて表示',
+      totalCount: '総数:',
+      visibleCount: '表示:',
+      cityCount: '市町村:',
+      idLabel: 'ID:',
+      titleLabel: 'タイトル:',
+      prefectureLabel: '都道府県:',
+      pokemonLabel: 'ポケモン:',
+      cityLabel: '市町村:',
+      officialDetail: '📝 公式詳細',
+      officialDetailCta: '公式詳細を見る',
+      detailPageCta: '詳細ページを見る',
+      prefectureSite: 'サイト'
+    };
+    const HERO_DISCOVERY_TEXT = window.I18N.heroDiscovery;
 
-    function updateUIText() { /* no-op */ }
+    // 初期テキストは既に HTML に記述しているため updateUIText は不要
+    function updateUIText() { /* no-op (多言語削除) */ }
 
     // Validate prefecture site URL (whitelist check)
     function validatePrefectureSiteUrl(rawUrl) {
@@ -730,7 +787,8 @@
       if (!rawDate) return '';
       const date = new Date(rawDate);
       if (Number.isNaN(date.getTime())) return '';
-      return new Intl.DateTimeFormat(window.I18N.intlLocale, {
+      return new Intl.DateTimeFormat(window.I18N?.lang || 'ja-JP', {
+        timeZone: 'Asia/Tokyo',
         year: 'numeric',
         month: 'long',
         day: 'numeric'
@@ -745,6 +803,222 @@
     function getPhotoTakenDate(id) {
       const meta = getLatestPhotoMeta(id);
       return formatPhotoDate(meta?.shot_at || meta?.created_at);
+    }
+
+    const HERO_TRAVEL_THEME_KEYS = ['remote_island', 'roadside', 'station_front', 'world_heritage'];
+    const HERO_RARE_THEME_KEYS = ['unique_pokemon', 'north_end', 'south_end', 'east_end', 'west_end', 'lone'];
+
+    function getJapanDateKey(date = new Date()) {
+      return new Intl.DateTimeFormat('en-CA', {
+        timeZone: 'Asia/Tokyo',
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit'
+      }).format(date);
+    }
+
+    function stableHash(value) {
+      let hash = 2166136261;
+      for (let index = 0; index < value.length; index += 1) {
+        hash ^= value.charCodeAt(index);
+        hash = Math.imul(hash, 16777619);
+      }
+      return hash >>> 0;
+    }
+
+    function getDailyRotationIndex(dateKey, itemCount, offset = 0) {
+      const dayNumber = Math.floor(Date.parse(`${dateKey}T00:00:00Z`) / 86400000);
+      return (dayNumber + offset) % itemCount;
+    }
+
+    function hasHeroTitle(manhole, key) {
+      if (key === 'lone') {
+        return (manhole.titles || []).some(title => title.key === 'lone' || title.key === 'lone_100');
+      }
+      return (manhole.titles || []).some(title => title.key === key);
+    }
+
+    function getHeroPokemonDisplayName(nameJa) {
+      const names = getPokemonMetadata(nameJa)?.names;
+      const lang = window.I18N?.lang || 'ja';
+      return {
+        en: names?.en,
+        ko: names?.ko,
+        'zh-TW': names?.['zh-Hant'],
+        'zh-CN': names?.['zh-Hans']
+      }[lang] || nameJa;
+    }
+
+    function getHeroPokemonText(manhole) {
+      const pokemons = Array.isArray(manhole.pokemons)
+        ? manhole.pokemons.filter(name => name && !name.includes('ローカルActs')).slice(0, 2)
+        : [];
+      return pokemons.length
+        ? pokemons.map(getHeroPokemonDisplayName).join(window.I18N?.pokemonJoiner || '・')
+        : (manhole.title || window.I18N?.manholeTitle || 'ポケふた');
+    }
+
+    function getHeroThemeCandidates(themeKey) {
+      return allData
+        .filter(manhole => getLatestPhotoMeta(manhole.id) && hasHeroTitle(manhole, themeKey))
+        .sort((a, b) => String(a.id).localeCompare(String(b.id), 'en', { numeric: true }));
+    }
+
+    function getSummaryHubUrl(anchor) {
+      const lang = window.I18N?.lang || 'ja';
+      const prefix = lang === 'ja' ? '/' : `/${lang}/`;
+      return `${prefix}summary/#${anchor}`;
+    }
+
+    function buildFreshHeroRecommendation() {
+      const manhole = allData
+        .filter(item => getLatestPhotoMeta(item.id))
+        .sort((a, b) => {
+          const aPhoto = getLatestPhotoMeta(a.id);
+          const bPhoto = getLatestPhotoMeta(b.id);
+          return (Date.parse(bPhoto?.created_at || bPhoto?.shot_at || '') || 0)
+            - (Date.parse(aPhoto?.created_at || aPhoto?.shot_at || '') || 0);
+        })[0];
+      if (!manhole) return null;
+      const strings = HERO_DISCOVERY_TEXT;
+      const photo = getLatestPhotoMeta(manhole.id);
+      const photoDate = formatPhotoDate(photo?.created_at);
+      return {
+        manhole,
+        category: 'fresh',
+        categoryLabel: strings.categories.fresh.label,
+        pokemon: getHeroPokemonText(manhole),
+        place: [manhole.prefecture, manhole.city].filter(Boolean).join(' ') || window.I18N?.unknownPref || '不明',
+        reason: photoDate ? strings.freshDate.replace('{date}', photoDate) : strings.categories.fresh.label,
+        imageUrl: getLocalManholeImageUrl(manhole.id),
+        destinationUrl: getManholePageUrl(manhole.id),
+        destinationHub: 'map_popup',
+        contentType: 'latest_photo',
+        contentId: photo?.photo_id || String(manhole.id),
+        photo
+      };
+    }
+
+    function buildThemeHeroRecommendation(category, themeKey, dateKey) {
+      const candidates = getHeroThemeCandidates(themeKey);
+      if (!candidates.length) return null;
+      const manhole = candidates[stableHash(`${dateKey}:${category}:${themeKey}:representative`) % candidates.length];
+      const strings = HERO_DISCOVERY_TEXT;
+      let reason = '';
+      if (category === 'travel') {
+        reason = `${strings.travelThemes[themeKey]} ${strings.countTemplate.replace('{count}', candidates.length)}`;
+      } else if (themeKey === 'unique_pokemon') {
+        reason = strings.uniqueTemplate.replace('{pokemon}', getHeroPokemonText(manhole));
+      } else {
+        reason = strings.rareThemes[themeKey];
+      }
+      return {
+        manhole,
+        category,
+        categoryLabel: strings.categories[category].label,
+        pokemon: reason,
+        place: [manhole.prefecture, manhole.city].filter(Boolean).join(' ') || window.I18N?.unknownPref || '不明',
+        reason,
+        imageUrl: getLocalManholeImageUrl(manhole.id),
+        destinationUrl: getSummaryHubUrl(category === 'travel' ? 'travel-discovery' : 'rare-discovery'),
+        destinationHub: category === 'travel' ? 'summary_travel' : 'summary_rare',
+        contentType: category === 'travel' ? 'travel_theme' : 'rare_fact',
+        contentId: themeKey
+      };
+    }
+
+    function trackHeroRecommendation(action, recommendation, position) {
+      if (!window.trackEvent || !recommendation) return;
+      window.trackEvent(action, {
+        event_category: 'hero_discovery',
+        event_label: recommendation.category,
+        recommendation_type: recommendation.category,
+        manhole_id: recommendation.manhole.id,
+        content_type: recommendation.contentType,
+        content_id: recommendation.contentId,
+        destination_hub: recommendation.destinationHub,
+        position,
+        site_type: 'map',
+        page_type: window.currentGA4PageType || 'map_top'
+      });
+    }
+
+    function configureHeroLink(link, recommendation, position, featured = false) {
+      link.href = recommendation.destinationUrl;
+      if (featured) {
+        const image = link.querySelector('.hero-feature-media img');
+        image.src = recommendation.imageUrl;
+        image.alt = `${recommendation.place} ${recommendation.pokemon}${window.I18N?.photoAltSuffix || 'の写真'}`;
+        image.addEventListener('error', () => {
+          link.classList.add('is-image-missing');
+          image.remove();
+        }, { once: true });
+        link.querySelector('.hero-feature-eyebrow').textContent = recommendation.categoryLabel;
+        link.querySelector('.hero-feature-title').textContent = recommendation.pokemon;
+        link.querySelector('.hero-feature-place').textContent = recommendation.place;
+        link.querySelector('.hero-feature-reason').textContent = recommendation.reason;
+        link.querySelector('.hero-feature-cta').textContent = HERO_DISCOVERY_TEXT.ctas[recommendation.category];
+      } else {
+        link.querySelector('.hero-discovery-link-label').textContent = recommendation.categoryLabel;
+        link.querySelector('strong').textContent = recommendation.pokemon;
+        link.querySelector('.hero-discovery-link-place').textContent =
+          `${recommendation.place} · ${HERO_DISCOVERY_TEXT.ctas[recommendation.category]}`;
+      }
+      link.addEventListener('click', event => {
+        if (recommendation.category === 'fresh') {
+          event.preventDefault();
+          trackHeroRecommendation('click_hero_new_photo', recommendation, position);
+          collapseBottomSheet();
+          openManholePopup(recommendation.manhole.id);
+          return;
+        }
+        trackHeroRecommendation('click_hero_discovery', recommendation, position);
+      });
+    }
+
+    function renderHeroDiscovery() {
+      const discovery = document.getElementById('hero-discovery');
+      const fallback = document.getElementById('hero-fallback');
+      if (!discovery || !fallback) return;
+
+      const dateKey = getJapanDateKey();
+      const availableTravelKeys = HERO_TRAVEL_THEME_KEYS.filter(key => getHeroThemeCandidates(key).length);
+      const availableRareKeys = HERO_RARE_THEME_KEYS.filter(key => getHeroThemeCandidates(key).length);
+      if (!availableTravelKeys.length || !availableRareKeys.length) return;
+      const travelKey = availableTravelKeys[getDailyRotationIndex(dateKey, availableTravelKeys.length)];
+      const rareKey = availableRareKeys[getDailyRotationIndex(dateKey, availableRareKeys.length, 2)];
+      const byCategory = {
+        fresh: buildFreshHeroRecommendation(),
+        travel: buildThemeHeroRecommendation('travel', travelKey, dateKey),
+        rare: buildThemeHeroRecommendation('rare', rareKey, dateKey)
+      };
+      const categories = ['travel', 'rare', 'fresh'];
+      const featuredIndex = getDailyRotationIndex(dateKey, categories.length, 1);
+      const orderedCategories = [
+        categories[featuredIndex],
+        categories[(featuredIndex + 1) % categories.length],
+        categories[(featuredIndex + 2) % categories.length]
+      ];
+      const recommendations = orderedCategories.map(category => byCategory[category]).filter(Boolean);
+      if (recommendations.length < 3) return;
+
+      const [featured, ...secondary] = recommendations;
+      const heroCard = discovery.closest('.map-hero-card');
+      const featureLink = discovery.querySelector('.hero-feature');
+      heroCard?.removeAttribute('aria-labelledby');
+      heroCard?.setAttribute('aria-label', HERO_DISCOVERY_TEXT.heading);
+      discovery.querySelector('.hero-discovery-heading').textContent = HERO_DISCOVERY_TEXT.heading;
+      discovery.querySelector('.hero-discovery-links').setAttribute('aria-label', HERO_DISCOVERY_TEXT.heading);
+      configureHeroLink(featureLink, featured, 'featured', true);
+
+      discovery.querySelectorAll('.hero-discovery-link').forEach((link, index) => {
+        const recommendation = secondary[index];
+        configureHeroLink(link, recommendation, link.dataset.position);
+      });
+
+      fallback.hidden = true;
+      discovery.hidden = false;
+      trackHeroRecommendation('view_hero_recommendation', featured, 'featured');
     }
 
     function handlePopupImageError(img) {
@@ -800,15 +1074,15 @@
           </a>
           ${photoMetaItems ? `<div class="travel-popup-photo-meta">${photoMetaItems}</div>` : ''}
           <div class="popup-photo__missing">
-            <b>${I.photoWanted}</b>
-            <span>${I.photoMissing}</span>
+            <b>写真募集中</b>
+            <span>全国でまだ写真0枚</span>
           </div>
         </div>
       ` : `
-        <div class="popup-photo travel-popup-photo popup-photo--missing" aria-label="${I.photoWanted}">
+        <div class="popup-photo travel-popup-photo popup-photo--missing" aria-label="写真募集中">
           <div class="popup-photo__missing">
-            <b>${I.photoWanted}</b>
-            <span>${I.photoMissing}</span>
+            <b>写真募集中</b>
+            <span>全国でまだ写真0枚</span>
           </div>
         </div>
       `;
@@ -817,21 +1091,21 @@
         const anchor = document.createElement('a');
         anchor.href = manholeDetailUrl;
         anchor.className = 'travel-popup-action travel-popup-action--detail';
-        anchor.textContent = UI_TEXT.detailPageCta;
+        anchor.textContent = '詳細を見る';
         anchor.setAttribute('onclick', `if(window.trackEvent){window.trackEvent('popup_click_detail',{${eventParams}});}`);
         return anchor.outerHTML;
       })() : '';
       const primaryAction = hasPhoto
         ? `<a href="${photoPageUrl}" target="_blank" rel="noopener noreferrer" class="travel-popup-action travel-popup-action--primary"
-              onclick="if(window.trackEvent){window.trackEvent('popup_click_photo',{${eventParams}});}">${I.photoViewCta}</a>`
+              onclick="if(window.trackEvent){window.trackEvent('popup_click_photo',{${eventParams}});}">写真を見る</a>`
         : `<a href="${uploadUrl}" target="_blank" rel="noopener noreferrer" class="travel-popup-action travel-popup-action--primary travel-popup-action--upload"
-              onclick="if(window.trackEvent){window.trackEvent('popup_click_upload',{${eventParams}});}">${I.firstPhotoUploadCta}</a>`;
+              onclick="if(window.trackEvent){window.trackEvent('popup_click_upload',{${eventParams}});}">最初の写真を投稿</a>`;
       const mapsUrl = Number.isFinite(Number(d.lat)) && Number.isFinite(Number(d.lng))
         ? `https://www.google.com/maps?q=${encodeURIComponent(`${d.lat},${d.lng}`)}`
         : '';
       const mapsAction = mapsUrl
         ? `<a href="${mapsUrl}" target="_blank" rel="noopener noreferrer" class="travel-popup-action travel-popup-action--maps"
-              onclick="if(window.trackEvent){window.trackEvent('popup_click_google_maps',{${eventParams}});}">${I.googleMapsCta}</a>`
+              onclick="if(window.trackEvent){window.trackEvent('popup_click_google_maps',{${eventParams}});}">Google Mapsで行く</a>`
         : '';
 
       return `
@@ -890,18 +1164,6 @@
     function getPokemonMetadata(nameJa) {
       if (!pokemonMetadata || !nameJa) return null;
       return pokemonMetadata.get(nameJa) || null;
-    }
-
-    function getPokemonDisplayName(nameJa) {
-      const names = getPokemonMetadata(nameJa)?.names;
-      const lang = window.I18N?.lang || 'ja';
-      const localizedName = {
-        en: names?.en,
-        ko: names?.ko,
-        'zh-TW': names?.['zh-Hant'],
-        'zh-CN': names?.['zh-Hans']
-      }[lang];
-      return localizedName || nameJa;
     }
 
     window.getPokemonLpUrl = function(jaName) {
@@ -1092,8 +1354,8 @@
           d._addedDate = normalizeDateString(raw);
         });
         await loadLatestPhotoMeta();
-        // Load Pokemon metadata asynchronously (non-blocking)
-        loadPokemonMetadata().catch(err => console.warn('Pokemon metadata loading failed', err));
+        await loadPokemonMetadata();
+        renderHeroDiscovery();
         initMarkerLayer();
         // Build markers
         allMarkers = [];
@@ -1747,8 +2009,10 @@
           if (priB >= 0) return 1;
           return b - a;
         });
-      const primaryTags = sorted.filter(([tag]) => TAG_PRIORITY.includes(tag));
-      const secondaryTags = sorted.filter(([tag]) => !TAG_PRIORITY.includes(tag));
+      const primaryTags = FEATURED_TAGS
+        .filter(tag => tagCounts[tag] >= TAG_DIRECTORY_MIN_COUNT && TAG_META[tag])
+        .map(tag => [tag, tagCounts[tag]]);
+      const secondaryTags = sorted.filter(([tag]) => !FEATURED_TAGS.includes(tag));
       function makeChip(tag, count) {
         const meta = TAG_META[tag];
         return `<button class="tag-chip" data-tag="${tag}" data-count="${count}" aria-pressed="false">${meta.emoji} ${meta.label} <span class="tag-count">${count}枚</span></button>`;

--- a/apps/web/index.template.html
+++ b/apps/web/index.template.html
@@ -701,33 +701,8 @@
       SECONDARY_TAG_KEYS.map(k => [k, TAG_META[k]?.label]).filter(([,v]) => v)
     ));
 
-    // ==== 単一言語 (日本語) 用 UI ラベル定数 ====
-    const UI_TEXT = {
-      recentLabel: '🆕 直近1ヶ月',
-      prefectureFilter: '都道府県で絞り込み',
-      allPrefectures: 'すべての都道府県',
-      prefectureCount: '都道府県別ポケふた数',
-      searchPrefecture: '都道府県を検索...',
-      codeHeader: 'コード',
-      prefectureHeader: '都道府県',
-      countHeader: 'ポケふた数',
-      siteHeader: 'サイト',
-      pokemonFilter: 'ポケモンで絞り込み',
-      searchPokemon: 'ポケモンを検索...',
-      showAll: '🔄 すべて表示',
-      totalCount: '総数:',
-      visibleCount: '表示:',
-      cityCount: '市町村:',
-      idLabel: 'ID:',
-      titleLabel: 'タイトル:',
-      prefectureLabel: '都道府県:',
-      pokemonLabel: 'ポケモン:',
-      cityLabel: '市町村:',
-      officialDetail: '📝 公式詳細',
-      officialDetailCta: '公式詳細を見る',
-      detailPageCta: '詳細ページを見る',
-      prefectureSite: 'サイト'
-    };
+    // UI labels: sourced from build-time injected window.I18N.UI
+    const UI_TEXT = window.I18N.UI;
     const HERO_DISCOVERY_TEXT = window.I18N.heroDiscovery;
 
     // 初期テキストは既に HTML に記述しているため updateUIText は不要
@@ -864,6 +839,22 @@
         .sort((a, b) => String(a.id).localeCompare(String(b.id), 'en', { numeric: true }));
     }
 
+    function getHeroThemeCount(themeKey) {
+      return allData.filter(manhole => hasHeroTitle(manhole, themeKey)).length;
+    }
+
+    function getUniqueHeroPokemon(manhole) {
+      const pokemonCounts = new Map();
+      allData.forEach(item => {
+        new Set(item.pokemons || []).forEach(name => {
+          if (name && !name.includes('ローカルActs')) {
+            pokemonCounts.set(name, (pokemonCounts.get(name) || 0) + 1);
+          }
+        });
+      });
+      return (manhole.pokemons || []).find(name => pokemonCounts.get(name) === 1) || '';
+    }
+
     function getSummaryHubUrl(anchor) {
       const lang = window.I18N?.lang || 'ja';
       const prefix = lang === 'ja' ? '/' : `/${lang}/`;
@@ -887,9 +878,10 @@
         manhole,
         category: 'fresh',
         categoryLabel: strings.categories.fresh.label,
-        pokemon: getHeroPokemonText(manhole),
+        title: getHeroPokemonText(manhole),
         place: [manhole.prefecture, manhole.city].filter(Boolean).join(' ') || window.I18N?.unknownPref || '不明',
         reason: photoDate ? strings.freshDate.replace('{date}', photoDate) : strings.categories.fresh.label,
+        imageAlt: getHeroPokemonText(manhole),
         imageUrl: getLocalManholeImageUrl(manhole.id),
         destinationUrl: getManholePageUrl(manhole.id),
         destinationHub: 'map_popup',
@@ -904,21 +896,27 @@
       if (!candidates.length) return null;
       const manhole = candidates[stableHash(`${dateKey}:${category}:${themeKey}:representative`) % candidates.length];
       const strings = HERO_DISCOVERY_TEXT;
+      let title = '';
       let reason = '';
       if (category === 'travel') {
-        reason = `${strings.travelThemes[themeKey]} ${strings.countTemplate.replace('{count}', candidates.length)}`;
+        title = strings.travelThemes[themeKey];
+        reason = strings.countTemplate.replace('{count}', getHeroThemeCount(themeKey));
       } else if (themeKey === 'unique_pokemon') {
-        reason = strings.uniqueTemplate.replace('{pokemon}', getHeroPokemonText(manhole));
+        const uniquePokemon = getUniqueHeroPokemon(manhole);
+        title = uniquePokemon ? getHeroPokemonDisplayName(uniquePokemon) : strings.rareThemes[themeKey];
+        reason = strings.uniqueTemplate.replace('{pokemon}', title);
       } else {
-        reason = strings.rareThemes[themeKey];
+        title = strings.rareThemes[themeKey];
+        reason = getHeroPokemonText(manhole);
       }
       return {
         manhole,
         category,
         categoryLabel: strings.categories[category].label,
-        pokemon: reason,
+        title,
         place: [manhole.prefecture, manhole.city].filter(Boolean).join(' ') || window.I18N?.unknownPref || '不明',
         reason,
+        imageAlt: getHeroPokemonText(manhole),
         imageUrl: getLocalManholeImageUrl(manhole.id),
         destinationUrl: getSummaryHubUrl(category === 'travel' ? 'travel-discovery' : 'rare-discovery'),
         destinationHub: category === 'travel' ? 'summary_travel' : 'summary_rare',
@@ -948,19 +946,19 @@
       if (featured) {
         const image = link.querySelector('.hero-feature-media img');
         image.src = recommendation.imageUrl;
-        image.alt = `${recommendation.place} ${recommendation.pokemon}${window.I18N?.photoAltSuffix || 'の写真'}`;
+        image.alt = `${recommendation.place} ${recommendation.imageAlt}${window.I18N?.photoAltSuffix || 'の写真'}`;
         image.addEventListener('error', () => {
           link.classList.add('is-image-missing');
           image.remove();
         }, { once: true });
         link.querySelector('.hero-feature-eyebrow').textContent = recommendation.categoryLabel;
-        link.querySelector('.hero-feature-title').textContent = recommendation.pokemon;
+        link.querySelector('.hero-feature-title').textContent = recommendation.title;
         link.querySelector('.hero-feature-place').textContent = recommendation.place;
         link.querySelector('.hero-feature-reason').textContent = recommendation.reason;
         link.querySelector('.hero-feature-cta').textContent = HERO_DISCOVERY_TEXT.ctas[recommendation.category];
       } else {
         link.querySelector('.hero-discovery-link-label').textContent = recommendation.categoryLabel;
-        link.querySelector('strong').textContent = recommendation.pokemon;
+        link.querySelector('strong').textContent = recommendation.title;
         link.querySelector('.hero-discovery-link-place').textContent =
           `${recommendation.place} · ${HERO_DISCOVERY_TEXT.ctas[recommendation.category]}`;
       }
@@ -1035,7 +1033,7 @@
       const pokemons = Array.isArray(d.pokemons) && d.pokemons.length ? d.pokemons : [];
       const pokemonsHtml = pokemons.length
         ? pokemons.map(pokemon => {
-            const displayName = escapeHtml(getPokemonDisplayName(pokemon));
+            const displayName = escapeHtml(getHeroPokemonDisplayName(pokemon));
             const url = getPokemonLpUrl(pokemon);
             return url
               ? `<a href="${escapeHtml(url)}" class="travel-popup-pokemon" target="_blank" rel="noopener noreferrer">${displayName}</a>`
@@ -1074,15 +1072,15 @@
           </a>
           ${photoMetaItems ? `<div class="travel-popup-photo-meta">${photoMetaItems}</div>` : ''}
           <div class="popup-photo__missing">
-            <b>写真募集中</b>
-            <span>全国でまだ写真0枚</span>
+            <b>${I.photoWanted}</b>
+            <span>${I.photoMissing}</span>
           </div>
         </div>
       ` : `
-        <div class="popup-photo travel-popup-photo popup-photo--missing" aria-label="写真募集中">
+        <div class="popup-photo travel-popup-photo popup-photo--missing" aria-label="${I.photoWanted}">
           <div class="popup-photo__missing">
-            <b>写真募集中</b>
-            <span>全国でまだ写真0枚</span>
+            <b>${I.photoWanted}</b>
+            <span>${I.photoMissing}</span>
           </div>
         </div>
       `;
@@ -1091,21 +1089,21 @@
         const anchor = document.createElement('a');
         anchor.href = manholeDetailUrl;
         anchor.className = 'travel-popup-action travel-popup-action--detail';
-        anchor.textContent = '詳細を見る';
+        anchor.textContent = UI_TEXT.detailPageCta;
         anchor.setAttribute('onclick', `if(window.trackEvent){window.trackEvent('popup_click_detail',{${eventParams}});}`);
         return anchor.outerHTML;
       })() : '';
       const primaryAction = hasPhoto
         ? `<a href="${photoPageUrl}" target="_blank" rel="noopener noreferrer" class="travel-popup-action travel-popup-action--primary"
-              onclick="if(window.trackEvent){window.trackEvent('popup_click_photo',{${eventParams}});}">写真を見る</a>`
+              onclick="if(window.trackEvent){window.trackEvent('popup_click_photo',{${eventParams}});}">${I.photoViewCta}</a>`
         : `<a href="${uploadUrl}" target="_blank" rel="noopener noreferrer" class="travel-popup-action travel-popup-action--primary travel-popup-action--upload"
-              onclick="if(window.trackEvent){window.trackEvent('popup_click_upload',{${eventParams}});}">最初の写真を投稿</a>`;
+              onclick="if(window.trackEvent){window.trackEvent('popup_click_upload',{${eventParams}});}">${I.firstPhotoUploadCta}</a>`;
       const mapsUrl = Number.isFinite(Number(d.lat)) && Number.isFinite(Number(d.lng))
         ? `https://www.google.com/maps?q=${encodeURIComponent(`${d.lat},${d.lng}`)}`
         : '';
       const mapsAction = mapsUrl
         ? `<a href="${mapsUrl}" target="_blank" rel="noopener noreferrer" class="travel-popup-action travel-popup-action--maps"
-              onclick="if(window.trackEvent){window.trackEvent('popup_click_google_maps',{${eventParams}});}">Google Mapsで行く</a>`
+              onclick="if(window.trackEvent){window.trackEvent('popup_click_google_maps',{${eventParams}});}">${I.googleMapsCta}</a>`
         : '';
 
       return `

--- a/apps/web/index.template.html
+++ b/apps/web/index.template.html
@@ -762,7 +762,7 @@
       if (!rawDate) return '';
       const date = new Date(rawDate);
       if (Number.isNaN(date.getTime())) return '';
-      return new Intl.DateTimeFormat(window.I18N?.lang || 'ja-JP', {
+      return new Intl.DateTimeFormat(window.I18N?.intlLocale || 'ja-JP', {
         timeZone: 'Asia/Tokyo',
         year: 'numeric',
         month: 'long',

--- a/tools/make_template.py
+++ b/tools/make_template.py
@@ -245,9 +245,11 @@ t = t.replace(
     '  <link rel="stylesheet" href="./assets/map.css" />',
     '  <link rel="stylesheet" href="%%BASE_PATH%%assets/map.css" />', 1
 )
-t = t.replace(
-    '  <link rel="stylesheet" href="./assets/pokefuta-map.css" />',
-    '  <link rel="stylesheet" href="%%BASE_PATH%%assets/pokefuta-map.css" />', 1
+t = re.sub(
+    r'  <link rel="stylesheet" href="\./assets/pokefuta-map\.css([^"]*)" />',
+    r'  <link rel="stylesheet" href="%%BASE_PATH%%assets/pokefuta-map.css\1" />',
+    t,
+    count=1
 )
 t = t.replace(
     '  <link rel="icon" href="./assets/pokefuta-marker.svg" type="image/svg+xml" />',
@@ -567,6 +569,41 @@ t = t.replace(
     "      heading.textContent = window.I18N.prefSpotsHeadingFormat.replace('{pref}', prefecture);", 1
 )
 
+t = t.replace(
+    """    const HERO_DISCOVERY_TEXT = {
+      heading: '今日、どのポケふたに会いに行く？',
+      freshDate: '{date}に届いた一枚',
+      countTemplate: '全国{count}枚',
+      uniqueTemplate: '{pokemon}のポケふたは全国1枚',
+      ctas: {
+        fresh: '地図で写真を見る →',
+        travel: '特集を見る →',
+        rare: 'ランキングを見る →'
+      },
+      categories: {
+        travel: { label: '旅に出る' },
+        rare: { label: 'レアを探す' },
+        fresh: { label: '新しい一枚' }
+      },
+      travelThemes: {
+        remote_island: '離島にあるポケふた',
+        roadside: '道の駅にあるポケふた',
+        station_front: '駅前にあるポケふた',
+        world_heritage: '世界遺産の近くにあるポケふた'
+      },
+      rareThemes: {
+        unique_pokemon: '全国でここだけ',
+        north_end: '日本最北端のポケふた',
+        south_end: '日本最南端のポケふた',
+        east_end: '日本最東端のポケふた',
+        west_end: '日本最西端のポケふた',
+        lone: 'ぽつんと離れた秘境のポケふた'
+      }
+    };""",
+    "    const HERO_DISCOVERY_TEXT = window.I18N.heroDiscovery;",
+    1
+)
+
 # ──────────────────────────────────────────
 # Q. initLocationSearch — use window.I18N
 # ──────────────────────────────────────────
@@ -606,12 +643,12 @@ t = t.replace(
     '  <main class="map-stage" aria-label="%%MAP_ARIA%%">', 1
 )
 t = t.replace(
-    '      <h1 id="hero-title">全国のポケふた・ポケモンマンホールマップ</h1>',
-    '      <h1 id="hero-title">%%HERO_TITLE%%</h1>', 1
+    '        <h1 id="hero-title">全国のポケふた・ポケモンマンホールマップ</h1>',
+    '        <h1 id="hero-title">%%HERO_TITLE%%</h1>', 1
 )
 t = t.replace(
-    '      <p>旅行やお出かけのついでに、ご当地マンホール「ポケふた」を見つけよう</p>',
-    '      <p>%%HERO_SUBTITLE%%</p>', 1
+    '        <p>旅行やお出かけのついでに、ご当地マンホール「ポケふた」を見つけよう</p>',
+    '        <p>%%HERO_SUBTITLE%%</p>', 1
 )
 t = t.replace(
     '      <p class="map-hero-meta">📍 全国<span id="hero-city-count">0</span>の自治体に設置</p>',

--- a/tools/make_template.py
+++ b/tools/make_template.py
@@ -295,38 +295,15 @@ t = t.replace(
 # ──────────────────────────────────────────
 
 # Find and replace the entire UI_TEXT block
-ui_text_old = '''    // ==== 単一言語 (日本語) 用 UI ラベル定数 ====
-    const UI_TEXT = {
-      recentLabel: '🆕 直近1ヶ月',
-      prefectureFilter: '都道府県で絞り込み',
-      allPrefectures: 'すべての都道府県',
-      prefectureCount: '都道府県別ポケふた数',
-      searchPrefecture: '都道府県を検索...',
-      codeHeader: 'コード',
-      prefectureHeader: '都道府県',
-      countHeader: 'ポケふた数',
-      siteHeader: 'サイト',
-      pokemonFilter: 'ポケモンで絞り込み',
-      searchPokemon: 'ポケモンを検索...',
-      showAll: '🔄 すべて表示',
-      totalCount: '総数:',
-      visibleCount: '表示:',
-      cityCount: '市町村:',
-      idLabel: 'ID:',
-      titleLabel: 'タイトル:',
-      prefectureLabel: '都道府県:',
-      pokemonLabel: 'ポケモン:',
-      cityLabel: '市町村:',
-      officialDetail: '📝 公式詳細',
-      officialDetailCta: '公式詳細を見る',
-      detailPageCta: '詳細ページを見る',
-      prefectureSite: 'サイト'
-    };
-
-    // 初期テキストは既に HTML に記述しているため updateUIText は不要
-    function updateUIText() { /* no-op (多言語削除) */ }'''
-ui_text_new = "    // UI labels: sourced from build-time injected window.I18N.UI\n    const UI_TEXT = window.I18N.UI;\n\n    function updateUIText() { /* no-op */ }"
-t = t.replace(ui_text_old, ui_text_new, 1)
+t = re.sub(
+    r"    // ==== 単一言語 \(日本語\) 用 UI ラベル定数 ====\n"
+    r"    const UI_TEXT = \{.*?^    \};",
+    "    // UI labels: sourced from build-time injected window.I18N.UI\n"
+    "    const UI_TEXT = window.I18N.UI;",
+    t,
+    count=1,
+    flags=re.MULTILINE | re.DOTALL,
+)
 
 # ──────────────────────────────────────────
 # I. buildPokefutaPopup — use window.I18N
@@ -366,9 +343,29 @@ t = t.replace(
     '        <div class="popup-photo travel-popup-photo" aria-label="${I.manholePhotoAria}">', 1
 )
 t = t.replace(
-    '            <b>写真募集中</b>\n            <span>このポケふたの写真はまだありません。</span>\n            <a href="https://pokefuta.com/visits" target="_blank" rel="noopener noreferrer" class="popup-link popup-link--upload">写真を投稿</a>',
-    '            <b>${I.photoWanted}</b>\n            <span>${I.photoMissing}</span>\n            <a href="https://pokefuta.com/visits" target="_blank" rel="noopener noreferrer" class="popup-link popup-link--upload">${I.uploadPhoto}</a>',
-    1
+    '            <b>写真募集中</b>\n            <span>全国でまだ写真0枚</span>',
+    '            <b>${I.photoWanted}</b>\n            <span>${I.photoMissing}</span>',
+)
+t = t.replace(
+    '        <div class="popup-photo travel-popup-photo popup-photo--missing" aria-label="写真募集中">',
+    '        <div class="popup-photo travel-popup-photo popup-photo--missing" aria-label="${I.photoWanted}">',
+    1,
+)
+t = t.replace("        anchor.textContent = '詳細を見る';", "        anchor.textContent = UI_TEXT.detailPageCta;", 1)
+t = t.replace(
+    '              onclick="if(window.trackEvent){window.trackEvent(\'popup_click_photo\',{${eventParams}});}">写真を見る</a>`',
+    '              onclick="if(window.trackEvent){window.trackEvent(\'popup_click_photo\',{${eventParams}});}">${I.photoViewCta}</a>`',
+    1,
+)
+t = t.replace(
+    '              onclick="if(window.trackEvent){window.trackEvent(\'popup_click_upload\',{${eventParams}});}">最初の写真を投稿</a>`;',
+    '              onclick="if(window.trackEvent){window.trackEvent(\'popup_click_upload\',{${eventParams}});}">${I.firstPhotoUploadCta}</a>`;',
+    1,
+)
+t = t.replace(
+    '              onclick="if(window.trackEvent){window.trackEvent(\'popup_click_google_maps\',{${eventParams}});}">Google Mapsで行く</a>`',
+    '              onclick="if(window.trackEvent){window.trackEvent(\'popup_click_google_maps\',{${eventParams}});}">${I.googleMapsCta}</a>`',
+    1,
 )
 t = t.replace(
     '            <h3 class="travel-popup-title">${escapeHtml(d.title || \'ポケふた\')}</h3>',
@@ -411,7 +408,7 @@ t = t.replace(
               : `<span class="travel-popup-pokemon">${escapeHtml(pokemon)}</span>`;
           }).join('')''',
     '''        ? pokemons.map(pokemon => {
-            const displayName = escapeHtml(getPokemonDisplayName(pokemon));
+            const displayName = escapeHtml(getHeroPokemonDisplayName(pokemon));
             const url = getPokemonLpUrl(pokemon);
             return url
               ? `<a href="${escapeHtml(url)}" class="travel-popup-pokemon" target="_blank" rel="noopener noreferrer">${displayName}</a>`


### PR DESCRIPTION
## Summary

- redesign the homepage hero as a three-route discovery hub
- open the latest photo directly in the map popup with `?manhole=` synchronization
- route travel and rarity discoveries through dedicated multilingual summary sections
- add GA4 destination metadata and focused generator tests

## Why

The previous hero sent every discovery directly to a manhole detail page, making the detail page an endpoint rather than encouraging continued exploration. This separates the cards by purpose so users can keep browsing through the map popup or summary hubs.

## Validation

- `python3 -m unittest apps/scraper/test_generate_summary_pages.py`
- `python3 tools/make_template.py`
- `python3 tools/build_i18n.py`
- `python3 apps/scraper/generate_summary_pages.py`
- `python3 -m py_compile apps/scraper/generate_summary_pages.py apps/scraper/test_generate_summary_pages.py tools/make_template.py`
- Browser checks at 390px and desktop widths for popup URL synchronization, summary anchors, zoom controls, and popup actions
