### PR TITLE
feat: トップページ改善版（画面1）— リスト優先レイアウト + map.html 分離 + 地図ゲートウェイ強化

### DIFF
--- a/apps/web/assets/top-page.css
+++ b/apps/web/assets/top-page.css
@@ -156,6 +156,13 @@ a { color: inherit; text-decoration: none; }
   line-height: 1.35;
 }
 
+.sec-file-label {
+  font-family: 'IBM Plex Mono', 'Courier New', monospace;
+  font-size: 10px;
+  color: var(--top-purple-light);
+  flex-shrink: 0;
+}
+
 /* ── Section 1: Intro ── */
 .top-h1 {
   margin: 7px 0 10px;
@@ -394,7 +401,7 @@ a { color: inherit; text-decoration: none; }
 .map-gateway-card {
   display: block;
   position: relative;
-  height: 236px;
+  height: 380px;
   border-radius: var(--top-radius-card-lg);
   overflow: hidden;
   border: 1px solid #C5D8E1;
@@ -410,6 +417,25 @@ a { color: inherit; text-decoration: none; }
   z-index: 0;
 }
 
+/* top-left live count badge */
+.map-gateway-badge {
+  position: absolute;
+  top: 11px;
+  left: 11px;
+  z-index: 2;
+  pointer-events: none;
+  background: rgba(255,255,255,.92);
+  -webkit-backdrop-filter: blur(2px);
+  backdrop-filter: blur(2px);
+  color: var(--top-purple-dark);
+  font-size: 11px;
+  font-weight: 700;
+  padding: 5px 11px;
+  border-radius: var(--top-radius-pill);
+  box-shadow: 0 1px 4px rgba(0,0,0,.14);
+  white-space: nowrap;
+}
+
 .map-gateway-overlay {
   position: absolute;
   inset: 0;
@@ -417,45 +443,68 @@ a { color: inherit; text-decoration: none; }
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
-  padding: 16px;
-  background: linear-gradient(to top, rgba(0,0,0,.45) 0%, rgba(0,0,0,0) 60%);
+  padding: 26px 13px 13px;
+  background: linear-gradient(to top, rgba(26,38,46,.9) 40%, rgba(26,38,46,0));
 }
 
 .map-gateway-title {
-  font-size: 16px;
-  font-weight: 800;
+  font-size: 14.5px;
+  font-weight: 700;
   color: #fff;
   line-height: 1.3;
+  text-shadow: 0 1px 4px rgba(0,0,0,.35);
 }
 
 .map-gateway-sub {
-  font-size: 11.5px;
-  color: rgba(255,255,255,.85);
-  margin-top: 3px;
+  font-size: 10.5px;
+  color: rgba(255,255,255,.82);
+  margin-top: 2px;
 }
 
 .map-gateway-cta {
-  margin-top: 8px;
-  display: inline-block;
-  background: rgba(255,255,255,.92);
-  color: var(--top-purple-dark);
-  font-size: 12px;
-  font-weight: 700;
-  padding: 5px 12px;
-  border-radius: 999px;
-  align-self: flex-start;
-}
-
-.mini-pin {
+  display: block;
+  margin-top: 11px;
   background: var(--top-purple);
   color: #fff;
+  font-size: 14.5px;
+  font-weight: 700;
+  padding: 13px;
+  border-radius: 12px;
+  text-align: center;
+  box-shadow: 0 5px 14px rgba(108,92,166,.5);
+}
+
+/* design-style circular count pins (non-interactive) */
+.mini-pin {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: var(--top-radius-pill);
+  background: var(--top-purple);
+  color: #fff;
+  border: 2px solid #fff;
+  box-shadow: 0 3px 7px rgba(0,0,0,.3);
+  line-height: 1;
+}
+
+.mini-pin--lg {
+  width: 42px;
+  height: 42px;
+  background: var(--top-purple-dark);
+}
+
+.mini-pin-name {
   font-size: 9px;
   font-weight: 700;
-  border-radius: 4px;
-  padding: 2px 4px;
-  white-space: nowrap;
-  box-shadow: 0 1px 3px rgba(0,0,0,.35);
-  line-height: 1.2;
+}
+
+.mini-pin-count {
+  font-size: 11px;
+  font-weight: 700;
+  font-family: 'IBM Plex Mono', monospace;
 }
 
 /* Prefecture text links */

--- a/apps/web/assets/top-page.css
+++ b/apps/web/assets/top-page.css
@@ -436,6 +436,18 @@ a { color: inherit; text-decoration: none; }
   white-space: nowrap;
 }
 
