### PR TITLE
feat: トップページに新作ポケふたセクションを追加

### DIFF
--- a/apps/web/assets/top-page.css
+++ b/apps/web/assets/top-page.css
@@ -427,6 +427,94 @@ a { color: inherit; text-decoration: none; }
   margin-top: 3px;
 }
 
+/* ── Section 0: New releases (topmost; revealed by JS only when recent) ── */
+#sec-newrelease[hidden] { display: none; }
+
+.newrel-update-label {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--top-eyebrow);
+  background: #FCEFE3;
+  padding: 3px 10px;
+  border-radius: var(--top-radius-pill);
+  white-space: nowrap;
+}
+
+.newrel-scroller {
+  display: flex;
+  gap: 10px;
+  margin-top: 10px;
+  overflow-x: auto;
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch;
+  padding-bottom: 4px;
+}
+.newrel-scroller::-webkit-scrollbar { height: 6px; }
+.newrel-scroller::-webkit-scrollbar-thumb {
+  background: var(--top-border);
+  border-radius: 3px;
+}
+
+.newrel-card {
+  flex: 0 0 auto;
+  width: 150px;
+  scroll-snap-align: start;
+  background: var(--top-card-bg);
+  border: 1px solid var(--top-border);
+  border-radius: 13px;
+  overflow: hidden;
+  text-decoration: none;
+  color: inherit;
+}
+
+.newrel-media {
+  height: 96px;
+  position: relative;
+  overflow: hidden;
+  background: linear-gradient(140deg, #F3D9C2, #E7B894);
+}
+
+.newrel-img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.newrel-badge {
+  position: absolute;
+  top: 6px;
+  left: 6px;
+  background: var(--top-eyebrow);
+  color: #fff;
+  font-size: 10px;
+  font-weight: 700;
+  padding: 2px 8px;
+  border-radius: var(--top-radius-pill);
+}
+
+.newrel-body { padding: 8px 10px 10px; }
+
+.newrel-title {
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.newrel-place {
+  font-size: 10px;
+  color: var(--top-text-faint);
+  margin-top: 3px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* ── Section 3: Map gateway (Leaflet mini-map card) ── */
 .map-gateway-card {
   display: block;
@@ -789,6 +877,18 @@ a { color: inherit; text-decoration: none; }
   #sec-map   { grid-area: maphero; }
   #sec-pref  { grid-area: pref; }
   #sec-hub   { grid-area: hub; }
+  #sec-newrelease { grid-area: newrelease; }
+
+  /* When new releases exist, prepend a topmost row so the band leads the page.
+     Hidden (the common case) leaves the base 4-row layout untouched — no gap. */
+  .top-main:has(> #sec-newrelease:not([hidden])) {
+    grid-template-areas:
+      "newrelease"
+      "maphero"
+      "hero"
+      "pref"
+      "hub";
+  }
 
   /* Roomier section headings to match the design. */
   .sec-title { font-size: 20px; }

--- a/apps/web/i18n/strings.en.json
+++ b/apps/web/i18n/strings.en.json
@@ -221,5 +221,7 @@
   "POKEMON_EEVEE": "Eevee",
   "POKEMON_LAPRAS": "Lapras",
   "POKEMON_SNORLAX": "Snorlax",
-  "POKEMON_SLOWPOKE": "Slowpoke"
+  "POKEMON_SLOWPOKE": "Slowpoke",
+  "NEWREL_TITLE": "New Poké Lids",
+  "NEWREL_LABEL": "Added this month"
 }

--- a/apps/web/i18n/strings.ko.json
+++ b/apps/web/i18n/strings.ko.json
@@ -221,5 +221,7 @@
   "POKEMON_EEVEE": "이브이",
   "POKEMON_LAPRAS": "라프라스",
   "POKEMON_SNORLAX": "잠만보",
-  "POKEMON_SLOWPOKE": "야돈"
+  "POKEMON_SLOWPOKE": "야돈",
+  "NEWREL_TITLE": "신작 포케후타",
+  "NEWREL_LABEL": "이번 달 신규"
 }

--- a/apps/web/i18n/strings.zh-CN.json
+++ b/apps/web/i18n/strings.zh-CN.json
@@ -221,5 +221,7 @@
   "POKEMON_EEVEE": "伊布",
   "POKEMON_LAPRAS": "拉普拉斯",
   "POKEMON_SNORLAX": "卡比兽",
-  "POKEMON_SLOWPOKE": "呆呆兽"
+  "POKEMON_SLOWPOKE": "呆呆兽",
+  "NEWREL_TITLE": "最新井盖",
+  "NEWREL_LABEL": "本月新增"
 }

--- a/apps/web/i18n/strings.zh-TW.json
+++ b/apps/web/i18n/strings.zh-TW.json
@@ -221,5 +221,7 @@
   "POKEMON_EEVEE": "伊布",
   "POKEMON_LAPRAS": "拉普拉斯",
   "POKEMON_SNORLAX": "卡比獸",
-  "POKEMON_SLOWPOKE": "呆呆獸"
+  "POKEMON_SLOWPOKE": "呆呆獸",
+  "NEWREL_TITLE": "最新人孔蓋",
+  "NEWREL_LABEL": "本月新增"
 }

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -114,6 +114,18 @@
 
   <main class="top-main">
 
