### PR TITLE
fix: /dev スキルに apps/web/ → dist/ 自動同期を追加

### DIFF
--- a/.claude/commands/dev.md
+++ b/.claude/commands/dev.md
@@ -5,14 +5,22 @@ Start the local dev server on port 8000, killing any existing process on that po
 _pid=$(lsof -ti:8000 2>/dev/null)
 [ -n "$_pid" ] && kill "$_pid" && echo "[dev] stopped previous server on :8000" || true
 
-ROOT="$(git rev-parse --show-toplevel)"
+ROOT="$(git rev-parse --show-toplevel)" || { echo "[dev] ERROR: not in a git repo"; exit 1; }
 
-# Sync apps/web/ → dist/ (map page + assets only; dist/index.html is the text-first page, not overwritten)
-cp "$ROOT/apps/web/index.html" "$ROOT/dist/map.html" 2>/dev/null && echo "[dev] synced map.html"
-cp -r "$ROOT/apps/web/assets/"* "$ROOT/dist/assets/" 2>/dev/null && echo "[dev] synced assets/"
+# Sync apps/web/ → dist/ (dist/index.html is the text-first page, not overwritten)
+cp "$ROOT/apps/web/index.html"       "$ROOT/dist/map.html"          && echo "[dev] synced map.html"          || echo "[dev] WARN: map.html sync failed"
+cp "$ROOT/apps/web/nearby_manholes.html" "$ROOT/dist/nearby.html"   && echo "[dev] synced nearby.html"       || echo "[dev] WARN: nearby.html sync failed"
+cp "$ROOT/apps/web/gmanhole_map.html" "$ROOT/dist/gmanhole_map.html" && echo "[dev] synced gmanhole_map.html" || echo "[dev] WARN: gmanhole_map.html sync failed"
+cp "$ROOT/apps/web/sitemap.xml"      "$ROOT/dist/sitemap.xml"        && echo "[dev] synced sitemap.xml"       || echo "[dev] WARN: sitemap.xml sync failed"
+[ -d "$ROOT/apps/web/assets" ] && cp -r "$ROOT/apps/web/assets/." "$ROOT/dist/assets/" && echo "[dev] synced assets/" || echo "[dev] WARN: assets/ sync failed"
 
 # Serve dist/ on port 8000
 python3 -m http.server 8000 --directory "$ROOT/dist" &
+_server_pid=$!
 sleep 0.5
-echo "[dev] http://localhost:8000"
+if kill -0 "$_server_pid" 2>/dev/null; then
+  echo "[dev] http://localhost:8000"
+else
+  echo "[dev] ERROR: server failed to start (is dist/ built?)"
+fi
 ```

--- a/.claude/commands/dev.md
+++ b/.claude/commands/dev.md
@@ -5,9 +5,14 @@ Start the local dev server on port 8000, killing any existing process on that po
 _pid=$(lsof -ti:8000 2>/dev/null)
 [ -n "$_pid" ] && kill "$_pid" && echo "[dev] stopped previous server on :8000" || true
 
+ROOT="$(git rev-parse --show-toplevel)"
+
+# Sync apps/web/ → dist/ (map page + assets only; dist/index.html is the text-first page, not overwritten)
+cp "$ROOT/apps/web/index.html" "$ROOT/dist/map.html" 2>/dev/null && echo "[dev] synced map.html"
+cp -r "$ROOT/apps/web/assets/"* "$ROOT/dist/assets/" 2>/dev/null && echo "[dev] synced assets/"
+
 # Serve dist/ on port 8000
-cd "$(git rev-parse --show-toplevel)"
-python3 -m http.server 8000 --directory dist &
+python3 -m http.server 8000 --directory "$ROOT/dist" &
 sleep 0.5
 echo "[dev] http://localhost:8000"
 ```

--- a/apps/web/assets/pokefuta-map.css
+++ b/apps/web/assets/pokefuta-map.css
@@ -121,6 +121,23 @@ body.pokefuta-map-page {
   display: none;
 }
 
+/* 展開時はnav-gridにトップリンクがあるので非表示。折りたたみ時のみ表示 */
+.pokefuta-map-page .map-hero-card:not(.is-collapsed) .map-back-to-top {
+  display: none;
+}
+
+.pokefuta-map-page .map-back-to-top {
+  display: block;
+  margin-top: 4px;
+  padding: 4px 2px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: #4a3728;
+  text-decoration: none;
+  opacity: 0.75;
+  white-space: nowrap;
+}
+
 .pokefuta-map-page .map-hero-card.is-collapsed .hero-card-toggle {
   position: relative;
   top: auto;


### PR DESCRIPTION
## Summary

- `/dev` 起動時に `apps/web/index.html → dist/map.html` を自動コピー
- `/dev` 起動時に `apps/web/assets/* → dist/assets/` を自動コピー
- `dist/index.html`（テキスト優先ページ）は上書きしない

## 背景

`/dev` スキルが `dist/` をそのまま配信するだけで、`apps/web/` の変更が反映されなかった。特に `apps/web/index.html`（地図ページ）の修正が `dist/map.html` に同期されず、古いバージョンが表示される問題があった。

## Test plan

- [ ] `/dev` 実行後に `http://localhost:8000/map.html` が最新の地図ページを表示する
- [ ] `http://localhost:8000/` がテキスト優先ページを表示する（map.html に置き換わらない）
- [ ] CSS/JS の変更が `dist/assets/` に反映される

🤖 Generated with [Claude Code](https://claude.com/claude-code)