### PR TITLE
[codex] Add Gundam manhole proximity tags

### DIFF
--- a/apps/scraper/generate_summary_pages.py
+++ b/apps/scraper/generate_summary_pages.py
@@ -141,7 +141,7 @@ SUMMARY_STRINGS: dict[str, dict] = {
             "travel_h2": "旅のテーマから探す", "travel_note": "行き先の雰囲気から、次に会いに行くポケふたを探せます。",
             "rare_h2": "レアなポケふたを探す", "rare_note": "全国でここだけのポケモンや、日本の四端、秘境の一枚を集めました。",
             "details": "このテーマのポケふたを見る", "count": "{count}枚", "unique_count": "{count}種",
-            "travel": {"remote_island": "離島", "roadside": "道の駅", "station_front": "駅前", "world_heritage": "世界遺産"},
+            "travel": {"remote_island": "離島", "roadside": "道の駅", "station_front": "駅前", "world_heritage": "世界遺産", "near_gundam_manhole": "ガンダムマンホールまで約500m以内", "gundam_manhole_city": "ガンダムマンホールのあるまち"},
             "rare": {"unique": "全国1枚しかないポケモン", "extremes": "日本の四端", "lone": "秘境・ぽつんと一枚"},
         },
         "latest_photos": {
@@ -237,7 +237,7 @@ SUMMARY_STRINGS: dict[str, dict] = {
             "travel_h2": "Explore by travel theme", "travel_note": "Choose your next Pokéfuta destination by the kind of journey you want.",
             "rare_h2": "Find rare Pokéfuta", "rare_note": "Discover one-of-a-kind Pokémon, Japan's four extremes, and remote locations.",
             "details": "View Pokéfuta in this theme", "count": "{count} Pokéfuta", "unique_count": "{count} Pokémon",
-            "travel": {"remote_island": "Remote islands", "roadside": "Roadside stations", "station_front": "Train stations", "world_heritage": "World Heritage"},
+            "travel": {"remote_island": "Remote islands", "roadside": "Roadside stations", "station_front": "Train stations", "world_heritage": "World Heritage", "near_gundam_manhole": "Within about 500 m of a Gundam manhole", "gundam_manhole_city": "Municipalities with Gundam manholes"},
             "rare": {"unique": "Pokémon found on only one Pokéfuta", "extremes": "Japan's four extremes", "lone": "Remote and solitary"},
         },
         "pokemon_ranking": {
@@ -324,7 +324,7 @@ SUMMARY_STRINGS: dict[str, dict] = {
             "travel_h2": "按旅行主题探索", "travel_note": "从想去的风景出发，寻找下一个 Pokéfuta。",
             "rare_h2": "寻找稀有 Pokéfuta", "rare_note": "探索全国唯一、日本四端与秘境中的 Pokéfuta。",
             "details": "查看此主题的 Pokéfuta", "count": "{count} 枚", "unique_count": "{count} 种宝可梦",
-            "travel": {"remote_island": "离岛", "roadside": "道之驿", "station_front": "车站前", "world_heritage": "世界遗产"},
+            "travel": {"remote_island": "离岛", "roadside": "道之驿", "station_front": "车站前", "world_heritage": "世界遗产", "near_gundam_manhole": "高达井盖约500米内", "gundam_manhole_city": "设有高达井盖的市町村"},
             "rare": {"unique": "全国仅一枚的宝可梦", "extremes": "日本四端", "lone": "秘境与孤立地点"},
         },
         "pokemon_ranking": {
@@ -411,7 +411,7 @@ SUMMARY_STRINGS: dict[str, dict] = {
             "travel_h2": "依旅行主題探索", "travel_note": "從想去的風景出發，尋找下一個 Pokéfuta。",
             "rare_h2": "尋找稀有 Pokéfuta", "rare_note": "探索全國唯一、日本四端與秘境中的 Pokéfuta。",
             "details": "查看此主題的 Pokéfuta", "count": "{count} 枚", "unique_count": "{count} 種寶可夢",
-            "travel": {"remote_island": "離島", "roadside": "道之驛", "station_front": "車站前", "world_heritage": "世界遺產"},
+            "travel": {"remote_island": "離島", "roadside": "道之驛", "station_front": "車站前", "world_heritage": "世界遺產", "near_gundam_manhole": "鋼彈人孔蓋約500公尺內", "gundam_manhole_city": "設有鋼彈人孔蓋的市町村"},
             "rare": {"unique": "全國僅一枚的寶可夢", "extremes": "日本四端", "lone": "秘境與孤立地點"},
         },
         "pokemon_ranking": {
@@ -498,7 +498,7 @@ SUMMARY_STRINGS: dict[str, dict] = {
             "travel_h2": "여행 테마로 찾기", "travel_note": "가고 싶은 풍경에서 다음 포케후타 여행지를 찾아보세요.",
             "rare_h2": "희귀 포케후타 찾기", "rare_note": "일본 전국 유일, 사방 끝, 비경의 포케후타를 만나보세요.",
             "details": "이 테마의 포케후타 보기", "count": "{count}개", "unique_count": "포켓몬 {count}종",
-            "travel": {"remote_island": "외딴섬", "roadside": "미치노에키", "station_front": "역 앞", "world_heritage": "세계유산"},
+            "travel": {"remote_island": "외딴섬", "roadside": "미치노에키", "station_front": "역 앞", "world_heritage": "세계유산", "near_gundam_manhole": "건담 맨홀 약 500m 이내", "gundam_manhole_city": "건담 맨홀이 있는 지자체"},
             "rare": {"unique": "전국에 하나뿐인 포켓몬", "extremes": "일본 사방 끝", "lone": "비경과 외딴 장소"},
         },
         "pokemon_ranking": {
@@ -3207,7 +3207,14 @@ def _build_discovery_hub_sections(
         )
 
     travel_cards = []
-    for key in ("remote_island", "roadside", "station_front", "world_heritage"):
+    for key in (
+        "remote_island",
+        "roadside",
+        "station_front",
+        "world_heritage",
+        "near_gundam_manhole",
+        "gundam_manhole_city",
+    ):
         candidates = [record for record in records if _has_title(record, key)]
         travel_cards.append(card(
             copy["travel"][key],

--- a/apps/scraper/manhole_titles.py
+++ b/apps/scraper/manhole_titles.py
@@ -285,6 +285,14 @@ def compute_titles(manhole: dict, ctx: dict, *, nc50: int, nc100: int) -> list[d
         if t := _entry("roadside"):
             results.append(t)
 
+    # Gundam manhole crossover tags
+    if "near_gundam_manhole" in tags:
+        if t := _entry("near_gundam_manhole"):
+            results.append(t)
+    if "gundam_manhole_city" in tags:
+        if t := _entry("gundam_manhole_city"):
+            results.append(t)
+
     # world_heritage: 世界遺産タグ
     if "world_heritage" in tags:
         if t := _entry("world_heritage"):

--- a/apps/scraper/test_generate_manhole_pages_gundam_tags.py
+++ b/apps/scraper/test_generate_manhole_pages_gundam_tags.py
@@ -1,0 +1,56 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).with_name("generate_manhole_pages.py")
+SPEC = importlib.util.spec_from_file_location("generate_manhole_pages", MODULE_PATH)
+pages = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(pages)
+
+
+class GundamTagPageTests(unittest.TestCase):
+    def test_gundam_titles_appear_in_badges_and_share_hashtags(self):
+        manhole = {
+            "id": "66",
+            "prefecture": "北海道",
+            "city": "天塩町",
+            "address": "北海道天塩郡天塩町",
+            "lat": 44.88,
+            "lng": 141.74,
+            "pokemons": ["ロコン"],
+            "titles": [
+                {
+                    "key": "near_gundam_manhole",
+                    "emoji": "🤖",
+                    "label": "ガンダムマンホールまで約500m以内",
+                    "hashtag": "#ガンダムマンホール近接",
+                },
+                {
+                    "key": "gundam_manhole_city",
+                    "emoji": "🤖",
+                    "label": "天塩町にはガンダムマンホールもある",
+                    "hashtag": "#ガンダムマンホールのあるまち",
+                },
+            ],
+        }
+
+        html = pages.generate_html(
+            manhole=manhole,
+            photo=None,
+            pokemon_meta={},
+            nearby=[],
+            same_pref=[],
+            pref_total=1,
+            same_pokemon=[],
+            id_to_image_url={},
+        )
+
+        self.assertIn("🤖 ガンダムマンホールまで約500m以内", html)
+        self.assertIn("🤖 天塩町にはガンダムマンホールもある", html)
+        self.assertIn("%23%E3%82%AC%E3%83%B3%E3%83%80%E3%83%A0%E3%83%9E%E3%83%B3%E3%83%9B%E3%83%BC%E3%83%AB%E8%BF%91%E6%8E%A5", html)
+        self.assertIn("%23%E3%82%AC%E3%83%B3%E3%83%80%E3%83%A0%E3%83%9E%E3%83%B3%E3%83%9B%E3%83%BC%E3%83%AB%E3%81%AE%E3%81%82%E3%82%8B%E3%81%BE%E3%81%A1", html)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/scraper/test_generate_summary_pages.py
+++ b/apps/scraper/test_generate_summary_pages.py
@@ -29,16 +29,53 @@ class DiscoveryHubTests(unittest.TestCase):
                 )
                 self.assertIn('id="travel-discovery"', html)
                 self.assertIn('id="rare-discovery"', html)
-                self.assertGreaterEqual(html.count("discovery-hub-card"), 7)
+                self.assertGreaterEqual(html.count("discovery-hub-card"), 9)
                 self.assertIn('data-destination-hub="manhole_detail"', html)
 
     def test_travel_counts_match_title_data(self):
         html = summary._build_discovery_hub_sections(
             summary.SUMMARY_STRINGS["ja"], self.records_by_id, self.metadata
         )
-        for key in ("remote_island", "roadside", "station_front", "world_heritage"):
+        for key in (
+            "remote_island",
+            "roadside",
+            "station_front",
+            "world_heritage",
+            "near_gundam_manhole",
+            "gundam_manhole_city",
+        ):
             count = sum(summary._has_title(record, key) for record in self.records)
             self.assertIn(f">{count}枚</strong>", html)
+
+    def test_gundam_hubs_use_title_data(self):
+        records = {
+            "66": {
+                "id": "66",
+                "prefecture": "北海道",
+                "city": "天塩町",
+                "pokemons": ["ロコン"],
+                "titles": [
+                    {"key": "near_gundam_manhole"},
+                    {"key": "gundam_manhole_city"},
+                ],
+            },
+            "67": {
+                "id": "67",
+                "prefecture": "北海道",
+                "city": "稚内市",
+                "pokemons": ["アローラロコン"],
+                "titles": [{"key": "gundam_manhole_city"}],
+            },
+        }
+        html = summary._build_discovery_hub_sections(
+            summary.SUMMARY_STRINGS["ja"], records, self.metadata
+        )
+        self.assertIn("ガンダムマンホールまで約500m以内", html)
+        self.assertIn("ガンダムマンホールのあるまち", html)
+        self.assertIn('data-content-id="near_gundam_manhole"', html)
+        self.assertIn('data-content-id="gundam_manhole_city"', html)
+        self.assertIn(">1枚</strong>", html)
+        self.assertIn(">2枚</strong>", html)
 
     def test_hero_uses_popup_and_summary_hubs(self):
         source = (summary.ROOT / "apps/web/index.html").read_text(encoding="utf-8")

--- a/apps/scraper/test_manhole_titles_gundam_tags.py
+++ b/apps/scraper/test_manhole_titles_gundam_tags.py
@@ -1,0 +1,54 @@
+import unittest
+
+from apps.scraper.manhole_titles import build_title_context, compute_titles
+
+
+class GundamManholeTitleTest(unittest.TestCase):
+    def test_gundam_tags_become_title_badges(self):
+        manhole = {
+            "id": "66",
+            "status": "active",
+            "prefecture": "北海道",
+            "city": "天塩",
+            "lat": 44.88452,
+            "lng": 141.74797,
+            "pokemons": ["ロコン"],
+            "tags": ["near_gundam_manhole", "gundam_manhole_city"],
+        }
+        master = {
+            "vocabulary": {
+                "near_gundam_manhole": {
+                    "enabled": True,
+                    "emoji": "🤖",
+                    "label": "ガンダムマンホールまで約500m以内",
+                    "hashtag": "#ガンダムマンホール近接",
+                    "priority": 44,
+                },
+                "gundam_manhole_city": {
+                    "enabled": True,
+                    "emoji": "🤖",
+                    "label": "{city}にはガンダムマンホールもある",
+                    "hashtag": "#ガンダムマンホールのあるまち",
+                    "priority": 31,
+                },
+            },
+            "islands": [],
+            "lakes": [],
+        }
+
+        titles = compute_titles(
+            manhole,
+            build_title_context([manhole], master),
+            nc50=0,
+            nc100=0,
+        )
+        by_key = {title["key"]: title for title in titles}
+
+        self.assertEqual(
+            by_key["near_gundam_manhole"]["label"],
+            "ガンダムマンホールまで約500m以内",
+        )
+        self.assertEqual(
+            by_key["gundam_manhole_city"]["label"],
+            "天塩にはガンダムマンホールもある",
+        )

--- a/dataset/manhole_titles.json
+++ b/dataset/manhole_titles.json
@@ -104,6 +104,22 @@
       "id_threshold": 30,
       "note": "int(id) <= id_threshold で判定。公式サイトのID登録順 = 設置時期順の近似"
     },
+    "near_gundam_manhole": {
+      "enabled": true,
+      "emoji": "🤖",
+      "label": "ガンダムマンホールまで約500m以内",
+      "hashtag": "#ガンダムマンホール近接",
+      "priority": 44,
+      "note": "ポケふたとガンダムマンホールの直線距離が約500m以内（目安として500.9mを含む）"
+    },
+    "gundam_manhole_city": {
+      "enabled": true,
+      "emoji": "🤖",
+      "label": "{city}にはガンダムマンホールもある",
+      "hashtag": "#ガンダムマンホールのあるまち",
+      "priority": 31,
+      "note": "同じ自治体内に設置中のガンダムマンホールが1基以上ある"
+    },
     "seaside": {
       "enabled": true,
       "emoji": "🌊",
@@ -769,7 +785,9 @@
       "building": "道の駅 てしお 正面入り口横",
       "verified_at": "2019-11-29",
       "tags": [
-        "roadside"
+        "roadside",
+        "near_gundam_manhole",
+        "gundam_manhole_city"
       ]
     },
     "67": {
@@ -780,14 +798,18 @@
         "roadside",
         "seaside",
         "station_front",
-        "tourism"
+        "tourism",
+        "near_gundam_manhole",
+        "gundam_manhole_city"
       ]
     },
     "68": {
       "building": "定住支援センター「ふらっと★きた」敷地内",
       "verified_at": "2019-12-10",
       "tags": [
-        "far_station"
+        "far_station",
+        "near_gundam_manhole",
+        "gundam_manhole_city"
       ]
     },
     "69": {
@@ -803,7 +825,9 @@
       "building": "道の駅遠軽 森のオホーツク",
       "tags": [
         "roadside",
-        "food"
+        "food",
+        "near_gundam_manhole",
+        "gundam_manhole_city"
       ]
     },
     "71": {
@@ -916,12 +940,15 @@
     "104": {
       "tags": [
         "lakeside",
-        "world_heritage"
+        "world_heritage",
+        "near_gundam_manhole",
+        "gundam_manhole_city"
       ]
     },
     "105": {
       "tags": [
-        "lakeside"
+        "lakeside",
+        "gundam_manhole_city"
       ]
     },
     "107": {
@@ -1342,10 +1369,26 @@
         "tourism"
       ]
     },
+    "222": {
+      "tags": [
+        "gundam_manhole_city"
+      ]
+    },
+    "223": {
+      "tags": [
+        "gundam_manhole_city"
+      ]
+    },
+    "224": {
+      "tags": [
+        "gundam_manhole_city"
+      ]
+    },
     "225": {
       "building": "道の駅水の郷さわら",
       "tags": [
-        "roadside"
+        "roadside",
+        "gundam_manhole_city"
       ]
     },
     "227": {
@@ -1553,7 +1596,9 @@
     },
     "267": {
       "tags": [
-        "world_heritage"
+        "world_heritage",
+        "near_gundam_manhole",
+        "gundam_manhole_city"
       ]
     },
     "269": {
@@ -1928,6 +1973,17 @@
         "station_front"
       ]
     },
+    "325": {
+      "tags": [
+        "near_gundam_manhole",
+        "gundam_manhole_city"
+      ]
+    },
+    "326": {
+      "tags": [
+        "gundam_manhole_city"
+      ]
+    },
     "327": {
       "tags": [
         "seaside"
@@ -2039,6 +2095,11 @@
     "345": {
       "tags": [
         "seaside"
+      ]
+    },
+    "347": {
+      "tags": [
+        "gundam_manhole_city"
       ]
     },
     "349": {
@@ -2368,6 +2429,11 @@
       "building": "道の駅ひたちおおた",
       "tags": [
         "roadside"
+      ]
+    },
+    "413": {
+      "tags": [
+        "gundam_manhole_city"
       ]
     },
     "414": {

--- a/docs/MANHOLE_TITLES.md
+++ b/docs/MANHOLE_TITLES.md
@@ -49,6 +49,8 @@
 | `remote_island` | 🏝 離島のポケふた（{island}） | `#離島ポケふた` + 実行時に `#{island}`（島名）を追加生成 | マスタの `islands` に当該 id / `prefecture+city` が登録 | 95 |
 | `seaside` | 🌊 海が見えるポケふた | `#海沿いポケふた` | `manhole_titles.json` の `manholes."<id>".tags` に `beach` か `seaside` を含む | 40 |
 | `lakeside` | 🏞 湖畔のポケふた（{lake}） | `#湖畔ポケふた` | マスタの `lakes` に当該 id / `prefecture+city` が登録 | 38 |
+| `near_gundam_manhole` | 🤖 ガンダムマンホールまで約500m以内 | `#ガンダムマンホール近接` | ガンダムマンホールとの直線距離が約500m以内と確認した id を手動登録（500.9mを含む） | 44 |
+| `gundam_manhole_city` | 🤖 ○○にはガンダムマンホールもある | `#ガンダムマンホールのあるまち` | ガンダムマンホールがある自治体のポケふた id を手動登録 | 31 |
 
 > `seaside` は地図で目視確認したIDを `manholes."<id>".tags` に手動登録する運用。現在 **116件** 登録済み。海岸線自動判定は将来拡張。
 > `lakeside` は `lakes` ブロックで湖ごとに ids を管理。現在 **4湖7件** 登録済み。`seaside` との重複付与あり（例: 中海は汽水湖のため両タグを持つ）。

--- a/tools/manhole-semantic-editor/src/semantic/validTags.ts
+++ b/tools/manhole-semantic-editor/src/semantic/validTags.ts
@@ -2,6 +2,7 @@ export const VALID_TAGS = [
   'seaside', 'beach', 'lakeside', 'river', 'remote_island', 'roadside',
   'in_station', 'station_front', 'near_station', 'rail_access_good', 'far_station',
   'tourism', 'park', 'museum', 'history', 'food', 'world_heritage',
+  'near_gundam_manhole', 'gundam_manhole_city',
 ] as const
 
 export type ValidTag = (typeof VALID_TAGS)[number]


### PR DESCRIPTION
## Summary
- add `near_gundam_manhole` for seven Pokéfuta within about 500 m of an active Gundam manhole
- add `gundam_manhole_city` for fifteen Pokéfuta in municipalities with active Gundam manholes
- expose both tags in title generation, the semantic editor, multilingual summary cards, detail-page badges, and share hashtags
- document the manual tag criteria and add regression tests

## Rationale
Pokéfuta and Gundam manholes overlap in several destinations, but that relationship was not represented in the dataset or discovery pages. The proximity threshold includes the verified Wakkanai pair at 500.9 m and is presented as approximately 500 m.

## Validation
- `python3 -m unittest apps/scraper/test_manhole_titles_gundam_tags.py apps/scraper/test_generate_summary_pages.py apps/scraper/test_generate_manhole_pages_gundam_tags.py`
- `npm run lint-titles:check`
- `npm run build`
- local preview of `/summary/#travel-discovery` and `/manholes/67/`
