### PR TITLE
[codex] 新規ポケふた6件にタグを追加

### DIFF
--- a/dataset/manhole_titles.json
+++ b/dataset/manhole_titles.json
@@ -2696,6 +2696,50 @@
       "tags": [
         "seaside"
       ]
+    },
+    "475": {
+      "building": "のと里山空港",
+      "tags": [
+        "tourism"
+      ]
+    },
+    "476": {
+      "building": "諫早駅前",
+      "tags": [
+        "station_front",
+        "rail_access_good"
+      ]
+    },
+    "477": {
+      "building": "対馬観光物産協会",
+      "tags": [
+        "tourism",
+        "remote_island"
+      ]
+    },
+    "478": {
+      "building": "鐙瀬ビジターセンター",
+      "tags": [
+        "tourism",
+        "museum",
+        "remote_island"
+      ]
+    },
+    "479": {
+      "building": "大島大橋公園",
+      "tags": [
+        "seaside",
+        "park",
+        "tourism"
+      ]
+    },
+    "480": {
+      "building": "波佐見やきもの公園",
+      "tags": [
+        "park",
+        "museum",
+        "tourism"
+      ]
     }
   },
   "lakes": [


### PR DESCRIPTION
## 概要

新しく追加されたポケふた ID 475〜480 に、設置施設名と既存語彙に沿ったタグを追加しました。

## 変更内容

- のと里山空港: `tourism`
- 諫早駅前: `station_front`, `rail_access_good`
- 対馬観光物産協会: `tourism`, `remote_island`
- 鐙瀬ビジターセンター: `tourism`, `museum`, `remote_island`
- 大島大橋公園: `seaside`, `park`, `tourism`
- 波佐見やきもの公園: `park`, `museum`, `tourism`

設置地点の公式情報と施設情報を照合し、手動メタデータの正本である `dataset/manhole_titles.json` のみを更新しています。

## 影響

次回のデータセット生成時に、各マンホールへ施設名とタグが反映されます。

## 確認

- `jq empty dataset/manhole_titles.json`
- `git diff --check`
- `python -m unittest discover -s apps/scraper -p 'test_manhole_titles*.py'`
- `python apps/scraper/update_pokefuta.py --help`