+    <!-- ===== 0. NEW RELEASES (shown only when manholes were added in the last month) ===== -->
+    <section class="top-section" id="sec-newrelease" hidden>
+      <div class="sec-header">
+        <div class="sec-eyebrow">
+          <span class="sec-num"></span>
+          <h2 class="sec-title">新作ポケふた</h2>
+        </div>
+        <span class="newrel-update-label">この1ヶ月の新着</span>
+      </div>
+      <div class="newrel-scroller" id="newrel-scroller"></div>
+    </section>
+
     <!-- ===== 1. H1 + INTRO + STATS ===== -->
     <section class="top-section" id="sec-intro">
       <div class="sec-eyebrow">
@@ -413,6 +425,11 @@
     var totalCount = 0;
     var pokemonSet = new Set();
 
+    // New releases: manholes added to the dataset within the last month
+    var NEW_WINDOW_DAYS = 30;
+    var newReleaseCutoff = Date.now() - NEW_WINDOW_DAYS * 86400000;
+    var newReleases = [];
+
     fetch('pokefuta.ndjson')
       .then(function(r) { return r.text(); })
       .then(function(text) {
@@ -433,6 +450,15 @@
                 }
               });
             }
+            var addedMs = m.added_at ? Date.parse(m.added_at) : NaN;
+            if (!isNaN(addedMs) && addedMs >= newReleaseCutoff) {
+              newReleases.push({
+                id: m.id,
+                pokemons: (Array.isArray(m.pokemons) ? m.pokemons : []).filter(function(p) { return p && !p.includes('ローカルActs'); }),
+                title: m.title || '',
+                addedMs: addedMs
+              });
+            }
           } catch (e) {}
         });
 
@@ -442,6 +468,9 @@
         setNum('stat-pokemon', pokemonSet.size);
         setNum('appbar-count', totalCount);
         setNum('map-badge-count', totalCount);
+
+        // New releases banner (topmost section; stays hidden when empty)
+        renderNewReleases(newReleases);
 
         // Pokemon chip counts
         var chipMap = {
@@ -524,6 +553,35 @@
     function setNum(id, val) {
       var el = document.getElementById(id);
       if (el) el.textContent = val.toLocaleString();
+    }
+    function escapeHtml(s) {
+      return String(s).replace(/[&<>"']/g, function(c) {
+        return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+      });
+    }
+    function renderNewReleases(list) {
+      var section = document.getElementById('sec-newrelease');
+      var scroller = document.getElementById('newrel-scroller');
+      if (!section || !scroller || !list || !list.length) return;
+      list.sort(function(a, b) { return b.addedMs - a.addedMs; });
+      scroller.innerHTML = list.map(function(m) {
+        var place = (m.title || '').replace('/', ' ');
+        var names = m.pokemons.join('・');
+        var href = 'map.html?manhole=' + encodeURIComponent(m.id);
+        var img = 'manhole/image/' + encodeURIComponent(m.id) + '_latest.jpeg';
+        return '<a class="newrel-card" href="' + href + '" onclick="trackEvent(\'click_newrelease\',{manhole:\'' + escapeHtml(m.id) + '\'})">'
+          + '<div class="newrel-media">'
+          +   '<img class="newrel-img" src="' + img + '" alt="' + escapeHtml(names || place) + '" loading="lazy" onerror="this.style.display=\'none\'">'
+          +   '<span class="newrel-badge">🆕 新作</span>'
+          + '</div>'
+          + '<div class="newrel-body">'
+          +   '<div class="newrel-title">' + escapeHtml(names || 'ポケふた') + '</div>'
+          +   '<div class="newrel-place">' + escapeHtml(place) + '</div>'
+          + '</div>'
+          + '</a>';
+      }).join('');
+      section.hidden = false;
+      if (window.trackEvent) trackEvent('view_newrelease', { count: list.length });
     }
   })();
   </script>

--- a/apps/web/index.template.html
+++ b/apps/web/index.template.html
@@ -117,6 +117,18 @@
 
   <main class="top-main">
 
+    <!-- ===== 0. NEW RELEASES (shown only when manholes were added in the last month) ===== -->
+    <section class="top-section" id="sec-newrelease" hidden>
+      <div class="sec-header">
+        <div class="sec-eyebrow">
+          <span class="sec-num"></span>
+          <h2 class="sec-title">%%NEWREL_TITLE%%</h2>
+        </div>
+        <span class="newrel-update-label">%%NEWREL_LABEL%%</span>
+      </div>
+      <div class="newrel-scroller" id="newrel-scroller"></div>
+    </section>
+
     <!-- ===== 1. H1 + INTRO + STATS ===== -->
     <section class="top-section" id="sec-intro">
       <div class="sec-eyebrow">
@@ -412,6 +424,11 @@
     var totalCount = 0;
     var pokemonSet = new Set();
 
