### PR TITLE
feat: トップページ地図をOSM＋都道府県件数ピンに刷新＋テーマ導線整理

### DIFF
--- a/apps/web/assets/top-page.css
+++ b/apps/web/assets/top-page.css
@@ -152,6 +152,11 @@ a { color: inherit; text-decoration: none; }
 
 .sec-num::before { content: counter(top-sec); }
 
+/* セクション番号バッジ（①〜⑤・ヘッダーの①）は意味がないため全て非表示。
+   ブレークポイントごとに display を切り替える既存ルールを確実に上書きする。 */
+.sec-num,
+.nav-num { display: none !important; }
+
 .sec-eyebrow-text {
   font-family: 'IBM Plex Mono', 'Courier New', monospace;
   font-size: 10px;
@@ -511,36 +516,38 @@ a { color: inherit; text-decoration: none; }
   box-shadow: 0 5px 14px rgba(108,92,166,.5);
 }
 
-/* design-style circular count pins (non-interactive) */
-.mini-pin {
-  display: flex;
+/* Per-prefecture count pins — map.html の .prefecture-overview-marker をベースに、
+   都道府県名と件数を明確に2行で表示（円を少し大きめに）。 */
+.prefecture-overview-marker {
+  /* leaflet.css が top-page.css より後に読まれるため display を !important で確実に上書き */
+  display: flex !important;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  width: 36px;
-  height: 36px;
-  border-radius: var(--top-radius-pill);
-  background: var(--top-purple);
+  width: 46px !important;
+  height: 46px !important;
+  margin: -23px 0 0 -23px !important;
+  border: 2px solid rgba(255, 255, 255, .94);
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 30%, #9374c8, #624095 76%);
   color: #fff;
-  border: 2px solid #fff;
-  box-shadow: 0 3px 7px rgba(0,0,0,.3);
+  box-shadow: 0 4px 12px rgba(67, 38, 111, .32);
+  white-space: nowrap;
+}
+
+.prefecture-overview-name {
+  display: block;
+  font-size: 8px;
+  font-weight: 700;
   line-height: 1;
 }
 
-.mini-pin--lg {
-  width: 42px;
-  height: 42px;
-  background: var(--top-purple-dark);
-}
-
-.mini-pin-name {
-  font-size: 9px;
-  font-weight: 700;
-}
-
-.mini-pin-count {
-  font-size: 11px;
-  font-weight: 700;
+.prefecture-overview-count {
+  display: block;
+  margin-top: 3px;
+  font-size: 13px;
+  font-weight: 800;
+  line-height: 1;
   font-family: 'IBM Plex Mono', monospace;
 }
 
@@ -763,9 +770,10 @@ a { color: inherit; text-decoration: none; }
   .top-nav-link--active { font-weight: 700; color: var(--top-purple-dark); }
 
   /* Single full-width column. Intro + map share one "maphero" band so the map
-     renders edge-to-edge with the H1 panel overlaid on its left. DOM order
-     (intro → hero → map → pref → hub) is preserved; the panel paints above the
-     map via z-index, not reordering. */
+     renders edge-to-edge with the H1 panel overlaid on its left. DOM order is
+     (intro → map → hero → pref → hub) — intro leads so the H1 + stats sit on top
+     on mobile, with the map directly below; on desktop grid-template-areas +
+     z-index pin the layout regardless of order (intro panel paints above the map). */
   .top-main {
     display: grid;
     grid-template-columns: minmax(0, 1fr);

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -56,7 +56,7 @@
     // Redirect legacy ?pref= / ?manhole= deep-links to map.html
     (function() {
       var p = new URLSearchParams(location.search);
-      if (p.has('pref') || p.has('manhole')) {
+      if (p.has('pref') || p.has('manhole') || p.has('tag') || p.has('view')) {
         location.replace('map.html' + location.search);
       }
     })();
@@ -79,7 +79,7 @@
   </script>
   <!-- End GA -->
   <link rel="stylesheet" href="./assets/theme.css" />
-  <link rel="stylesheet" href="./assets/top-page.css?v=20260621a" />
+  <link rel="stylesheet" href="./assets/top-page.css?v=20260623d" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
   <link rel="icon" href="./assets/pokefuta-marker.svg" type="image/svg+xml" />
 </head>
@@ -140,6 +140,28 @@
       </div>
     </section>
 
+    <!-- ===== MAP GATEWAY (under intro on mobile; full-bleed hero on desktop) ===== -->
+    <section class="top-section" id="sec-map">
+      <div class="sec-header">
+        <div class="sec-eyebrow">
+          <span class="sec-num"></span>
+          <h2 class="sec-title">地図から探す</h2>
+        </div>
+        <span class="sec-file-label">/ map.html</span>
+      </div>
+
+      <a class="map-gateway-card" href="map.html" onclick="trackEvent('click_map_gateway')">
+        <div id="mini-map" class="map-gateway-minimap" aria-hidden="true"></div>
+        <span class="map-gateway-badge">🗺 全国 <b id="map-badge-count">—</b>枚</span>
+        <span class="map-gateway-attr">© OpenStreetMap contributors</span>
+        <div class="map-gateway-overlay">
+          <div class="map-gateway-title">日本地図で近くのポケふたを探す</div>
+          <div class="map-gateway-sub">都道府県別の件数ピンから全画面マップへ</div>
+          <div class="map-gateway-cta">🗺 地図を全画面で開く</div>
+        </div>
+      </a>
+    </section>
+
     <!-- ===== 2. TODAY'S HERO ===== -->
     <section class="top-section" id="sec-hero">
       <div class="sec-header">
@@ -192,28 +214,6 @@
       </div>
     </section>
 
-    <!-- ===== 3. MAP GATEWAY ===== -->
-    <section class="top-section" id="sec-map">
-      <div class="sec-header">
-        <div class="sec-eyebrow">
-          <span class="sec-num"></span>
-          <h2 class="sec-title">地図から探す</h2>
-        </div>
-        <span class="sec-file-label">/ map.html</span>
-      </div>
-
-      <a class="map-gateway-card" href="map.html" onclick="trackEvent('click_map_gateway')">
-        <div id="mini-map" class="map-gateway-minimap" aria-hidden="true"></div>
-        <span class="map-gateway-badge">🗺 全国 <b id="map-badge-count">—</b>枚</span>
-        <span class="map-gateway-attr">© OpenStreetMap © CARTO</span>
-        <div class="map-gateway-overlay">
-          <div class="map-gateway-title">日本地図で近くのポケふたを探す</div>
-          <div class="map-gateway-sub">都道府県別の件数ピンから全画面マップへ</div>
-          <div class="map-gateway-cta">🗺 地図を全画面で開く</div>
-        </div>
-      </a>
-    </section>
-
     <!-- ===== 4. PREFECTURE LIST ===== -->
     <section class="top-section" id="sec-pref">
       <div class="sec-eyebrow">
@@ -241,7 +241,7 @@
       <div class="hub-card">
         <div class="hub-card-header">
           <span>テーマから探す</span>
-          <a class="hub-card-more" href="map.html" onclick="trackEvent('click_hub_tag_all')">地図で探す →</a>
+          <a class="hub-card-more" href="map.html?view=theme" onclick="trackEvent('click_hub_tag_all')">地図で探す →</a>
         </div>
         <div class="hub-chips">
           <a class="hub-chip" href="map.html?tag=roadside" onclick="trackEvent('click_hub_tag',{tag:'roadside'})">🛤 道の駅</a>
@@ -388,19 +388,16 @@
       var counts = window._prefCountMap;
       if (!map || !counts || window._miniPinsRendered) return;
       window._miniPinsRendered = true;
-      var prefMax = Math.max.apply(null, Object.keys(counts).map(function(k) { return counts[k]; }));
       Object.keys(counts).forEach(function(pref) {
         var c = PREF_COORDS[pref];
         if (!c) return;
         var cnt = counts[pref];
-        var big = cnt >= prefMax * 0.7;
-        var sz = big ? 42 : 36;
-        var shortName = pref.replace(/[県都府]$/, '');
+        var shortName = pref === '北海道' ? pref : pref.replace(/[都府県]$/, '');
+        // map.html の都道府県オーバービューマーカーと同じデザイン
         var icon = L.divIcon({
-          html: '<div class="mini-pin' + (big ? ' mini-pin--lg' : '') + '">'
-            + '<span class="mini-pin-name">' + shortName + '</span>'
-            + '<span class="mini-pin-count">' + cnt + '</span></div>',
-          className: '', iconSize: [sz, sz], iconAnchor: [sz / 2, sz / 2],
+          html: '<span class="prefecture-overview-name">' + shortName + '</span>'
+            + '<span class="prefecture-overview-count">' + cnt + '</span>',
+          className: 'prefecture-overview-marker', iconSize: null,
         });
         L.marker(c, { icon: icon }).addTo(map);
       });
@@ -531,13 +528,15 @@
   (function() {
     var miniMapEl = document.getElementById('mini-map');
     if (!miniMapEl || typeof L === 'undefined') return;
+    // SP（スマホ）は2段階ズームイン（7）、デスクトップは全国が収まる5
+    var _miniZoom = window.matchMedia('(min-width: 960px)').matches ? 5 : 7;
     var miniMap = L.map('mini-map', {
       zoomControl: false, scrollWheelZoom: false, dragging: false,
       touchZoom: false, doubleClickZoom: false, boxZoom: false,
       keyboard: false, attributionControl: false,
-    }).setView([37.6, 137.5], 4);
-    L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
-      subdomains: 'abcd', maxZoom: 19,
+    }).setView([37.6, 137.5], _miniZoom);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      maxZoom: 19,
     }).addTo(miniMap);
     window._miniMap = miniMap;
     if (window._renderMiniPins) window._renderMiniPins();

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -53,7 +53,7 @@
     });
     window.SITE_BASE_URL = 'https://data.pokefuta.com/';
 
