### PR TITLE
fix: map-back-to-top を展開時非表示・折りたたみ時スタイル付きに修正（iOS実機バグ対応）

### DIFF
--- a/apps/web/assets/pokefuta-map.css
+++ b/apps/web/assets/pokefuta-map.css
@@ -121,6 +121,23 @@ body.pokefuta-map-page {
   display: none;
 }
 
+/* 展開時はnav-gridにトップリンクがあるので非表示。折りたたみ時のみ表示 */
+.pokefuta-map-page .map-hero-card:not(.is-collapsed) .map-back-to-top {
+  display: none;
+}
+
+.pokefuta-map-page .map-back-to-top {
+  display: block;
+  margin-top: 4px;
+  padding: 4px 2px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: #4a3728;
+  text-decoration: none;
+  opacity: 0.75;
+  white-space: nowrap;
+}
+
 .pokefuta-map-page .map-hero-card.is-collapsed .hero-card-toggle {
   position: relative;
   top: auto;


### PR DESCRIPTION
## Summary

- `.map-back-to-top` リンクに CSS が一切定義されていなかった（`display: inline` のデフォルト動作のまま）
- iOS Safari 実機（iPhone 16 Plus）で「← トップに戻る」が意図しない位置に表示される問題があった
- 展開状態では `.map-hero-nav-grid` に「🏠 トップ」が既にあるため `display: none` で非表示
- 折りたたみ状態（`.is-collapsed`）では `display: block` + 小文字スタイルでトグルボタン直下に正しく表示

## Test plan

- [ ] map.html を iPhone Safari 実機で開く → 「← トップに戻る」が展開状態で表示されないことを確認
- [ ] ヒーローカードを折りたたむ → トグルボタンの下に「← トップに戻る」が表示されることを確認
- [ ] DevTools iPhone シミュレータでも同様の挙動を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)