### PR TITLE
[codex] Add Gundam manhole theme filter

### DIFF
--- a/apps/scraper/test_generate_summary_pages.py
+++ b/apps/scraper/test_generate_summary_pages.py
@@ -155,8 +155,11 @@ class DiscoveryHubTests(unittest.TestCase):
                     encoding="utf-8"
                 )
                 self.assertIn(
-                    "near_gundam_manhole: { emoji: '🤖', "
-                    "label: 'ガンダムマンホール' }",
+                    "label: 'ガンダムマンホール',",
+                    source,
+                )
+                self.assertIn(
+                    "description: 'ガンダムマンホールまで約500m以内のポケふた',",
                     source,
                 )
                 self.assertIn(
@@ -167,6 +170,11 @@ class DiscoveryHubTests(unittest.TestCase):
                 self.assertNotIn(
                     "const FEATURED_TAGS = ['roadside', 'remote_island', "
                     "'station_front'",
+                    source,
+                )
+                self.assertIn(
+                    'aria-label="${description} ${count}枚" '
+                    'title="${description}"',
                     source,
                 )
 

--- a/apps/scraper/test_generate_summary_pages.py
+++ b/apps/scraper/test_generate_summary_pages.py
@@ -148,6 +148,28 @@ class DiscoveryHubTests(unittest.TestCase):
         self.assertNotIn("countTemplate.replace('{count}', candidates.length)", source)
         self.assertNotIn("pokemon: reason", source)
 
+    def test_map_theme_directory_features_nearby_gundam_manholes(self):
+        for filename in ("index.html", "index.template.html"):
+            with self.subTest(filename=filename):
+                source = (summary.ROOT / "apps/web" / filename).read_text(
+                    encoding="utf-8"
+                )
+                self.assertIn(
+                    "near_gundam_manhole: { emoji: '🤖', "
+                    "label: 'ガンダムマンホール' }",
+                    source,
+                )
+                self.assertIn(
+                    "const FEATURED_TAGS = ['roadside', 'remote_island', "
+                    "'world_heritage', 'near_gundam_manhole', 'seaside'];",
+                    source,
+                )
+                self.assertNotIn(
+                    "const FEATURED_TAGS = ['roadside', 'remote_island', "
+                    "'station_front'",
+                    source,
+                )
+
     def test_generated_template_keeps_popup_copy_localized(self):
         template = (summary.ROOT / "apps/web/index.template.html").read_text(
             encoding="utf-8"

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -450,7 +450,7 @@
         <div class="section-title-row">
           <h2 id="tag-directory-heading">テーマでポケふた巡り</h2>
         </div>
-        <p class="tag-directory-desc">道の駅・世界遺産・離島・海沿いなど、旅の目的になるポケふたをテーマ別に探せます。</p>
+        <p class="tag-directory-desc">道の駅・世界遺産・離島・ガンダムマンホールなど、旅の目的になるポケふたをテーマ別に探せます。</p>
         <p class="tag-directory-subdesc">タグをタップすると地図上の表示を絞り込みます。もう一度タップで解除。</p>
         <div id="tag-directory-chips" class="tag-directory-chips" aria-label="テーマ別タグ"></div>
         <div id="tag-directory-more" class="tag-directory-chips tag-directory-chips--secondary" aria-label="その他のテーマタグ" hidden></div>
@@ -681,8 +681,8 @@
     var activeTagFilter = null;  // タグフィルタ（null = 全件）
     var showTagDirectory = false;
     const TAG_DIRECTORY_MIN_COUNT = 5;  // この件数未満のタグはチップに表示しない
-    const TAG_PRIORITY = ['roadside', 'world_heritage', 'remote_island', 'seaside', 'tourism', 'station_front', 'food', 'museum', 'history', 'rail_access_good'];
-    const FEATURED_TAGS = ['roadside', 'remote_island', 'station_front', 'world_heritage', 'seaside'];
+    const TAG_PRIORITY = ['roadside', 'world_heritage', 'remote_island', 'near_gundam_manhole', 'seaside', 'tourism', 'station_front', 'food', 'museum', 'history', 'rail_access_good'];
+    const FEATURED_TAGS = ['roadside', 'remote_island', 'world_heritage', 'near_gundam_manhole', 'seaside'];
 
     const TAG_META = {
       seaside:          { emoji: '🌊', label: '海沿い' },
@@ -702,6 +702,7 @@
       history:          { emoji: '⛩', label: '史跡・名所' },
       food:             { emoji: '🍜', label: 'グルメ・食の名所' },
       world_heritage:   { emoji: '🌐', label: '世界遺産' },
+      near_gundam_manhole: { emoji: '🤖', label: 'ガンダムマンホール' },
     };
 
     function getOverallPanelMediaQuery() {

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -702,7 +702,11 @@
       history:          { emoji: '⛩', label: '史跡・名所' },
       food:             { emoji: '🍜', label: 'グルメ・食の名所' },
       world_heritage:   { emoji: '🌐', label: '世界遺産' },
-      near_gundam_manhole: { emoji: '🤖', label: 'ガンダムマンホール' },
+      near_gundam_manhole: {
+        emoji: '🤖',
+        label: 'ガンダムマンホール',
+        description: 'ガンダムマンホールまで約500m以内のポケふた',
+      },
     };
 
     function getOverallPanelMediaQuery() {
@@ -2133,7 +2137,8 @@
       const secondaryTags = sorted.filter(([tag]) => !FEATURED_TAGS.includes(tag));
       function makeChip(tag, count) {
         const meta = TAG_META[tag];
-        return `<button class="tag-chip" data-tag="${tag}" data-count="${count}" aria-pressed="false">${meta.emoji} ${meta.label} <span class="tag-count">${count}枚</span></button>`;
+        const description = meta.description || meta.label;
+        return `<button class="tag-chip" data-tag="${tag}" data-count="${count}" aria-label="${description} ${count}枚" title="${description}" aria-pressed="false">${meta.emoji} ${meta.label} <span class="tag-count">${count}枚</span></button>`;
       }
       container.innerHTML = primaryTags.map(([tag, count]) => makeChip(tag, count)).join('');
       if (moreContainer) {

--- a/apps/web/index.template.html
+++ b/apps/web/index.template.html
@@ -462,7 +462,7 @@
         <div class="section-title-row">
           <h2 id="tag-directory-heading">テーマでポケふた巡り</h2>
         </div>
-        <p class="tag-directory-desc">道の駅・世界遺産・離島・海沿いなど、旅の目的になるポケふたをテーマ別に探せます。</p>
+        <p class="tag-directory-desc">道の駅・世界遺産・離島・ガンダムマンホールなど、旅の目的になるポケふたをテーマ別に探せます。</p>
         <p class="tag-directory-subdesc">タグをタップすると地図上の表示を絞り込みます。もう一度タップで解除。</p>
         <div id="tag-directory-chips" class="tag-directory-chips" aria-label="テーマ別タグ"></div>
         <div id="tag-directory-more" class="tag-directory-chips tag-directory-chips--secondary" aria-label="その他のテーマタグ" hidden></div>
@@ -693,8 +693,8 @@
     var activeTagFilter = null;  // タグフィルタ（null = 全件）
     var showTagDirectory = false;
     const TAG_DIRECTORY_MIN_COUNT = 5;  // この件数未満のタグはチップに表示しない
-    const TAG_PRIORITY = ['roadside', 'world_heritage', 'remote_island', 'seaside', 'tourism', 'station_front', 'food', 'museum', 'history', 'rail_access_good'];
-    const FEATURED_TAGS = ['roadside', 'remote_island', 'station_front', 'world_heritage', 'seaside'];
+    const TAG_PRIORITY = ['roadside', 'world_heritage', 'remote_island', 'near_gundam_manhole', 'seaside', 'tourism', 'station_front', 'food', 'museum', 'history', 'rail_access_good'];
+    const FEATURED_TAGS = ['roadside', 'remote_island', 'world_heritage', 'near_gundam_manhole', 'seaside'];
 
     const TAG_META = {
       seaside:          { emoji: '🌊', label: '海沿い' },
@@ -714,6 +714,7 @@
       history:          { emoji: '⛩', label: '史跡・名所' },
       food:             { emoji: '🍜', label: 'グルメ・食の名所' },
       world_heritage:   { emoji: '🌐', label: '世界遺産' },
+      near_gundam_manhole: { emoji: '🤖', label: 'ガンダムマンホール' },
     };
 
     function getOverallPanelMediaQuery() {

--- a/apps/web/index.template.html
+++ b/apps/web/index.template.html
@@ -714,7 +714,11 @@
       history:          { emoji: '⛩', label: '史跡・名所' },
       food:             { emoji: '🍜', label: 'グルメ・食の名所' },
       world_heritage:   { emoji: '🌐', label: '世界遺産' },
-      near_gundam_manhole: { emoji: '🤖', label: 'ガンダムマンホール' },
+      near_gundam_manhole: {
+        emoji: '🤖',
+        label: 'ガンダムマンホール',
+        description: 'ガンダムマンホールまで約500m以内のポケふた',
+      },
     };
 
     function getOverallPanelMediaQuery() {
@@ -2098,7 +2102,8 @@
       const secondaryTags = sorted.filter(([tag]) => !FEATURED_TAGS.includes(tag));
       function makeChip(tag, count) {
         const meta = TAG_META[tag];
-        return `<button class="tag-chip" data-tag="${tag}" data-count="${count}" aria-pressed="false">${meta.emoji} ${meta.label} <span class="tag-count">${count}枚</span></button>`;
+        const description = meta.description || meta.label;
+        return `<button class="tag-chip" data-tag="${tag}" data-count="${count}" aria-label="${description} ${count}枚" title="${description}" aria-pressed="false">${meta.emoji} ${meta.label} <span class="tag-count">${count}枚</span></button>`;
       }
       container.innerHTML = primaryTags.map(([tag, count]) => makeChip(tag, count)).join('');
       if (moreContainer) {


### PR DESCRIPTION
## Summary

- Add a featured Gundam manhole theme to the map theme directory.
- Keep the filter backed by the existing `near_gundam_manhole` data.
- Move the station-front theme from featured chips to the secondary list.
- Keep `apps/web/index.html` and `index.template.html` synchronized with a regression test.

## Validation

- `python3 -m unittest apps.scraper.test_generate_summary_pages apps.scraper.test_generate_manhole_pages_gundam_tags apps.scraper.test_manhole_titles_gundam_tags`
- `git diff --check`
- Confirmed 7 active `near_gundam_manhole` records and 20 active `station_front` records.