-    // Redirect legacy ?pref= / ?manhole= deep-links to map.html
+    // Redirect deep-links (?pref= / ?manhole= / ?tag= / ?view=) to map.html
     (function() {
       var p = new URLSearchParams(location.search);
       if (p.has('pref') || p.has('manhole') || p.has('tag') || p.has('view')) {

--- a/apps/web/index.template.html
+++ b/apps/web/index.template.html
@@ -56,7 +56,7 @@
     });
     window.SITE_BASE_URL = 'https://data.pokefuta.com/';
 
-    // Redirect legacy ?pref= / ?manhole= deep-links to map.html
+    // Redirect deep-links (?pref= / ?manhole= / ?tag= / ?view=) to map.html
     (function() {
       var p = new URLSearchParams(location.search);
       if (p.has('pref') || p.has('manhole') || p.has('tag') || p.has('view')) {

--- a/apps/web/index.template.html
+++ b/apps/web/index.template.html
@@ -59,7 +59,7 @@
     // Redirect legacy ?pref= / ?manhole= deep-links to map.html
     (function() {
       var p = new URLSearchParams(location.search);
-      if (p.has('pref') || p.has('manhole')) {
+      if (p.has('pref') || p.has('manhole') || p.has('tag') || p.has('view')) {
         location.replace('%%BASE_PATH%%map.html' + location.search);
       }
     })();
@@ -82,7 +82,7 @@
   </script>
   <!-- End GA -->
   <link rel="stylesheet" href="%%BASE_PATH%%assets/theme.css" />
-  <link rel="stylesheet" href="%%BASE_PATH%%assets/top-page.css?v=20260621a" />
+  <link rel="stylesheet" href="%%BASE_PATH%%assets/top-page.css?v=20260623d" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
   <link rel="icon" href="%%BASE_PATH%%assets/pokefuta-marker.svg" type="image/svg+xml" />
 </head>
@@ -139,6 +139,28 @@
       </div>
     </section>
 
+    <!-- ===== MAP GATEWAY (under intro on mobile; full-bleed hero on desktop) ===== -->
+    <section class="top-section" id="sec-map">
+      <div class="sec-header">
+        <div class="sec-eyebrow">
+          <span class="sec-num"></span>
+          <h2 class="sec-title">%%SEC3_TITLE%%</h2>
+        </div>
+        <span class="sec-file-label">/ map.html</span>
+      </div>
+
+      <a class="map-gateway-card" href="%%BASE_PATH%%map.html" onclick="trackEvent('click_map_gateway')">
+        <div id="mini-map" class="map-gateway-minimap" aria-hidden="true"></div>
+        <span class="map-gateway-badge">🗺 %%APPBAR_PREFIX%%<b id="map-badge-count">—</b>%%APPBAR_SUFFIX%%</span>
+        <span class="map-gateway-attr">© OpenStreetMap contributors</span>
+        <div class="map-gateway-overlay">
+          <div class="map-gateway-title">%%SEC3_MAP_TITLE%%</div>
+          <div class="map-gateway-sub">%%SEC3_MAP_SUB%%</div>
+          <div class="map-gateway-cta">%%SEC3_MAP_CTA%%</div>
+        </div>
+      </a>
+    </section>
+
     <!-- ===== 2. TODAY'S HERO ===== -->
     <section class="top-section" id="sec-hero">
       <div class="sec-header">
@@ -189,28 +211,6 @@
       </div>
     </section>
 
-    <!-- ===== 3. MAP GATEWAY ===== -->
-    <section class="top-section" id="sec-map">
-      <div class="sec-header">
-        <div class="sec-eyebrow">
-          <span class="sec-num"></span>
-          <h2 class="sec-title">%%SEC3_TITLE%%</h2>
-        </div>
-        <span class="sec-file-label">/ map.html</span>
-      </div>
-
-      <a class="map-gateway-card" href="%%BASE_PATH%%map.html" onclick="trackEvent('click_map_gateway')">
-        <div id="mini-map" class="map-gateway-minimap" aria-hidden="true"></div>
-        <span class="map-gateway-badge">🗺 %%APPBAR_PREFIX%%<b id="map-badge-count">—</b>%%APPBAR_SUFFIX%%</span>
-        <span class="map-gateway-attr">© OpenStreetMap © CARTO</span>
-        <div class="map-gateway-overlay">
-          <div class="map-gateway-title">%%SEC3_MAP_TITLE%%</div>
-          <div class="map-gateway-sub">%%SEC3_MAP_SUB%%</div>
-          <div class="map-gateway-cta">%%SEC3_MAP_CTA%%</div>
-        </div>
-      </a>
-    </section>
-
     <!-- ===== 4. PREFECTURE LIST ===== -->
     <section class="top-section" id="sec-pref">
       <div class="sec-eyebrow">
@@ -238,7 +238,7 @@
       <div class="hub-card">
         <div class="hub-card-header">
           <span>%%SEC5_THEME_LABEL%%</span>
-          <a class="hub-card-more" href="%%BASE_PATH%%map.html" onclick="trackEvent('click_hub_tag_all')">%%SEC5_THEME_MORE%%</a>
+          <a class="hub-card-more" href="%%BASE_PATH%%map.html?view=theme" onclick="trackEvent('click_hub_tag_all')">%%SEC5_THEME_MORE%%</a>
         </div>
         <div class="hub-chips">
           <a class="hub-chip" href="%%BASE_PATH%%map.html?tag=roadside" onclick="trackEvent('click_hub_tag',{tag:'roadside'})">%%TAG_ROADSIDE%%</a>
@@ -387,19 +387,16 @@
       var counts = window._prefCountMap;
       if (!map || !counts || window._miniPinsRendered) return;
       window._miniPinsRendered = true;
-      var prefMax = Math.max.apply(null, Object.keys(counts).map(function(k) { return counts[k]; }));
       Object.keys(counts).forEach(function(pref) {
         var c = PREF_COORDS[pref];
         if (!c) return;
         var cnt = counts[pref];
-        var big = cnt >= prefMax * 0.7;
-        var sz = big ? 42 : 36;
-        var shortName = pref.replace(/[県都府]$/, '');
+        var shortName = pref === '北海道' ? pref : pref.replace(/[都府県]$/, '');
+        // map.html の都道府県オーバービューマーカーと同じデザイン
         var icon = L.divIcon({
-          html: '<div class="mini-pin' + (big ? ' mini-pin--lg' : '') + '">'
-            + '<span class="mini-pin-name">' + shortName + '</span>'
-            + '<span class="mini-pin-count">' + cnt + '</span></div>',
-          className: '', iconSize: [sz, sz], iconAnchor: [sz / 2, sz / 2],
+          html: '<span class="prefecture-overview-name">' + shortName + '</span>'
+            + '<span class="prefecture-overview-count">' + cnt + '</span>',
+          className: 'prefecture-overview-marker', iconSize: null,
         });
         L.marker(c, { icon: icon }).addTo(map);
       });
@@ -530,13 +527,15 @@
   (function() {
     var miniMapEl = document.getElementById('mini-map');
     if (!miniMapEl || typeof L === 'undefined') return;
+    // SP（スマホ）は2段階ズームイン（7）、デスクトップは全国が収まる5
+    var _miniZoom = window.matchMedia('(min-width: 960px)').matches ? 5 : 7;
     var miniMap = L.map('mini-map', {
       zoomControl: false, scrollWheelZoom: false, dragging: false,
       touchZoom: false, doubleClickZoom: false, boxZoom: false,
       keyboard: false, attributionControl: false,
-    }).setView([37.6, 137.5], 4);
-    L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
-      subdomains: 'abcd', maxZoom: 19,
+    }).setView([37.6, 137.5], _miniZoom);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      maxZoom: 19,
     }).addTo(miniMap);
     window._miniMap = miniMap;
     if (window._renderMiniPins) window._renderMiniPins();

--- a/apps/web/map.html
+++ b/apps/web/map.html
@@ -1561,7 +1561,9 @@
           // 地図をその都道府県にズーム
           setTimeout(() => zoomToPrefecture(initialPref), 100);
         }
-        const tagParam = new URLSearchParams(window.location.search).get('tag');
+        const urlParams = new URLSearchParams(window.location.search);
+        const tagParam = urlParams.get('tag');
+        const viewParam = urlParams.get('view');
         if (tagParam) {
           activeTagFilter = tagParam;
           document.querySelectorAll('.tag-chip').forEach(b => {
@@ -1569,7 +1571,9 @@
             b.setAttribute('aria-pressed', String(b.dataset.tag === tagParam));
           });
           recomputeVisibility();
-          syncExploreSections();
+          openThemeDirectory(); // テーマ絞り込みパネルを開く（タグ選択済み）
+        } else if (viewParam === 'theme') {
+          openThemeDirectory(); // タグ未選択でテーマ一覧パネルを開く
         }
         // Mark initial page load as complete to enable SPA page_view tracking
         isInitialPageLoad = false;
@@ -1751,6 +1755,24 @@
 
 // Prefecture table toggle機能は削除済み（テーブル自体は残存）
 
+    function scrollTagDirectoryIntoView() {
+      requestAnimationFrame(() => {
+        const section = document.querySelector('.tag-directory');
+        const controlsContent = document.getElementById('controls-content');
+        if (!section || !controlsContent) return;
+        const top = Math.max(0, section.offsetTop - controlsContent.offsetTop - 8);
+        controlsContent.scrollTo({ top, behavior: 'smooth' });
+      });
+    }
+
+    // テーマで絞り込むパネルを開く（トグルではなく常に開く）。?tag= / ?view=theme 着地時に使用。
+    function openThemeDirectory() {
+      showTagDirectory = true;
+      expandBottomSheet();
+      syncExploreSections();
+      scrollTagDirectoryIntoView();
+    }
+
     function initControlsToggle() {
       const toggleBtn = document.getElementById('controls-toggle');
       const controlsContent = document.getElementById('controls-content');
@@ -1788,15 +1810,7 @@
             'event_label': showTagDirectory ? 'opened' : 'closed'
           });
         }