+/* OSM/CARTO attribution — bottom-right of gateway card */
+.map-gateway-attr {
+  position: absolute;
+  bottom: 4px;
+  right: 6px;
+  z-index: 3;
+  font-size: 9px;
+  color: rgba(255,255,255,.5);
+  pointer-events: none;
+  white-space: nowrap;
+}
+
 .map-gateway-overlay {
   position: absolute;
   inset: 0;

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -195,6 +195,7 @@
       <a class="map-gateway-card" href="map.html" onclick="trackEvent('click_map_gateway')">
         <div id="mini-map" class="map-gateway-minimap" aria-hidden="true"></div>
         <span class="map-gateway-badge">🗺 全国 <b id="map-badge-count">—</b>枚</span>
+        <span class="map-gateway-attr">© OpenStreetMap © CARTO</span>
         <div class="map-gateway-overlay">
           <div class="map-gateway-title">日本地図で近くのポケふたを探す</div>
           <div class="map-gateway-sub">都道府県別の件数ピンから全画面マップへ</div>
@@ -356,6 +357,45 @@
       setText('hero-small-place-' + i, s.place);
     });
 
+    // ── Mini-map pin coords + shared renderer (called from fetch OR map init) ──
+    var PREF_COORDS = {
+      '北海道':[43.2,142.8],'青森県':[40.8,140.7],'岩手県':[39.7,141.2],'宮城県':[38.4,140.8],
+      '秋田県':[39.7,140.1],'山形県':[38.5,140.3],'福島県':[37.4,140.5],'茨城県':[36.3,140.3],
+      '栃木県':[36.5,139.9],'群馬県':[36.4,138.9],'埼玉県':[36.0,139.4],'千葉県':[35.6,140.1],
+      '東京都':[35.7,139.7],'神奈川県':[35.5,139.5],'新潟県':[37.6,139.0],'富山県':[36.7,137.2],
+      '石川県':[36.6,136.6],'福井県':[36.1,136.2],'山梨県':[35.7,138.6],'長野県':[36.2,138.0],
+      '岐阜県':[35.8,137.0],'静岡県':[34.9,138.4],'愛知県':[35.1,137.0],'三重県':[34.7,136.5],
+      '滋賀県':[35.1,136.2],'京都府':[35.2,135.8],'大阪府':[34.7,135.5],'兵庫県':[34.9,135.2],
+      '奈良県':[34.4,135.8],'和歌山県':[33.9,135.2],'鳥取県':[35.5,134.3],'島根県':[35.1,133.1],
+      '岡山県':[34.7,133.9],'広島県':[34.5,132.5],'山口県':[34.2,131.5],'徳島県':[34.0,134.5],
+      '香川県':[34.3,134.0],'愛媛県':[33.9,132.8],'高知県':[33.6,133.5],'福岡県':[33.6,130.4],
+      '佐賀県':[33.3,130.2],'長崎県':[32.8,129.9],'熊本県':[32.8,130.7],'大分県':[33.2,131.6],
+      '宮崎県':[31.9,131.4],'鹿児島県':[31.6,130.6],'沖縄県':[26.2,127.7]
+    };
+
+    window._renderMiniPins = function() {
+      var map = window._miniMap;
+      var counts = window._prefCountMap;
+      if (!map || !counts || window._miniPinsRendered) return;
+      window._miniPinsRendered = true;
+      var prefMax = Math.max.apply(null, Object.keys(counts).map(function(k) { return counts[k]; }));
+      Object.keys(counts).forEach(function(pref) {
+        var c = PREF_COORDS[pref];
+        if (!c) return;
+        var cnt = counts[pref];
+        var big = cnt >= prefMax * 0.7;
+        var sz = big ? 42 : 36;
+        var shortName = pref.replace(/[県都府]$/, '');
+        var icon = L.divIcon({
+          html: '<div class="mini-pin' + (big ? ' mini-pin--lg' : '') + '">'
+            + '<span class="mini-pin-name">' + shortName + '</span>'
+            + '<span class="mini-pin-count">' + cnt + '</span></div>',
+          className: '', iconSize: [sz, sz], iconAnchor: [sz / 2, sz / 2],
+        });
+        L.marker(c, { icon: icon }).addTo(map);
+      });
+    };
+
     // ── Load pokefuta.ndjson → stats + prefecture links ──────────────────────
     var POKEMON_COUNTS = {};
     var prefCountMap = {};
