### PR TITLE
[codex] Add Manhole Map semantic layers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,10 @@ pokefuta.ndjson
 # 道の駅JSONLDはimport_michineki.pyで都度再生成する
 dataset/michineki.json
 
+# Manhole Map JSON-LDはimport_manholemap.pyで都度再生成する
+dataset/manholemap.json
+dataset/manholemap-cache/
+
 .env*.local
 .env.production
 .env

--- a/apps/tools/README.md
+++ b/apps/tools/README.md
@@ -13,6 +13,7 @@ GitHub Actions からは呼ばれない手動実行ツール群。
 | `export_pokemon_park_kml.py` | `dataset/pokemon_park.tsv` → KML 変換 |
 | `check_quality.py` | `pokefuta.ndjson` の address フィールド完全性チェック |
 | `import_michineki.py` | 道の駅JSONLDの生成・pokefutaへの roadside 自動登録（[詳細](#import_michinekipy)） |
+| `import_manholemap.py` | Manhole Map公開データの全件取得・JSON-LD生成 |
 
 ## 依存パッケージ
 
@@ -32,6 +33,11 @@ pip install -r requirements.txt
 # 道の駅JSONLD再生成 + roadside自動登録
 python3 apps/tools/import_michineki.py          # 本番適用
 python3 apps/tools/import_michineki.py --dry-run # 確認のみ
+
+# Manhole Map 全件JSON-LD生成（2回目以降は都道府県別キャッシュを使用）
+python3 apps/tools/import_manholemap.py
+# 最新データを再取得
+python3 apps/tools/import_manholemap.py --refresh
 
 # データ品質チェック（pokefuta.ndjson は自動解決）
 python apps/tools/check_quality.py
@@ -87,3 +93,20 @@ python3 apps/tools/import_michineki.py
 |---|---|---|
 | `dataset/michineki.json` | gitignore（再生成） | 道の駅 ~1200件 JSON-LD |
 | `dataset/manhole_titles.json` | git管理 | roadside タグ・building名 追記済み |
+
+## import_manholemap.py
+
+`https://manholemap.juge.me/searchmisc` の公開検索結果を都道府県単位で取得し、
+緯度経度、住所、タグ、説明、投稿者、日時、評価数、元ページ・画像URLを
+schema.orgベースのJSON-LDへ変換します。画像自体はダウンロードしません。
+
+出力とキャッシュは再生成可能なためgitignore対象です。
+
+```bash
+python3 apps/tools/import_manholemap.py
+cd tools/manhole-semantic-editor
+npm run dev
+```
+
+エディターの「近くのマンホールを探す」で、ポケふたから100m〜3km以内の
+Manhole Map投稿を地図・距離・説明・タグから確認できます。

--- a/apps/tools/import_manholemap.py
+++ b/apps/tools/import_manholemap.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Manhole Map の公開検索結果を取得し、JSON-LD に変換する。
+
+Usage:
+  python3 apps/tools/import_manholemap.py
+  python3 apps/tools/import_manholemap.py --refresh
+  python3 apps/tools/import_manholemap.py --prefecture 東京都 --output /tmp/tokyo.json
+"""
+
+import argparse
+import json
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+BASE_URL = "https://manholemap.juge.me"
+CITY_CODES_URL = f"{BASE_URL}/getcitycodes?format=json"
+SEARCH_URL = f"{BASE_URL}/searchmisc"
+REPO_ROOT = Path(__file__).parent.parent.parent
+DEFAULT_OUTPUT = REPO_ROOT / "dataset" / "manholemap.json"
+DEFAULT_CACHE_DIR = REPO_ROOT / "dataset" / "manholemap-cache"
+USER_AGENT = "pokefuta-tracker-manholemap-import/1.0 (+https://github.com/nishioka/pokefuta-tracker)"
+
+
+def fetch_json(url, *, timeout=60, retries=3):
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/json",
+            "User-Agent": USER_AGENT,
+        },
+    )
+    for attempt in range(retries):
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                charset = response.headers.get_content_charset() or "utf-8"
+                return json.loads(response.read().decode(charset))
+        except (urllib.error.URLError, TimeoutError, json.JSONDecodeError):
+            if attempt == retries - 1:
+                raise
+            time.sleep(2**attempt)
+
+
+def load_city_codes():
+    cities = fetch_json(CITY_CODES_URL)
+    if not isinstance(cities, list):
+        raise ValueError("getcitycodes returned a non-list response")
+    return cities
+
+
+def build_municipality_index(cities):
+    by_prefecture = {}
+    for city in cities:
+        prefecture = str(city.get("pref", "")).strip()
+        municipality = str(city.get("city", "")).strip()
+        if not prefecture or not municipality:
+            continue
+        by_prefecture.setdefault(prefecture, []).append(municipality)
+
+    # 政令市の区など、長い自治体名を先に照合する。
+    return {
+        prefecture: sorted(set(names), key=len, reverse=True)
+        for prefecture, names in by_prefecture.items()
+    }
+
+
+def detect_municipality(address, prefecture, municipality_index):
+    remainder = address[len(prefecture):] if address.startswith(prefecture) else address
+    for municipality in municipality_index.get(prefecture, []):
+        if remainder.startswith(municipality):
+            return municipality
+    return ""
+
+
+def cache_path(cache_dir, prefecture):
+    return cache_dir / f"{prefecture}.json"
+
+
+def fetch_prefecture_records(prefecture, cache_dir, refresh=False):
+    path = cache_path(cache_dir, prefecture)
+    if path.exists() and not refresh:
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    query = urllib.parse.urlencode({"format": "json", "misc": prefecture})
+    records = fetch_json(f"{SEARCH_URL}?{query}")
+    if not isinstance(records, list):
+        raise ValueError(f"searchmisc returned a non-list response for {prefecture}")
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(records, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return records
+
+
+def clean_text(value):
+    return str(value or "").strip()
+
+
+def as_number(value, number_type, default=0):
+    try:
+        return number_type(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def record_to_jsonld(record, prefecture, municipality_index):
+    identifier = clean_text(record.get("id"))
+    address_text = clean_text(record.get("misc") or record.get("address"))
+    municipality = detect_municipality(address_text, prefecture, municipality_index)
+    tag = clean_text(record.get("tag"))
+    description = clean_text(record.get("text"))
+    name = tag or description or address_text or f"Manhole Map {identifier}"
+    lat = as_number(record.get("lat"), float, None)
+    lng = as_number(record.get("lng"), float, None)
+
+    item = {
+        "@id": f"{BASE_URL}/page?id={urllib.parse.quote(identifier)}",
+        "@type": "Place",
+        "additionalType": "https://www.wikidata.org/wiki/Q652657",
+        "identifier": identifier,
+        "name": name,
+        "url": f"{BASE_URL}/page?id={urllib.parse.quote(identifier)}",
+        "mainEntityOfPage": f"{BASE_URL}/page?id={urllib.parse.quote(identifier)}",
+        "image": {
+            "@type": "ImageObject",
+            "contentUrl": f"{BASE_URL}/get?id={urllib.parse.quote(identifier)}",
+            "encodingFormat": clean_text(record.get("type")) or "image/jpeg",
+            "width": as_number(record.get("width"), int),
+            "height": as_number(record.get("height"), int),
+        },
+        "address": {
+            "@type": "PostalAddress",
+            "streetAddress": address_text,
+            "addressRegion": prefecture,
+            "addressCountry": "JP",
+        },
+        "geo": {
+            "@type": "GeoCoordinates",
+            "latitude": lat,
+            "longitude": lng,
+        },
+        "dateCreated": clean_text(record.get("created")),
+        "dateModified": clean_text(record.get("updated")),
+        "author": {
+            "@type": "Person",
+            "name": clean_text(record.get("username")),
+        },
+        "interactionStatistic": {
+            "@type": "InteractionCounter",
+            "interactionType": "https://schema.org/LikeAction",
+            "userInteractionCount": as_number(record.get("nice"), int),
+        },
+        "additionalProperty": [
+            {
+                "@type": "PropertyValue",
+                "name": "tag",
+                "value": tag,
+            },
+            {
+                "@type": "PropertyValue",
+                "name": "sourceAddress",
+                "value": address_text,
+            },
+        ],
+    }
+    if description:
+        item["description"] = description
+    if municipality:
+        item["address"]["addressLocality"] = municipality
+
+    # 無効な座標や空文字をJSON-LDに残さない。
+    if lat is None or lng is None:
+        item.pop("geo")
+    if not item["author"]["name"]:
+        item.pop("author")
+    if not item["dateCreated"]:
+        item.pop("dateCreated")
+    if not item["dateModified"]:
+        item.pop("dateModified")
+    if not tag:
+        item["additionalProperty"] = [
+            prop for prop in item["additionalProperty"] if prop["name"] != "tag"
+        ]
+    return item
+
+
+def build_jsonld(records, municipality_index, fetched_at):
+    seen = set()
+    graph = []
+    for prefecture, record in records:
+        identifier = clean_text(record.get("id"))
+        if not identifier or identifier in seen:
+            continue
+        seen.add(identifier)
+        graph.append(record_to_jsonld(record, prefecture, municipality_index))
+
+    graph.sort(key=lambda item: item["identifier"])
+    return {
+        "@context": "https://schema.org",
+        "@type": "Dataset",
+        "name": "Manhole Map public records",
+        "description": "Manhole Map の公開検索結果を、近隣マンホール調査用にJSON-LDへ変換したローカルデータセット。",
+        "url": f"{BASE_URL}/bycity",
+        "isBasedOn": f"{BASE_URL}/bycity",
+        "dateModified": fetched_at,
+        "usageInfo": f"{BASE_URL}/tou",
+        "creator": {
+            "@type": "Organization",
+            "name": "Manhole Map",
+            "url": BASE_URL,
+        },
+        "distribution": {
+            "@type": "DataDownload",
+            "encodingFormat": "application/ld+json",
+        },
+        "numberOfItems": len(graph),
+        "@graph": graph,
+    }
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--cache-dir", type=Path, default=DEFAULT_CACHE_DIR)
+    parser.add_argument(
+        "--prefecture",
+        action="append",
+        help="対象都道府県。複数指定可。省略時は全国。",
+    )
+    parser.add_argument("--delay", type=float, default=0.25, help="API呼び出し間隔（秒）")
+    parser.add_argument("--refresh", action="store_true", help="キャッシュを使わず再取得")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    cities = load_city_codes()
+    municipality_index = build_municipality_index(cities)
+    available = list(municipality_index)
+    targets = args.prefecture or available
+    unknown = sorted(set(targets) - set(available))
+    if unknown:
+        raise SystemExit(f"Unknown prefecture: {', '.join(unknown)}")
+
+    all_records = []
+    for index, prefecture in enumerate(targets, start=1):
+        records = fetch_prefecture_records(
+            prefecture,
+            args.cache_dir,
+            refresh=args.refresh,
+        )
+        print(f"[{index:02d}/{len(targets):02d}] {prefecture}: {len(records)} records")
+        all_records.extend((prefecture, record) for record in records)
+        if index < len(targets) and args.delay > 0:
+            time.sleep(args.delay)
+
+    fetched_at = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    jsonld = build_jsonld(all_records, municipality_index, fetched_at)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(jsonld, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    print(f"Saved {jsonld['numberOfItems']} records -> {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/tools/test_import_manholemap.py
+++ b/apps/tools/test_import_manholemap.py
@@ -1,0 +1,69 @@
+import unittest
+
+from apps.tools.import_manholemap import (
+    build_jsonld,
+    build_municipality_index,
+    detect_municipality,
+    record_to_jsonld,
+)
+
+
+class ImportManholeMapTest(unittest.TestCase):
+    def setUp(self):
+        self.cities = [
+            {"pref": "東京都", "city": "渋谷区"},
+            {"pref": "北海道", "city": "札幌市中央区"},
+            {"pref": "北海道", "city": "札幌市"},
+        ]
+        self.index = build_municipality_index(self.cities)
+        self.record = {
+            "id": "123",
+            "username": "owner",
+            "created": "2020-07-16 22:34:13",
+            "updated": "2022-04-09 11:49:16",
+            "tag": "3月のライオン",
+            "type": "image/jpeg",
+            "text": "王さまニャー",
+            "lat": 35.6794,
+            "lng": 139.7080,
+            "nice": 2,
+            "width": 480,
+            "height": 320,
+            "misc": "東京都渋谷区千駄ヶ谷4丁目15",
+        }
+
+    def test_detects_longest_municipality(self):
+        self.assertEqual(
+            detect_municipality("北海道札幌市中央区北一条西", "北海道", self.index),
+            "札幌市中央区",
+        )
+
+    def test_converts_record_to_schema_org_jsonld(self):
+        item = record_to_jsonld(self.record, "東京都", self.index)
+        self.assertEqual(item["@type"], "Place")
+        self.assertEqual(item["identifier"], "123")
+        self.assertEqual(item["address"]["addressLocality"], "渋谷区")
+        self.assertEqual(item["geo"]["latitude"], 35.6794)
+        self.assertEqual(item["description"], "王さまニャー")
+        self.assertEqual(item["image"]["contentUrl"], "https://manholemap.juge.me/get?id=123")
+
+    def test_deduplicates_and_sorts_graph(self):
+        second = {**self.record, "id": "99"}
+        data = build_jsonld(
+            [
+                ("東京都", self.record),
+                ("東京都", second),
+                ("東京都", self.record),
+            ],
+            self.index,
+            "2026-06-14T00:00:00+00:00",
+        )
+        self.assertEqual(data["numberOfItems"], 2)
+        self.assertEqual(
+            [item["identifier"] for item in data["@graph"]],
+            ["123", "99"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/manhole-semantic-editor/README.md
+++ b/tools/manhole-semantic-editor/README.md
@@ -42,6 +42,17 @@ docs/*.ndjson
 | 6 | titleを確認する | `confidence` / `verified_at` を更新 |
 | 7 | Admin: 特定マンホール編集 | ID指定で直接編集 |
 | 8 | Admin: 一括編集 | 条件フィルタで複数件を一括変更（要確認テキスト入力） |
+| 9 | 近くのマンホールを探す | Manhole Map投稿をポケふたからの距離順に閲覧 |
+
+## Manhole Map データ
+
+「近くのマンホールを探す」は、事前に生成した読み取り専用JSON-LDを使います。
+
+```bash
+python3 apps/tools/import_manholemap.py
+```
+
+生成先の `dataset/manholemap.json` と都道府県別キャッシュはgitignore対象です。
 
 ## PR を作成する
 

--- a/tools/manhole-semantic-editor/src/App.tsx
+++ b/tools/manhole-semantic-editor/src/App.tsx
@@ -9,6 +9,7 @@ import { AssignAllTagsTask } from './tasks/assignAllTags/AssignAllTagsTask'
 import { AdminBulkEditTask } from './tasks/adminBulkEdit/AdminBulkEditTask'
 import { TagReverseLookupTask } from './tasks/tagReverseLookup/TagReverseLookupTask'
 import { MichinekiNearbyTask } from './tasks/michinekiNearby/MichinekiNearbyTask'
+import { ManholeMapNearbyTask } from './tasks/manholeMapNearby/ManholeMapNearbyTask'
 
 type ActiveTask = 'home' | TaskType
 
@@ -20,6 +21,7 @@ const TASK_MENU: Array<{ group: string; items: Array<{ id: TaskType; label: stri
       { id: 'assign_all_tags', label: '全タグを付ける', icon: '🏷', desc: '場所・駅・観光 すべてのタグ＋OSM連携・施設名設定' },
       { id: 'tag_reverse_lookup', label: 'タグ別マンホール一覧', icon: '🔍', desc: 'タグごとに設定済みマンホールを逆引き' },
       { id: 'michineki_nearby', label: '道の駅 300m圏内', icon: '🏪', desc: '道の駅と300m以内のポケふたを一覧・紐づけ' },
+      { id: 'manholemap_nearby', label: '近くのマンホールを探す', icon: '🗺', desc: 'Manhole Map投稿を距離・説明から調査' },
     ],
   },
   {
@@ -147,6 +149,8 @@ export default function App() {
         return <TagReverseLookupTask titles={titles} records={records} onNavigateToEdit={handleNavigateToEdit} />
       case 'michineki_nearby':
         return <MichinekiNearbyTask {...commonProps} titles={titles} onSaveMany={handleSavePatches} />
+      case 'manholemap_nearby':
+        return <ManholeMapNearbyTask records={records} />
       default:
         return <Home onSelectTask={navigate} />
     }

--- a/tools/manhole-semantic-editor/src/semantic/semanticPatch.ts
+++ b/tools/manhole-semantic-editor/src/semantic/semanticPatch.ts
@@ -10,6 +10,7 @@ export type TaskType =
   | 'admin_bulk_edit'
   | 'tag_reverse_lookup'
   | 'michineki_nearby'
+  | 'manholemap_nearby'
 
 export type OperationType =
   | 'set_municipality_url'

--- a/tools/manhole-semantic-editor/src/tasks/assignAllTags/AssignAllTagsTask.tsx
+++ b/tools/manhole-semantic-editor/src/tasks/assignAllTags/AssignAllTagsTask.tsx
@@ -66,6 +66,7 @@ export function AssignAllTagsTask({ initialSearch, ...props }: Props) {
       tagGroups={TAG_GROUPS}
       tagLabels={TAG_LABELS}
       osmPoi={OSM_CONFIGS}
+      externalManholeMaps
       initialSearch={initialSearch}
     />
   )

--- a/tools/manhole-semantic-editor/src/tasks/manholeMapNearby/ManholeMapNearbyTask.tsx
+++ b/tools/manhole-semantic-editor/src/tasks/manholeMapNearby/ManholeMapNearbyTask.tsx
@@ -1,0 +1,227 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import L from 'leaflet'
+import 'leaflet/dist/leaflet.css'
+import type { PokefutaRecord } from '../../semantic/semanticPatch'
+
+type ManholeMapRecord = {
+  id: string
+  name: string
+  description: string
+  tag: string
+  address: string
+  prefecture: string
+  municipality: string
+  lat: number
+  lng: number
+  url: string
+  imageUrl: string
+  author: string
+  created: string
+  nice: number
+}
+
+type NearbyPair = {
+  manhole: ManholeMapRecord
+  pokefuta: PokefutaRecord
+  distanceM: number
+}
+
+function haversineM(lat1: number, lng1: number, lat2: number, lng2: number): number {
+  const earthRadiusM = 6_371_000
+  const p1 = (lat1 * Math.PI) / 180
+  const p2 = (lat2 * Math.PI) / 180
+  const dp = ((lat2 - lat1) * Math.PI) / 180
+  const dl = ((lng2 - lng1) * Math.PI) / 180
+  const a = Math.sin(dp / 2) ** 2 + Math.cos(p1) * Math.cos(p2) * Math.sin(dl / 2) ** 2
+  return earthRadiusM * 2 * Math.asin(Math.sqrt(a))
+}
+
+function markerIcon(color: string, square = false) {
+  return L.divIcon({
+    className: '',
+    html: `<div style="width:14px;height:14px;border-radius:${square ? '3px' : '50%'};background:${color};border:2px solid white;box-shadow:0 1px 4px rgba(0,0,0,.5)"></div>`,
+    iconSize: [14, 14],
+    iconAnchor: [7, 7],
+  })
+}
+
+function escapeHtml(value: string) {
+  return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+}
+
+export function ManholeMapNearbyTask({ records }: { records: PokefutaRecord[] }) {
+  const [manholes, setManholes] = useState<ManholeMapRecord[]>([])
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [radiusM, setRadiusM] = useState(300)
+  const [search, setSearch] = useState('')
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const mapDivRef = useRef<HTMLDivElement>(null)
+  const mapRef = useRef<L.Map | null>(null)
+  const layerRef = useRef<L.LayerGroup | null>(null)
+
+  useEffect(() => {
+    fetch('/__editor/data/manholemap')
+      .then(async response => {
+        if (!response.ok) {
+          const body = await response.json().catch(() => ({})) as { error?: string }
+          throw new Error(body.error || `HTTP ${response.status}`)
+        }
+        return response.json() as Promise<ManholeMapRecord[]>
+      })
+      .then(setManholes)
+      .catch(error => setLoadError(String(error)))
+  }, [])
+
+  const pairs = useMemo(() => {
+    const activePokefuta = records.filter(record => record.status === 'active')
+    const result: NearbyPair[] = []
+    for (const manhole of manholes) {
+      let nearest: NearbyPair | null = null
+      for (const pokefuta of activePokefuta) {
+        const distanceM = haversineM(manhole.lat, manhole.lng, pokefuta.lat, pokefuta.lng)
+        if (distanceM <= radiusM && (!nearest || distanceM < nearest.distanceM)) {
+          nearest = { manhole, pokefuta, distanceM }
+        }
+      }
+      if (nearest) result.push(nearest)
+    }
+    return result.sort((a, b) => a.distanceM - b.distanceM)
+  }, [manholes, radiusM, records])
+
+  const filtered = useMemo(() => {
+    const query = search.trim().toLowerCase()
+    if (!query) return pairs
+    return pairs.filter(pair => [
+      pair.manhole.name,
+      pair.manhole.description,
+      pair.manhole.tag,
+      pair.manhole.address,
+      pair.manhole.author,
+      pair.pokefuta.title,
+      pair.pokefuta.pokemons.join(' '),
+    ].some(value => value.toLowerCase().includes(query)))
+  }, [pairs, search])
+
+  useEffect(() => {
+    if (!mapDivRef.current) return
+    const map = L.map(mapDivRef.current).setView([36.5, 136], 5)
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+    }).addTo(map)
+    mapRef.current = map
+    layerRef.current = L.layerGroup().addTo(map)
+    return () => {
+      map.remove()
+      mapRef.current = null
+      layerRef.current = null
+    }
+  }, [])
+
+  useEffect(() => {
+    const map = mapRef.current
+    const layer = layerRef.current
+    if (!map || !layer) return
+    layer.clearLayers()
+
+    const visible = filtered.slice(0, 500)
+    for (const pair of visible) {
+      const selected = pair.manhole.id === selectedId
+      const manholeMarker = L.marker([pair.manhole.lat, pair.manhole.lng], {
+        icon: markerIcon(selected ? '#ef4444' : '#7c3aed', true),
+      }).bindPopup(
+        `<b>${escapeHtml(pair.manhole.name)}</b><br><small>${Math.round(pair.distanceM)}m / ${escapeHtml(pair.manhole.address)}</small>`,
+      ).on('click', () => setSelectedId(pair.manhole.id))
+      const pokefutaMarker = L.marker([pair.pokefuta.lat, pair.pokefuta.lng], {
+        icon: markerIcon('#3b82f6'),
+      }).bindPopup(`<b>${escapeHtml(pair.pokefuta.title)}</b>`)
+      layer.addLayer(L.polyline(
+        [[pair.manhole.lat, pair.manhole.lng], [pair.pokefuta.lat, pair.pokefuta.lng]],
+        { color: selected ? '#ef4444' : '#94a3b8', weight: selected ? 3 : 1, opacity: 0.6, dashArray: '4,4' },
+      ))
+      layer.addLayer(manholeMarker)
+      layer.addLayer(pokefutaMarker)
+    }
+
+    const selected = filtered.find(pair => pair.manhole.id === selectedId)
+    if (selected) map.flyTo([selected.manhole.lat, selected.manhole.lng], 17, { duration: 0.5 })
+  }, [filtered, selectedId])
+
+  if (loadError) {
+    return (
+      <div className="error-banner">
+        Manhole Mapデータ読み込みエラー: {loadError}<br />
+        <code>python3 apps/tools/import_manholemap.py</code> を先に実行してください。
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <h2 style={{ marginBottom: 4 }}>Manhole Map × ポケふた</h2>
+      <p style={{ marginTop: 0, color: '#6b7280', fontSize: 13 }}>
+        Manhole Map全{manholes.length.toLocaleString()}件から、各ポケふたに近い投稿と説明を距離順で確認します。
+      </p>
+
+      <div className="filter-bar" style={{ marginBottom: 12 }}>
+        <select value={radiusM} onChange={event => { setRadiusM(Number(event.target.value)); setSelectedId(null) }}>
+          {[100, 300, 500, 1000, 3000].map(radius => (
+            <option key={radius} value={radius}>{radius.toLocaleString()}m以内</option>
+          ))}
+        </select>
+        <input
+          value={search}
+          onChange={event => { setSearch(event.target.value); setSelectedId(null) }}
+          placeholder="説明・タグ・住所・ポケモン名で検索"
+          style={{ width: 320 }}
+        />
+        <span style={{ color: '#6b7280', fontSize: 13 }}>{filtered.length.toLocaleString()}件</span>
+      </div>
+
+      <div style={{ display: 'flex', gap: 12, marginBottom: 8, color: '#6b7280', fontSize: 12 }}>
+        <span><b style={{ color: '#3b82f6' }}>●</b> ポケふた</span>
+        <span><b style={{ color: '#7c3aed' }}>■</b> Manhole Map投稿</span>
+        <span>地図表示は先頭500件まで</span>
+      </div>
+      <div ref={mapDivRef} style={{ height: 360, border: '1px solid #e5e7eb', borderRadius: 8, marginBottom: 12 }} />
+
+      <table className="table">
+        <thead>
+          <tr>
+            <th style={{ width: 72 }}>距離</th>
+            <th>ポケふた</th>
+            <th>近くのマンホール情報</th>
+            <th style={{ width: 120 }}>投稿</th>
+          </tr>
+        </thead>
+        <tbody>
+          {filtered.slice(0, 1000).map(pair => (
+            <tr
+              key={pair.manhole.id}
+              onClick={() => setSelectedId(pair.manhole.id)}
+              style={{ cursor: 'pointer', background: selectedId === pair.manhole.id ? '#eff6ff' : undefined }}
+            >
+              <td style={{ textAlign: 'right', fontWeight: 600 }}>{Math.round(pair.distanceM)}m</td>
+              <td>
+                <div style={{ fontWeight: 600 }}>{pair.pokefuta.title}</div>
+                <small style={{ color: '#6b7280' }}>{pair.pokefuta.pokemons.join(', ')}</small>
+              </td>
+              <td>
+                <div style={{ fontWeight: 600 }}>{pair.manhole.name}</div>
+                {pair.manhole.description && pair.manhole.description !== pair.manhole.name && (
+                  <div>{pair.manhole.description}</div>
+                )}
+                <small style={{ color: '#6b7280' }}>{pair.manhole.address}</small>
+              </td>
+              <td>
+                <a href={pair.manhole.url} target="_blank" rel="noreferrer" onClick={event => event.stopPropagation()}>
+                  元ページ
+                </a>
+                <div style={{ color: '#6b7280', fontSize: 11 }}>{pair.manhole.author}</div>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/tools/manhole-semantic-editor/src/tasks/shared/MapTagsTask.tsx
+++ b/tools/manhole-semantic-editor/src/tasks/shared/MapTagsTask.tsx
@@ -52,6 +52,27 @@ function makeIcon(color: string) {
   })
 }
 
+function makeMapSourceIcon(label: 'M' | 'G', color: string) {
+  return L.divIcon({
+    className: '',
+    html: `<div style="width:22px;height:22px;border-radius:5px;background:${color};border:2px solid white;box-shadow:0 1px 5px rgba(0,0,0,0.55);color:white;font:bold 12px/18px system-ui;text-align:center">${label}</div>`,
+    iconSize: [22, 22],
+    iconAnchor: [11, 11],
+    popupAnchor: [0, -13],
+  })
+}
+
+type ExternalManholeRecord = {
+  id: string
+  name: string
+  description?: string
+  address: string
+  lat: number
+  lng: number
+  url: string
+  source: 'manholemap' | 'gundam'
+}
+
 export type HintFilter = {
   label: string
   fn: (r: PokefutaRecord, entry: ManholeEntry | undefined) => boolean
@@ -76,6 +97,7 @@ export type MapTagsTaskProps = {
   onSaveMany: (patches: SemanticPatch[]) => Promise<void>
   saving: boolean
   initialSearch?: string
+  externalManholeMaps?: boolean
 }
 
 export function MapTagsTask({
@@ -91,6 +113,7 @@ export function MapTagsTask({
   onSaveMany,
   saving,
   initialSearch = '',
+  externalManholeMaps = false,
 }: MapTagsTaskProps) {
   const [search, setSearch] = useState(initialSearch)
 
@@ -107,6 +130,8 @@ export function MapTagsTask({
   const [nearbyPois, setNearbyPois] = useState<OsmPoi[]>([])
   const [poisLoading, setPoisLoading] = useState(false)
   const [poisError, setPoisError] = useState<string | null>(null)
+  const [externalManholes, setExternalManholes] = useState<ExternalManholeRecord[]>([])
+  const [externalMapsError, setExternalMapsError] = useState<string | null>(null)
 
   const [mapClickPos, setMapClickPos] = useState<{ lat: number; lng: number } | null>(null)
   const [mapClickPois, setMapClickPois] = useState<ClickPoi[] | null>(null)
@@ -117,6 +142,7 @@ export function MapTagsTask({
   const mapRef = useRef<L.Map | null>(null)
   const markersRef = useRef<Map<string, L.Marker>>(new Map())
   const poiMarkersRef = useRef<L.Marker[]>([])
+  const externalMarkersRef = useRef<L.Marker[]>([])
   const clickMarkerRef = useRef<L.Marker | null>(null)
 
   const tags = useMemo(
@@ -170,6 +196,68 @@ export function MapTagsTask({
       mapRef.current = null
     }
   }, [])
+
+  useEffect(() => {
+    if (!externalManholeMaps) return
+    let cancelled = false
+    Promise.all([
+      fetch('/__editor/data/manholemap').then(r => {
+        if (!r.ok) throw new Error(`Manhole Map: HTTP ${r.status}`)
+        return r.json() as Promise<Array<Omit<ExternalManholeRecord, 'source'>>>
+      }),
+      fetch('/__editor/data/gmanhole').then(r => {
+        if (!r.ok) throw new Error(`ガンダムマンホール: HTTP ${r.status}`)
+        return r.json() as Promise<Array<Omit<ExternalManholeRecord, 'source'>>>
+      }),
+    ]).then(([manholeMap, gundam]) => {
+      if (cancelled) return
+      setExternalManholes([
+        ...manholeMap.map(record => ({ ...record, source: 'manholemap' as const })),
+        ...gundam.map(record => ({ ...record, source: 'gundam' as const })),
+      ])
+    }).catch(error => {
+      if (!cancelled) setExternalMapsError(error instanceof Error ? error.message : String(error))
+    })
+    return () => { cancelled = true }
+  }, [externalManholeMaps])
+
+  useEffect(() => {
+    const map = mapRef.current
+    if (!map || !externalManholeMaps || externalManholes.length === 0) return
+
+    const renderVisibleMarkers = () => {
+      externalMarkersRef.current.forEach(marker => marker.remove())
+      externalMarkersRef.current = []
+      const bounds = map.getBounds().pad(0.15)
+      const visible = externalManholes
+        .filter(record => bounds.contains([record.lat, record.lng]))
+        .slice(0, 500)
+
+      for (const record of visible) {
+        const isGundam = record.source === 'gundam'
+        const description = record.description
+          ? `<br><span style="font-size:11px">${esc(record.description)}</span>`
+          : ''
+        const marker = L.marker([record.lat, record.lng], {
+          icon: makeMapSourceIcon(isGundam ? 'G' : 'M', isGundam ? '#dc2626' : '#7c3aed'),
+          zIndexOffset: 300,
+        })
+          .addTo(map)
+          .bindPopup(
+            `<b>${isGundam ? 'ガンダムマンホール' : 'Manhole Map'}</b><br>${esc(record.name)}${description}<br><span style="font-size:11px">${esc(record.address)}</span><br><a href="${esc(record.url)}" target="_blank" rel="noreferrer">元ページ</a>`,
+          )
+        externalMarkersRef.current.push(marker)
+      }
+    }
+
+    renderVisibleMarkers()
+    map.on('moveend', renderVisibleMarkers)
+    return () => {
+      map.off('moveend', renderVisibleMarkers)
+      externalMarkersRef.current.forEach(marker => marker.remove())
+      externalMarkersRef.current = []
+    }
+  }, [externalManholeMaps, externalManholes])
 
   function buildPopupHtml(r: import('../../semantic/semanticPatch').PokefutaRecord, extraHtml = ''): string {
     const badges = (r.titles ?? [])
@@ -476,8 +564,26 @@ export function MapTagsTask({
             {label}
           </span>
         ))}
+        {externalManholeMaps && (
+          <>
+            <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+              <span style={{ width: 16, height: 16, borderRadius: 3, background: '#7c3aed', color: 'white', fontSize: 9, fontWeight: 700, lineHeight: '16px', textAlign: 'center' }}>M</span>
+              Manhole Map
+            </span>
+            <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+              <span style={{ width: 16, height: 16, borderRadius: 3, background: '#dc2626', color: 'white', fontSize: 9, fontWeight: 700, lineHeight: '16px', textAlign: 'center' }}>G</span>
+              ガンダム
+            </span>
+          </>
+        )}
         <span style={{ marginLeft: 'auto' }}>マーカーをクリックで詳細</span>
       </div>
+
+      {externalMapsError && (
+        <div style={{ fontSize: 12, color: '#b45309', marginBottom: 8 }}>
+          外部マンホール地図の読み込みエラー: {externalMapsError}
+        </div>
+      )}
 
       <div ref={mapDivRef} style={{ height: 340, borderRadius: 8, border: '1px solid #e5e7eb', marginBottom: 12, overflow: 'hidden' }} />
 

--- a/tools/manhole-semantic-editor/vite.config.ts
+++ b/tools/manhole-semantic-editor/vite.config.ts
@@ -9,6 +9,8 @@ const REPO_ROOT = path.resolve(__dirname, '../..')
 const NDJSON_PATH = path.join(REPO_ROOT, 'docs/pokefuta.ndjson')
 const TITLES_PATH = path.join(REPO_ROOT, 'dataset/manhole_titles.json')
 const MICHINEKI_PATH = path.join(REPO_ROOT, 'dataset/michineki.json')
+const MANHOLEMAP_PATH = path.join(REPO_ROOT, 'dataset/manholemap.json')
+const GMANHOLE_PATH = path.join(REPO_ROOT, 'docs/gmanhole.ndjson')
 const WORKSPACE_DIR = path.join(__dirname, 'workspace')
 const PATCHES_PATH = path.join(WORKSPACE_DIR, 'changes.ndjson')
 const SCRIPTS_DIR = path.join(__dirname, 'scripts')
@@ -55,6 +57,77 @@ async function handleEditorRequest(
       lng: s.geo.longitude,
     }))
     jsonRes(res, stations)
+    return
+  }
+
+  if (method === 'GET' && subpath === '/data/manholemap') {
+    if (!fs.existsSync(MANHOLEMAP_PATH)) {
+      jsonRes(res, { error: 'dataset/manholemap.json not found' }, 404)
+      return
+    }
+    const raw = fs.readFileSync(MANHOLEMAP_PATH, 'utf-8')
+    const jsonld = JSON.parse(raw) as {
+      '@graph': Array<{
+        identifier: string
+        name?: string
+        description?: string
+        url: string
+        image?: { contentUrl?: string }
+        address?: {
+          streetAddress?: string
+          addressRegion?: string
+          addressLocality?: string
+        }
+        geo?: { latitude?: number; longitude?: number }
+        author?: { name?: string }
+        dateCreated?: string
+        interactionStatistic?: { userInteractionCount?: number }
+        additionalProperty?: Array<{ name?: string; value?: string }>
+      }>
+    }
+    const records = (jsonld['@graph'] ?? [])
+      .filter(item => Number.isFinite(item.geo?.latitude) && Number.isFinite(item.geo?.longitude))
+      .map(item => ({
+        id: item.identifier,
+        name: item.name ?? '',
+        description: item.description ?? '',
+        tag: item.additionalProperty?.find(prop => prop.name === 'tag')?.value ?? '',
+        address: item.address?.streetAddress ?? '',
+        prefecture: item.address?.addressRegion ?? '',
+        municipality: item.address?.addressLocality ?? '',
+        lat: item.geo!.latitude,
+        lng: item.geo!.longitude,
+        url: item.url,
+        imageUrl: item.image?.contentUrl ?? '',
+        author: item.author?.name ?? '',
+        created: item.dateCreated ?? '',
+        nice: item.interactionStatistic?.userInteractionCount ?? 0,
+      }))
+    jsonRes(res, records)
+    return
+  }
+
+  if (method === 'GET' && subpath === '/data/gmanhole') {
+    const raw = fs.readFileSync(GMANHOLE_PATH, 'utf-8')
+    const records = raw.trim().split('\n').filter(Boolean).map(line => JSON.parse(line)) as Array<{
+      id: string
+      title?: string
+      address?: string
+      lat?: number | null
+      lng?: number | null
+      detail_url?: string
+      status?: string
+    }>
+    jsonRes(res, records
+      .filter(record => record.status === 'active' && Number.isFinite(record.lat) && Number.isFinite(record.lng))
+      .map(record => ({
+        id: record.id,
+        name: record.title ?? '',
+        address: record.address ?? '',
+        lat: record.lat,
+        lng: record.lng,
+        url: record.detail_url ?? '',
+      })))
     return
   }
 


### PR DESCRIPTION
## Summary
- add a resumable importer that converts all public Manhole Map records to schema.org JSON-LD
- add a semantic-editor view for finding Manhole Map posts near Pokefuta
- show Manhole Map and Gundam manhole markers in the all-tags map with source links

## Impact
Editors can inspect nearby manhole descriptions and compare Pokefuta with Manhole Map and Gundam locations without leaving the semantic workflow. Generated Manhole Map data remains local and gitignored.

## Validation
- `python3 -m unittest apps/tools/test_import_manholemap.py`
- `npm run build` in `tools/manhole-semantic-editor`
- browser verification of Manhole Map and Gundam marker popups