-        if (showTagDirectory) {
-          requestAnimationFrame(() => {
-            const section = document.querySelector('.tag-directory');
-            const controlsContent = document.getElementById('controls-content');
-            if (!section || !controlsContent) return;
-            const top = Math.max(0, section.offsetTop - controlsContent.offsetTop - 8);
-            controlsContent.scrollTo({ top, behavior: 'smooth' });
-          });
-        }
+        if (showTagDirectory) scrollTagDirectoryIntoView();
       });
       let startY = 0;
       toggleBtn.addEventListener('touchstart', e => { startY = e.touches[0].clientY; }, { passive: true });

--- a/apps/web/map.template.html
+++ b/apps/web/map.template.html
@@ -1525,7 +1525,9 @@
           // 地図をその都道府県にズーム
           setTimeout(() => zoomToPrefecture(initialPref), 100);
         }
-        const tagParam = new URLSearchParams(window.location.search).get('tag');
+        const urlParams = new URLSearchParams(window.location.search);
+        const tagParam = urlParams.get('tag');
+        const viewParam = urlParams.get('view');
         if (tagParam) {
           activeTagFilter = tagParam;
           document.querySelectorAll('.tag-chip').forEach(b => {
@@ -1533,7 +1535,9 @@
             b.setAttribute('aria-pressed', String(b.dataset.tag === tagParam));
           });
           recomputeVisibility();
-          syncExploreSections();
+          openThemeDirectory(); // テーマ絞り込みパネルを開く（タグ選択済み）
+        } else if (viewParam === 'theme') {
+          openThemeDirectory(); // タグ未選択でテーマ一覧パネルを開く
         }
         // Mark initial page load as complete to enable SPA page_view tracking
         isInitialPageLoad = false;