@@ -442,40 +482,9 @@
           });
         }
 
-        // Mini-map prefecture count pins
-        var PREF_COORDS = {
-          '北海道':[43.2,142.8],'青森県':[40.8,140.7],'岩手県':[39.7,141.2],'宮城県':[38.4,140.8],
-          '秋田県':[39.7,140.1],'山形県':[38.5,140.3],'福島県':[37.4,140.5],'茨城県':[36.3,140.3],
-          '栃木県':[36.5,139.9],'群馬県':[36.4,138.9],'埼玉県':[36.0,139.4],'千葉県':[35.6,140.1],
-          '東京都':[35.7,139.7],'神奈川県':[35.5,139.5],'新潟県':[37.6,139.0],'富山県':[36.7,137.2],
-          '石川県':[36.6,136.6],'福井県':[36.1,136.2],'山梨県':[35.7,138.6],'長野県':[36.2,138.0],
-          '岐阜県':[35.8,137.0],'静岡県':[34.9,138.4],'愛知県':[35.1,137.0],'三重県':[34.7,136.5],
-          '滋賀県':[35.1,136.2],'京都府':[35.2,135.8],'大阪府':[34.7,135.5],'兵庫県':[34.9,135.2],
-          '奈良県':[34.4,135.8],'和歌山県':[33.9,135.2],'鳥取県':[35.5,134.3],'島根県':[35.1,133.1],
-          '岡山県':[34.7,133.9],'広島県':[34.5,132.5],'山口県':[34.2,131.5],'徳島県':[34.0,134.5],
-          '香川県':[34.3,134.0],'愛媛県':[33.9,132.8],'高知県':[33.6,133.5],'福岡県':[33.6,130.4],
-          '佐賀県':[33.3,130.2],'長崎県':[32.8,129.9],'熊本県':[32.8,130.7],'大分県':[33.2,131.6],
-          '宮崎県':[31.9,131.4],'鹿児島県':[31.6,130.6],'沖縄県':[26.2,127.7]
-        };
-        var miniMapInst = window._miniMap;
-        if (miniMapInst) {
-          var prefMax = Math.max.apply(null, Object.keys(prefCountMap).map(function(k) { return prefCountMap[k]; }));
-          Object.keys(prefCountMap).forEach(function(pref) {
-            var coords = PREF_COORDS[pref];
-            if (!coords) return;
-            var cnt = prefCountMap[pref];
-            var big = cnt >= prefMax * 0.7;
-            var sz = big ? 42 : 36;
-            var shortName = pref.replace(/[県都府]$/, '');
-            var icon = L.divIcon({
-              html: '<div class="mini-pin' + (big ? ' mini-pin--lg' : '') + '">'
-                + '<span class="mini-pin-name">' + shortName + '</span>'
-                + '<span class="mini-pin-count">' + cnt + '</span></div>',
-              className: '', iconSize: [sz, sz], iconAnchor: [sz / 2, sz / 2],
-            });
-            L.marker(coords, { icon: icon }).addTo(miniMapInst);
-          });
-        }
+        // Mini-map pins — delegate to shared renderer (race-safe)
+        window._prefCountMap = prefCountMap;
+        window._renderMiniPins();
       })
       .catch(function() {
         // Stats remain as defaults if fetch fails
@@ -505,6 +514,7 @@
       subdomains: 'abcd', maxZoom: 19,
     }).addTo(miniMap);
     window._miniMap = miniMap;