+    // New releases: manholes added to the dataset within the last month
+    var NEW_WINDOW_DAYS = 30;
+    var newReleaseCutoff = Date.now() - NEW_WINDOW_DAYS * 86400000;
+    var newReleases = [];
+
     fetch(BASE_PATH + 'pokefuta.ndjson')
       .then(function(r) { return r.text(); })
       .then(function(text) {
@@ -432,6 +449,15 @@
                 }
               });
             }
+            var addedMs = m.added_at ? Date.parse(m.added_at) : NaN;
+            if (!isNaN(addedMs) && addedMs >= newReleaseCutoff) {
+              newReleases.push({
+                id: m.id,
+                pokemons: (Array.isArray(m.pokemons) ? m.pokemons : []).filter(function(p) { return p && !p.includes('ローカルActs'); }),
+                title: m.title || '',
+                addedMs: addedMs
+              });
+            }
           } catch (e) {}
         });
 
@@ -440,6 +466,9 @@
         setNum('stat-pokemon', pokemonSet.size);
         setNum('appbar-count', totalCount);
         setNum('map-badge-count', totalCount);
+
+        // New releases banner (topmost section; stays hidden when empty)
+        renderNewReleases(newReleases);
 
         var chipMap = {
           'ピカチュウ': 'chip-pikachu',
@@ -523,6 +552,35 @@
     function setNum(id, val) {
       var el = document.getElementById(id);
       if (el) el.textContent = val.toLocaleString();
+    }
+    function escapeHtml(s) {
+      return String(s).replace(/[&<>"']/g, function(c) {
+        return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+      });
+    }
+    function renderNewReleases(list) {
+      var section = document.getElementById('sec-newrelease');
+      var scroller = document.getElementById('newrel-scroller');
+      if (!section || !scroller || !list || !list.length) return;
+      list.sort(function(a, b) { return b.addedMs - a.addedMs; });
+      scroller.innerHTML = list.map(function(m) {
+        var place = (m.title || '').replace('/', ' ');
+        var names = m.pokemons.join('・');
+        var href = BASE_PATH + 'map.html?manhole=' + encodeURIComponent(m.id);
+        var img = BASE_PATH + 'manhole/image/' + encodeURIComponent(m.id) + '_latest.jpeg';
+        return '<a class="newrel-card" href="' + href + '" onclick="trackEvent(\'click_newrelease\',{manhole:\'' + escapeHtml(m.id) + '\'})">'
+          + '<div class="newrel-media">'
+          +   '<img class="newrel-img" src="' + img + '" alt="' + escapeHtml(names || place) + '" loading="lazy" onerror="this.style.display=\'none\'">'
+          +   '<span class="newrel-badge">🆕 新作</span>'
+          + '</div>'
+          + '<div class="newrel-body">'
+          +   '<div class="newrel-title">' + escapeHtml(names || 'ポケふた') + '</div>'
+          +   '<div class="newrel-place">' + escapeHtml(place) + '</div>'
+          + '</div>'
+          + '</a>';
+      }).join('');
+      section.hidden = false;
+      if (window.trackEvent) trackEvent('view_newrelease', { count: list.length });
     }
   })();
   </script>


### PR DESCRIPTION
## 概要
新しいマンホールができてから**1ヶ月間**、トップページ最上部に「新作ポケふた」セクションを表示する。要望：「新しいマンホールができて１ヶ月間は新作マンホールをトップに出そう」。

## 仕様
- `pokefuta.ndjson` の各レコードの `added_at` が**直近30日以内**のものを抽出し、最上部の専用セクションに**新しい順**で横スクロールカード表示
- 該当が無い期間は `hidden` のままで、従来のトップページの見た目を一切変えない
- カードは `map.html?manhole={id}` へリンク（GAイベント `view_newrelease` / `click_newrelease`）
- 判定ウィンドウは `NEW_WINDOW_DAYS` 定数1箇所で調整可能

## 変更ファイル
| ファイル | 内容 |
|---|---|
| `apps/web/index.html` | 新作セクション(日本語) + 抽出/描画JS（相対パス） |
| `apps/web/index.template.html` | 同上（`%%NEWREL_*%%` プレースホルダ・`BASE_PATH` 対応の多言語版） |
| `apps/web/assets/top-page.css` | `.newrel-*` スタイル + デスクトップ `:has()` グリッド配置 |
| `apps/web/i18n/strings.{en,zh-TW,zh-CN,ko}.json` | `NEWREL_TITLE` / `NEWREL_LABEL` を4言語追加 |

## 検証
- `python3 tools/build_i18n.py` → unreplaced markers 警告なし（全言語）
- ローカル配信の実データ（2026-06-28 追加の新作6件: 長崎5・石川1）でセクションが表示され、6枚のカードが新しい順で描画されることをページ実装そのもので確認

## 補足
- ja版 `index.html` は `BASE_PATH` 変数を持たない相対パス方式のため、新作カードのパスは相対指定。多言語テンプレート側は `BASE_PATH` 対応。

🤖 Generated with [Claude Code](https://claude.com/claude-code)