@@ -1715,6 +1719,24 @@
 
 // Prefecture table toggle機能は削除済み（テーブル自体は残存）
 
+    function scrollTagDirectoryIntoView() {
+      requestAnimationFrame(() => {
+        const section = document.querySelector('.tag-directory');
+        const controlsContent = document.getElementById('controls-content');
+        if (!section || !controlsContent) return;
+        const top = Math.max(0, section.offsetTop - controlsContent.offsetTop - 8);
+        controlsContent.scrollTo({ top, behavior: 'smooth' });
+      });
+    }
+
+    // テーマで絞り込むパネルを開く（トグルではなく常に開く）。?tag= / ?view=theme 着地時に使用。
+    function openThemeDirectory() {
+      showTagDirectory = true;
+      expandBottomSheet();
+      syncExploreSections();
+      scrollTagDirectoryIntoView();
+    }
+
     function initControlsToggle() {
       const toggleBtn = document.getElementById('controls-toggle');
       const controlsContent = document.getElementById('controls-content');
@@ -1752,15 +1774,7 @@
             'event_label': showTagDirectory ? 'opened' : 'closed'
           });
         }
-        if (showTagDirectory) {
-          requestAnimationFrame(() => {
-            const section = document.querySelector('.tag-directory');
-            const controlsContent = document.getElementById('controls-content');
-            if (!section || !controlsContent) return;
-            const top = Math.max(0, section.offsetTop - controlsContent.offsetTop - 8);
-            controlsContent.scrollTo({ top, behavior: 'smooth' });
-          });
-        }
+        if (showTagDirectory) scrollTagDirectoryIntoView();
       });
       let startY = 0;
       toggleBtn.addEventListener('touchstart', e => { startY = e.touches[0].clientY; }, { passive: true });