+    if (window._renderMiniPins) window._renderMiniPins();
     if (typeof IntersectionObserver !== 'undefined') {
       new IntersectionObserver(function(entries, obs) {
         if (entries[0].isIntersecting) { miniMap.invalidateSize(); obs.disconnect(); }

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -79,7 +79,7 @@
   </script>
   <!-- End GA -->
   <link rel="stylesheet" href="./assets/theme.css" />
-  <link rel="stylesheet" href="./assets/top-page.css?v=20260616c" />
+  <link rel="stylesheet" href="./assets/top-page.css?v=20260617a" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
   <link rel="icon" href="./assets/pokefuta-marker.svg" type="image/svg+xml" />
 </head>
@@ -189,10 +189,12 @@
           <span class="sec-num">3</span>
           <h2 class="sec-title">地図から探す</h2>
         </div>
+        <span class="sec-file-label">/ map.html</span>
       </div>
 
       <a class="map-gateway-card" href="map.html" onclick="trackEvent('click_map_gateway')">
         <div id="mini-map" class="map-gateway-minimap" aria-hidden="true"></div>
+        <span class="map-gateway-badge">🗺 全国 <b id="map-badge-count">—</b>枚</span>
         <div class="map-gateway-overlay">
           <div class="map-gateway-title">日本地図で近くのポケふたを探す</div>
           <div class="map-gateway-sub">都道府県別の件数ピンから全画面マップへ</div>
@@ -388,6 +390,7 @@
         setNum('stat-pref', Object.keys(prefCountMap).length);
         setNum('stat-pokemon', pokemonSet.size);
         setNum('appbar-count', totalCount);
+        setNum('map-badge-count', totalCount);
 
         // Pokemon chip counts
         var chipMap = {
@@ -456,13 +459,19 @@
         };
         var miniMapInst = window._miniMap;
         if (miniMapInst) {
+          var prefMax = Math.max.apply(null, Object.keys(prefCountMap).map(function(k) { return prefCountMap[k]; }));
           Object.keys(prefCountMap).forEach(function(pref) {
             var coords = PREF_COORDS[pref];
             if (!coords) return;
             var cnt = prefCountMap[pref];
+            var big = cnt >= prefMax * 0.7;
+            var sz = big ? 42 : 36;
+            var shortName = pref.replace(/[県都府]$/, '');
             var icon = L.divIcon({
-              html: '<div class="mini-pin">' + cnt + '</div>',
-              className: '', iconSize: [28, 22], iconAnchor: [14, 11],
+              html: '<div class="mini-pin' + (big ? ' mini-pin--lg' : '') + '">'
+                + '<span class="mini-pin-name">' + shortName + '</span>'
+                + '<span class="mini-pin-count">' + cnt + '</span></div>',
+              className: '', iconSize: [sz, sz], iconAnchor: [sz / 2, sz / 2],
             });
             L.marker(coords, { icon: icon }).addTo(miniMapInst);
           });
@@ -491,8 +500,10 @@
       zoomControl: false, scrollWheelZoom: false, dragging: false,
       touchZoom: false, doubleClickZoom: false, boxZoom: false,
       keyboard: false, attributionControl: false,
-    }).setView([36.5, 137.0], 5);
-    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', { maxZoom: 19 }).addTo(miniMap);
+    }).setView([37.6, 137.5], 4);
+    L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
+      subdomains: 'abcd', maxZoom: 19,
+    }).addTo(miniMap);
     window._miniMap = miniMap;
     if (typeof IntersectionObserver !== 'undefined') {
       new IntersectionObserver(function(entries, obs) {

--- a/apps/web/index.template.html
+++ b/apps/web/index.template.html
@@ -192,6 +192,7 @@
       <a class="map-gateway-card" href="%%BASE_PATH%%map.html" onclick="trackEvent('click_map_gateway')">
         <div id="mini-map" class="map-gateway-minimap" aria-hidden="true"></div>
         <span class="map-gateway-badge">🗺 %%APPBAR_PREFIX%%<b id="map-badge-count">—</b>%%APPBAR_SUFFIX%%</span>
+        <span class="map-gateway-attr">© OpenStreetMap © CARTO</span>
         <div class="map-gateway-overlay">
           <div class="map-gateway-title">%%SEC3_MAP_TITLE%%</div>
           <div class="map-gateway-sub">%%SEC3_MAP_SUB%%</div>
@@ -355,6 +356,45 @@
       setText('hero-small-place-' + i, s.place);
     });
 
+    // ── Mini-map pin coords + shared renderer (called from fetch OR map init) ──
+    var PREF_COORDS = {
+      '北海道':[43.2,142.8],'青森県':[40.8,140.7],'岩手県':[39.7,141.2],'宮城県':[38.4,140.8],
+      '秋田県':[39.7,140.1],'山形県':[38.5,140.3],'福島県':[37.4,140.5],'茨城県':[36.3,140.3],
+      '栃木県':[36.5,139.9],'群馬県':[36.4,138.9],'埼玉県':[36.0,139.4],'千葉県':[35.6,140.1],
+      '東京都':[35.7,139.7],'神奈川県':[35.5,139.5],'新潟県':[37.6,139.0],'富山県':[36.7,137.2],
+      '石川県':[36.6,136.6],'福井県':[36.1,136.2],'山梨県':[35.7,138.6],'長野県':[36.2,138.0],
+      '岐阜県':[35.8,137.0],'静岡県':[34.9,138.4],'愛知県':[35.1,137.0],'三重県':[34.7,136.5],
+      '滋賀県':[35.1,136.2],'京都府':[35.2,135.8],'大阪府':[34.7,135.5],'兵庫県':[34.9,135.2],
+      '奈良県':[34.4,135.8],'和歌山県':[33.9,135.2],'鳥取県':[35.5,134.3],'島根県':[35.1,133.1],
+      '岡山県':[34.7,133.9],'広島県':[34.5,132.5],'山口県':[34.2,131.5],'徳島県':[34.0,134.5],
+      '香川県':[34.3,134.0],'愛媛県':[33.9,132.8],'高知県':[33.6,133.5],'福岡県':[33.6,130.4],
+      '佐賀県':[33.3,130.2],'長崎県':[32.8,129.9],'熊本県':[32.8,130.7],'大分県':[33.2,131.6],
+      '宮崎県':[31.9,131.4],'鹿児島県':[31.6,130.6],'沖縄県':[26.2,127.7]
+    };
+
+    window._renderMiniPins = function() {
+      var map = window._miniMap;
+      var counts = window._prefCountMap;
+      if (!map || !counts || window._miniPinsRendered) return;
+      window._miniPinsRendered = true;
+      var prefMax = Math.max.apply(null, Object.keys(counts).map(function(k) { return counts[k]; }));
+      Object.keys(counts).forEach(function(pref) {
+        var c = PREF_COORDS[pref];
+        if (!c) return;
+        var cnt = counts[pref];
+        var big = cnt >= prefMax * 0.7;
+        var sz = big ? 42 : 36;
+        var shortName = pref.replace(/[県都府]$/, '');
+        var icon = L.divIcon({
+          html: '<div class="mini-pin' + (big ? ' mini-pin--lg' : '') + '">'
+            + '<span class="mini-pin-name">' + shortName + '</span>'
+            + '<span class="mini-pin-count">' + cnt + '</span></div>',
+          className: '', iconSize: [sz, sz], iconAnchor: [sz / 2, sz / 2],
+        });
+        L.marker(c, { icon: icon }).addTo(map);
+      });
+    };
+
     // ── Load pokefuta.ndjson → stats + prefecture links ──────────────────────
     var POKEMON_COUNTS = {};
     var prefCountMap = {};
@@ -443,40 +483,9 @@
           });
         }
 
-        // Mini-map prefecture count pins
-        var PREF_COORDS = {
-          '北海道':[43.2,142.8],'青森県':[40.8,140.7],'岩手県':[39.7,141.2],'宮城県':[38.4,140.8],
-          '秋田県':[39.7,140.1],'山形県':[38.5,140.3],'福島県':[37.4,140.5],'茨城県':[36.3,140.3],
-          '栃木県':[36.5,139.9],'群馬県':[36.4,138.9],'埼玉県':[36.0,139.4],'千葉県':[35.6,140.1],
-          '東京都':[35.7,139.7],'神奈川県':[35.5,139.5],'新潟県':[37.6,139.0],'富山県':[36.7,137.2],
-          '石川県':[36.6,136.6],'福井県':[36.1,136.2],'山梨県':[35.7,138.6],'長野県':[36.2,138.0],
-          '岐阜県':[35.8,137.0],'静岡県':[34.9,138.4],'愛知県':[35.1,137.0],'三重県':[34.7,136.5],
-          '滋賀県':[35.1,136.2],'京都府':[35.2,135.8],'大阪府':[34.7,135.5],'兵庫県':[34.9,135.2],
-          '奈良県':[34.4,135.8],'和歌山県':[33.9,135.2],'鳥取県':[35.5,134.3],'島根県':[35.1,133.1],
-          '岡山県':[34.7,133.9],'広島県':[34.5,132.5],'山口県':[34.2,131.5],'徳島県':[34.0,134.5],
-          '香川県':[34.3,134.0],'愛媛県':[33.9,132.8],'高知県':[33.6,133.5],'福岡県':[33.6,130.4],
-          '佐賀県':[33.3,130.2],'長崎県':[32.8,129.9],'熊本県':[32.8,130.7],'大分県':[33.2,131.6],
-          '宮崎県':[31.9,131.4],'鹿児島県':[31.6,130.6],'沖縄県':[26.2,127.7]
-        };
-        var miniMapInst = window._miniMap;
-        if (miniMapInst) {
-          var prefMax = Math.max.apply(null, Object.keys(prefCountMap).map(function(k) { return prefCountMap[k]; }));
-          Object.keys(prefCountMap).forEach(function(pref) {
-            var coords = PREF_COORDS[pref];
-            if (!coords) return;
-            var cnt = prefCountMap[pref];
-            var big = cnt >= prefMax * 0.7;
-            var sz = big ? 42 : 36;
-            var shortName = pref.replace(/[県都府]$/, '');
-            var icon = L.divIcon({
-              html: '<div class="mini-pin' + (big ? ' mini-pin--lg' : '') + '">'
-                + '<span class="mini-pin-name">' + shortName + '</span>'
-                + '<span class="mini-pin-count">' + cnt + '</span></div>',
-              className: '', iconSize: [sz, sz], iconAnchor: [sz / 2, sz / 2],
-            });
-            L.marker(coords, { icon: icon }).addTo(miniMapInst);
-          });
-        }
+        // Mini-map pins — delegate to shared renderer (race-safe)
+        window._prefCountMap = prefCountMap;
+        window._renderMiniPins();
       })
       .catch(function() {});
 