### PR DESCRIPTION
## 概要
トップページ（index.html）の地図を map.html と同じ見た目・操作系に寄せ、「目的から探す」のテーマ導線を整理しました。あわせてリンクの引き継ぎ（パラメータ受け渡し）も見直しています。

## 変更内容

### テーマ導線（目的から探す → テーマ絞り込み画面）
- テーマチップ（`map.html?tag=xxx`）着地時に「テーマで絞り込む」パネルを**自動で開く**（タグ選択済み）。
- 「地図で探す →」を `map.html?view=theme` に変更し、タグ未選択でテーマパネルを開く。
- map 側のパネル開放ロジックを `openThemeDirectory()` / `scrollTagDirectoryIntoView()` に共通化（`feature-open-button` と共用）。
- 旧ディープリンク転送（index→map）に `tag` / `view` を追加。

### トップページ地図
- タイルを CARTO → **OSM**（`tile.openstreetmap.org`、`map.html` と同じ）に変更。
- マーカーを map.html の `.prefecture-overview-marker` に統一（**都道府県名＋件数を2行表示**・放射状グラデーション）。
- **SP は2段ズームイン（zoom 7）/ PC は全国表示（zoom 5）** のレスポンシブ。
- SP の並びを **イントロ（H1＋件数）→ 地図** の順に（PC は従来の地図ヒーロー＋イントロ重ねを維持）。
- セクション番号バッジ（①〜⑤・ヘッダーの①）を**非表示**。

### 対象ファイル
`apps/web/index.html` / `index.template.html` / `map.html` / `map.template.html` / `assets/top-page.css`（テンプレートにもミラー済み）

## 検証
- Playwright（モバイル/デスクトップ）でレイアウト・マーカー・件数・ズーム・並び順を確認、**コンソールエラー0**。
- 全インラインJSの構文チェック **エラー0**。
- テンプレート整合テスト（`apps/scraper/test_generate_summary_pages.py`）の失敗は**変更前から存在する既存failureのみ**（本PRによる新規failureなし）。
- self code-review 済み（OSMタイルの `{s}` サブドメイン、`.mini-pin` の完全撤去、CSSの読み込み順による `display` 上書き等を確認）。

## 備考
- ローカル確認では `pokefuta.ndjson` が `apps/web` に無く404になるため、検証時のみ一時シンボリックリンクで確認（コミットには含めていません）。本番は dist/docs から配信。

🤖 Generated with [Claude Code](https://claude.com/claude-code)