@@ -504,6 +513,7 @@
       subdomains: 'abcd', maxZoom: 19,
     }).addTo(miniMap);
     window._miniMap = miniMap;
+    if (window._renderMiniPins) window._renderMiniPins();
     if (typeof IntersectionObserver !== 'undefined') {
       new IntersectionObserver(function(entries, obs) {
         if (entries[0].isIntersecting) { miniMap.invalidateSize(); obs.disconnect(); }

--- a/apps/web/index.template.html
+++ b/apps/web/index.template.html
@@ -82,7 +82,7 @@
   </script>
   <!-- End GA -->
   <link rel="stylesheet" href="%%BASE_PATH%%assets/theme.css" />
-  <link rel="stylesheet" href="%%BASE_PATH%%assets/top-page.css?v=20260616c" />
+  <link rel="stylesheet" href="%%BASE_PATH%%assets/top-page.css?v=20260617a" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
   <link rel="icon" href="%%BASE_PATH%%assets/pokefuta-marker.svg" type="image/svg+xml" />
 </head>
@@ -186,10 +186,12 @@
           <span class="sec-num">3</span>
           <h2 class="sec-title">%%SEC3_TITLE%%</h2>
         </div>
+        <span class="sec-file-label">/ map.html</span>
       </div>
 
       <a class="map-gateway-card" href="%%BASE_PATH%%map.html" onclick="trackEvent('click_map_gateway')">
         <div id="mini-map" class="map-gateway-minimap" aria-hidden="true"></div>
+        <span class="map-gateway-badge">🗺 %%APPBAR_PREFIX%%<b id="map-badge-count">—</b>%%APPBAR_SUFFIX%%</span>
         <div class="map-gateway-overlay">
           <div class="map-gateway-title">%%SEC3_MAP_TITLE%%</div>
           <div class="map-gateway-sub">%%SEC3_MAP_SUB%%</div>
@@ -386,6 +388,7 @@
         setNum('stat-pref', Object.keys(prefCountMap).length);
         setNum('stat-pokemon', pokemonSet.size);
         setNum('appbar-count', totalCount);
+        setNum('map-badge-count', totalCount);
 
         var chipMap = {
           'ピカチュウ': 'chip-pikachu',
@@ -457,13 +460,19 @@
         };
         var miniMapInst = window._miniMap;
         if (miniMapInst) {
+          var prefMax = Math.max.apply(null, Object.keys(prefCountMap).map(function(k) { return prefCountMap[k]; }));
           Object.keys(prefCountMap).forEach(function(pref) {
             var coords = PREF_COORDS[pref];
             if (!coords) return;
             var cnt = prefCountMap[pref];
+            var big = cnt >= prefMax * 0.7;
+            var sz = big ? 42 : 36;
+            var shortName = pref.replace(/[県都府]$/, '');
             var icon = L.divIcon({
-              html: '<div class="mini-pin">' + cnt + '</div>',
-              className: '', iconSize: [28, 22], iconAnchor: [14, 11],
+              html: '<div class="mini-pin' + (big ? ' mini-pin--lg' : '') + '">'
+                + '<span class="mini-pin-name">' + shortName + '</span>'
+                + '<span class="mini-pin-count">' + cnt + '</span></div>',
+              className: '', iconSize: [sz, sz], iconAnchor: [sz / 2, sz / 2],
             });
             L.marker(coords, { icon: icon }).addTo(miniMapInst);
           });
@@ -490,8 +499,10 @@
       zoomControl: false, scrollWheelZoom: false, dragging: false,
       touchZoom: false, doubleClickZoom: false, boxZoom: false,
       keyboard: false, attributionControl: false,
-    }).setView([36.5, 137.0], 5);
-    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', { maxZoom: 19 }).addTo(miniMap);
+    }).setView([37.6, 137.5], 4);
+    L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
+      subdomains: 'abcd', maxZoom: 19,
+    }).addTo(miniMap);
     window._miniMap = miniMap;
     if (typeof IntersectionObserver !== 'undefined') {
       new IntersectionObserver(function(entries, obs) {


### PR DESCRIPTION
## Summary

- **IA 方針転換**: 地図ファースト → テキスト/リスト優先。トップ（`index.html`）は SEO の土台、地図は独立ページ（`map.html`）へ分離
- **Section 1**: H1 + 導入文 + 件数スタッツで検索着地を強化
- **Section 2**: "今日行く動機" ヒーローを H1 直下に常設（毎日更新、MAU 向け）
- **Section 3**: 地図ゲートウェイを Claude Design「画面1 改善版」仕様にビジュアル強化（236px → 380px、左上 live 件数バッジ、全幅パープル CTA、CARTO Light タイル、円形件数ピン）
- **Section 4**: 全 47 都道府県テキストリンクをクロール性確保のうえ配置
- **Section 5**: ポケモン別・テーマ別ハブ（目的から探す）
- **多言語対応**: `build_i18n.py` で en / zh-TW / zh-CN / ko を自動生成
- 検索バーを廃止（トップはコンテンツ導線に集中）

## Test plan

- [ ] `python3 tools/build_i18n.py` → 4 言語すべて `[OK]`、unreplaced marker なし
- [ ] `http://localhost:8000/` — Section 3 地図が 380px で表示、左上バッジに件数が入る、円形ピンが都道府県に配置される、カード全体タップで map.html へ遷移
- [ ] `http://localhost:8000/en/` — 英語バッジ・CTA が表示される
- [ ] ページスクロールが地図カードで止まらない（静的ゲートウェイ確認）
- [ ] `http://localhost:8000/map.html` — 全画面地図が正常動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)