### PR TITLE
[codex] キャラマンホール表崩れ修正と作品フィルタ追加

### DIFF
--- a/apps/web/assets/pokefuta-map.css
+++ b/apps/web/assets/pokefuta-map.css
@@ -706,7 +706,7 @@ body.pokefuta-map-page {
   font-size: .74rem;
 }
 
-.pokefuta-map-page #prefecture-table-body {
+.pokefuta-map-page .prefecture-card-list #prefecture-table-body {
   display: grid;
   gap: 10px;
 }
@@ -1559,7 +1559,7 @@ body.pokefuta-map-page {
     padding-bottom: 18px;
   }
 
-  .pokefuta-map-page #prefecture-table-body {
+  .pokefuta-map-page .prefecture-card-list #prefecture-table-body {
     grid-template-columns: 1fr;
   }
 

--- a/apps/web/gmanhole_map.html
+++ b/apps/web/gmanhole_map.html
@@ -329,7 +329,7 @@
       return mediaQuery ? mediaQuery.matches : true;
     }
 
-    function franchiseIcon(franchise, overlap=false) {
+    function franchiseIcon(franchise) {
       let cls = 'fr-marker ';
       if (franchise === 'gundam') cls += 'fr-gundam';
       else if (franchise === 'pokefuta' || franchise === 'pokemon') cls += 'fr-pokemon';
@@ -369,6 +369,7 @@
     let characterData = []; // character_manholes (ZLS/ロマサガ/弱虫ペダル/ちびまる子 など)
     let allMarkers = [];
     let selectedPrefecture = '';
+    const characterWorkCheckboxes = new Map();
     let userLocationMarker = null;
     let lastNearbyLocation = null; // 現在地検索後、フィルタ変更時にリストを再計算するため保持
     // Note: prefectureCodeMap and codeToPrefectureMap are defined globally in head script
@@ -655,6 +656,10 @@
           </button>
         </div>`
       ).join('');
+      characterWorkCheckboxes.clear();
+      el.querySelectorAll('.character-work-checkbox').forEach(input => {
+        characterWorkCheckboxes.set(input.dataset.work, input);
+      });
     }
 
     function esc(s){ return String(s||'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;'}[c])); }
@@ -897,8 +902,7 @@
     function isMarkerVisibleByWork(d) {
       if (d.franchise === 'gundam') return Boolean(document.getElementById('chk-gundam')?.checked);
       if (d.franchise === 'pokefuta') return Boolean(document.getElementById('chk-pokemon')?.checked);
-      const workCheckbox = [...document.querySelectorAll('.character-work-checkbox')]
-        .find(input => input.dataset.work === d.work);
+      const workCheckbox = characterWorkCheckboxes.get(d.work);
       return Boolean(workCheckbox?.checked);
     }
 
@@ -1075,8 +1079,7 @@
       } else if (button.dataset.filterKind === 'pokefuta') {
         document.getElementById('chk-pokemon').checked = true;
       } else {
-        const selected = [...document.querySelectorAll('.character-work-checkbox')]
-          .find(input => input.dataset.work === button.dataset.work);
+        const selected = characterWorkCheckboxes.get(button.dataset.work);
         if (selected) selected.checked = true;
       }
       recomputeVisibility();

--- a/apps/web/gmanhole_map.html
+++ b/apps/web/gmanhole_map.html
@@ -46,15 +46,19 @@
     .fr-marker { width:30px; height:30px; border-radius:50%; display:flex; align-items:center; justify-content:center; font-size:15px; font-weight:600; color:#fff; box-shadow:0 0 0 2px #fff, 0 2px 6px rgba(0,0,0,.35); }
     .fr-pokemon { background:linear-gradient(135deg,#ffcc00,#ff6b00); }
     .fr-gundam { background:linear-gradient(135deg,#0044aa,#cc0000); }
-    .fr-both { background:linear-gradient(135deg,#6a00cc,#ff0066); }
     .legend { margin-top:6px; display:flex; gap:8px; flex-wrap:wrap; }
     .legend-item { display:flex; align-items:center; gap:4px; font-size:0.75rem; }
     .legend-swatch { width:18px; height:18px; border-radius:50%; box-shadow:0 0 0 1px #fff,0 1px 3px rgba(0,0,0,.3); }
     .legend-pokemon { background:linear-gradient(135deg,#ffcc00,#ff6b00); }
     .legend-gundam { background:linear-gradient(135deg,#0044aa,#cc0000); }
-    .legend-both { background:linear-gradient(135deg,#6a00cc,#ff0066); }
     .franchise-filter-group { display:flex; gap:8px; flex-wrap:wrap; margin:4px 0 8px; }
-    .franchise-filter-group label { font-size:0.8rem; cursor:pointer; display:flex; align-items:center; gap:4px; }
+    .work-filter-list { display:flex; gap:6px; flex-wrap:wrap; margin:4px 0 8px; }
+    .work-filter-item { display:flex; align-items:center; gap:3px; min-height:30px; padding:2px 7px; border:1px solid var(--top-border); border-radius:999px; background:#fff; }
+    .work-filter-item input { margin:0; }
+    .work-filter-only { display:flex; align-items:center; gap:4px; padding:0; border:0; background:transparent; color:inherit; font:inherit; font-size:.75rem; cursor:pointer; }
+    .work-filter-only:hover, .work-filter-only:focus-visible { text-decoration:underline; }
+    .work-filter-swatch { width:12px; height:12px; border-radius:50%; flex:0 0 auto; }
+    .work-filter-help { margin:0; color:var(--top-text-muted); font-size:.68rem; line-height:1.4; }
     .stat-inline { font-size:0.7rem; color:#444; margin:2px 0; }
     .franchise-filter-group input { margin:0; }
     .gmanhole-display-row { display:flex; align-items:center; gap:8px; margin-bottom:2px; padding:2px 0; flex-wrap:wrap; }
@@ -185,18 +189,23 @@
       <div class="sheet-utility-section">
         <p class="sheet-section-label">表示する作品</p>
         <div class="gmanhole-display-row">
-          <div class="franchise-filter-group" role="group" aria-label="Franchise filters">
-            <label><input type="checkbox" id="chk-gundam" checked aria-label="ガンダム表示" /> ガンダム</label>
-            <label><input type="checkbox" id="chk-character" checked aria-label="キャラマンホール表示" /> キャラ</label>
-            <label><input type="checkbox" id="chk-pokemon" aria-label="ポケモン表示" /> ポケモン</label>
-          </div>
-          <div class="legend" aria-label="Legend">
-            <div class="legend-item"><span class="legend-swatch legend-gundam"></span>ガンダム</div>
-            <span id="char-legend" style="display:contents"></span>
-            <div class="legend-item"><span class="legend-swatch legend-both"></span>座標共有/重複</div>
-            <div class="legend-item"><span class="legend-swatch legend-pokemon"></span>ポケふた</div>
+          <div id="work-filter-list" class="work-filter-list" role="group" aria-label="表示する作品">
+            <div class="work-filter-item">
+              <input type="checkbox" id="chk-gundam" checked aria-label="ガンダム表示" />
+              <button type="button" class="work-filter-only" data-filter-kind="gundam" title="ガンダムだけ表示">
+                <span class="work-filter-swatch legend-gundam"></span>ガンダム
+              </button>
+            </div>
+            <span id="character-work-filters" style="display:contents"></span>
+            <div class="work-filter-item">
+              <input type="checkbox" id="chk-pokemon" aria-label="ポケふた表示" />
+              <button type="button" class="work-filter-only" data-filter-kind="pokefuta" title="ポケふただけ表示">
+                <span class="work-filter-swatch legend-pokemon"></span>ポケふた
+              </button>
+            </div>
           </div>
         </div>
+        <p class="work-filter-help">チェックで複数表示、作品名をクリックするとその作品だけ表示します。</p>
       </div>
       <div class="sheet-utility-section">
         <p class="sheet-section-label">便利機能</p>
@@ -322,11 +331,10 @@
 
     function franchiseIcon(franchise, overlap=false) {
       let cls = 'fr-marker ';
-      if (overlap) cls += 'fr-both';
-      else if (franchise === 'gundam') cls += 'fr-gundam';
+      if (franchise === 'gundam') cls += 'fr-gundam';
       else if (franchise === 'pokefuta' || franchise === 'pokemon') cls += 'fr-pokemon';
       else cls += 'fr-pokemon';
-      const label = overlap ? '◎' : (franchise === 'gundam' ? 'G' : 'P');
+      const label = franchise === 'gundam' ? 'G' : 'P';
       return L.divIcon({ className: cls, html: label, iconSize: [30,30], iconAnchor:[15,15], popupAnchor:[0,-15] });
     }
 
@@ -438,8 +446,8 @@
           const cRes = await fetch('./character_manholes.ndjson');
           if (cRes.ok) characterData = await parseNdjson(cRes);
         } catch (e) { console.warn('character manholes not loaded', e); }
+        buildCharacterWorkFilters();
         buildMarkers();
-        buildCharacterLegend();
         buildPrefectureCounts();
         // ヘッダーバッジは実際に描画できるガンダム＋キャラの総数。
         const appbarEl = document.getElementById('appbar-count');
@@ -559,16 +567,10 @@
       
       // 指定された都道府県のマンホールマーカーを取得
       const prefectureMarkers = allMarkers.filter(marker => {
-        const showPokemon = document.getElementById('chk-pokemon')?.checked;
-        const showGundam = document.getElementById('chk-gundam')?.checked;
-        const showCharacter = document.getElementById('chk-character')?.checked;
         const data = marker._data;
 
         // 表示設定に応じてフィルタ
-        let shouldShow = false;
-        if (data.franchise === 'gundam' && showGundam) shouldShow = true;
-        if (data.franchise === 'pokefuta' && showPokemon) shouldShow = true;
-        if (data.franchise === 'character' && showCharacter) shouldShow = true;
+        const shouldShow = isMarkerVisibleByWork(data);
 
         return shouldShow && data.prefecture === prefecture;
       });
@@ -616,27 +618,19 @@
     function buildMarkers() {
       allMarkers.forEach(m => { if (map.hasLayer(m)) map.removeLayer(m); });
       allMarkers = [];
-      // Determine overlaps -> same lat/lng (rounded) between franchises
-      const locKey = d => d.lat != null && d.lng != null ? (d.lat.toFixed(5)+'|'+d.lng.toFixed(5)) : null;
-      const pokemonLocs = new Set(pokemonData.map(locKey).filter(Boolean));
-      const gundamLocs = new Set(gundamData.map(locKey).filter(Boolean));
-      const overlapLocs = new Set([...pokemonLocs].filter(k => gundamLocs.has(k)));
-
       gundamData.forEach(d => {
         if (d.lat == null || d.lng == null) return; // skip unless geocoded
-        const overlap = overlapLocs.has(locKey(d));
-        const popup = buildGundamPopup(d, overlap);
-        const marker = L.marker([d.lat, d.lng], { icon: franchiseIcon('gundam', overlap) }).bindPopup(popup, franchisePopupOptions);
-        marker._data = { ...d, prefecture: normalizePrefecture(d.prefecture), franchise:'gundam', overlap };
+        const popup = buildGundamPopup(d);
+        const marker = L.marker([d.lat, d.lng], { icon: franchiseIcon('gundam') }).bindPopup(popup, franchisePopupOptions);
+        marker._data = { ...d, prefecture: normalizePrefecture(d.prefecture), franchise:'gundam' };
         marker.addTo(map); allMarkers.push(marker);
       });
       pokemonData.forEach(d => {
         if (d.lat == null || d.lng == null) return;
-        const overlap = overlapLocs.has(locKey(d));
-        const popup = buildPokemonPopup(d, overlap);
+        const popup = buildPokemonPopup(d);
         // ポケふたは常に最下層（ガンダム/キャラを上に描画）
-        const marker = L.marker([d.lat, d.lng], { icon: franchiseIcon('pokefuta', overlap), zIndexOffset: -1000 }).bindPopup(popup, franchisePopupOptions);
-        marker._data = { ...d, prefecture: normalizePrefecture(d.prefecture), franchise:'pokefuta', overlap };
+        const marker = L.marker([d.lat, d.lng], { icon: franchiseIcon('pokefuta'), zIndexOffset: -1000 }).bindPopup(popup, franchisePopupOptions);
+        marker._data = { ...d, prefecture: normalizePrefecture(d.prefecture), franchise:'pokefuta' };
         marker.addTo(map); allMarkers.push(marker);
       });
       characterData.forEach(d => {
@@ -649,12 +643,17 @@
       recomputeVisibility();
     }
 
-    function buildCharacterLegend() {
-      const el = document.getElementById('char-legend');
+    function buildCharacterWorkFilters() {
+      const el = document.getElementById('character-work-filters');
       if (!el) return;
       const works = [...new Map(characterData.filter(d => d.work).map(d => [d.work, d])).values()];
-      el.innerHTML = works.map(record =>
-        `<div class="legend-item"><span class="legend-swatch" style="background:${markerColor(record)}"></span>${esc(markerLabel(record))} ${esc(record.work)}</div>`
+      el.innerHTML = works.map((record, index) =>
+        `<div class="work-filter-item">
+          <input type="checkbox" id="chk-work-${index}" class="character-work-checkbox" data-work="${esc(record.work)}" checked aria-label="${esc(record.work)}表示" />
+          <button type="button" class="work-filter-only" data-filter-kind="character" data-work="${esc(record.work)}" title="${esc(record.work)}だけ表示">
+            <span class="work-filter-swatch" style="background:${markerColor(record)}"></span>${esc(record.work)}
+          </button>
+        </div>`
       ).join('');
     }
 
@@ -705,7 +704,7 @@
         onclick="if(window.trackEvent){window.trackEvent('popup_click_detail',{${eventParams}});}">${esc(label)}</a>`;
     }
 
-    function buildTravelPopup({ d, title, building, badgeHtml, chipsHtml, chipsLabel, photoUrl, photoLink, detailUrl, detailLabel, overlap }){
+    function buildTravelPopup({ d, title, building, badgeHtml, chipsHtml, chipsLabel, photoUrl, photoLink, detailUrl, detailLabel }){
       const code = prefectureCodeMap[d.prefecture] || '--';
       const eventParams = popupEventParams(d);
       const photoBlock = photoUrl ? `
@@ -728,7 +727,6 @@
             ${building ? `<p class="travel-popup-building">📍 ${esc(building)}</p>` : ''}
             ${badgeHtml}
             ${chipsHtml ? `<div class="travel-popup-pokemon-list" aria-label="${esc(chipsLabel || '')}">${chipsHtml}</div>` : ''}
-            ${overlap ? '<p class="stat-inline">※ ポケふたと座標共有</p>' : ''}
             <div class="popup-actions travel-popup-actions">
               ${buildMapsAction(d, eventParams)}
               ${buildDetailAction(detailUrl, detailLabel, eventParams)}
@@ -737,7 +735,7 @@
         </div>`;
     }
 
-    function buildGundamPopup(d, overlap){
+    function buildGundamPopup(d){
       const chars = Array.isArray(d.characters) ? d.characters.filter(Boolean) : [];
       const detailUrl = safeHttpUrl(d.detail_url);
       // image_urls はスクレイプ元からの相対パスなので detail_url 基準で絶対化する
@@ -756,12 +754,11 @@
         photoUrl,
         photoLink: detailUrl,
         detailUrl,
-        detailLabel: '詳細を見る',
-        overlap
+        detailLabel: '詳細を見る'
       });
     }
 
-    function buildPokemonPopup(d, overlap){
+    function buildPokemonPopup(d){
       const pokes = Array.isArray(d.pokemons) ? d.pokemons.filter(Boolean) : [];
       const detailUrl = d.detail_url ? validateDetailUrl(d.detail_url) : null;
       return buildTravelPopup({
@@ -774,8 +771,7 @@
         photoUrl: '',
         photoLink: '',
         detailUrl: detailUrl || '',
-        detailLabel: '詳細を見る',
-        overlap
+        detailLabel: '詳細を見る'
       });
     }
 
@@ -791,8 +787,7 @@
         photoUrl: '',
         photoLink: '',
         detailUrl: sourceUrl,
-        detailLabel: '出典を見る',
-        overlap: false
+        detailLabel: '出典を見る'
       });
     }
 
@@ -899,15 +894,17 @@
       return 2 * r * Math.asin(Math.sqrt(s));
     }
 
-    function franchiseChecked(franchise) {
-      if (franchise === 'gundam') return Boolean(document.getElementById('chk-gundam')?.checked);
-      if (franchise === 'character') return Boolean(document.getElementById('chk-character')?.checked);
-      return Boolean(document.getElementById('chk-pokemon')?.checked);
+    function isMarkerVisibleByWork(d) {
+      if (d.franchise === 'gundam') return Boolean(document.getElementById('chk-gundam')?.checked);
+      if (d.franchise === 'pokefuta') return Boolean(document.getElementById('chk-pokemon')?.checked);
+      const workCheckbox = [...document.querySelectorAll('.character-work-checkbox')]
+        .find(input => input.dataset.work === d.work);
+      return Boolean(workCheckbox?.checked);
     }
 
     // 作品チェック + 都道府県選択の両方を満たすか（マーカー表示・近くのリスト・クリック時で共通利用）
     function isMarkerVisibleByFilters(d) {
-      if (!franchiseChecked(d.franchise)) return false;
+      if (!isMarkerVisibleByWork(d)) return false;
       if (selectedPrefecture && d.prefecture !== selectedPrefecture) return false;
       return true;
     }
@@ -1056,12 +1053,31 @@
       }
       recomputeVisibility();
     });
-    document.getElementById('chk-character').addEventListener('change', (e) => {
+    document.getElementById('work-filter-list').addEventListener('change', (e) => {
+      if (!e.target.matches('.character-work-checkbox')) return;
       if (window.trackEvent) {
-        window.trackEvent('toggle_character_filter', {
+        window.trackEvent('toggle_character_work_filter', {
           'event_category': 'user_engagement',
-          'event_label': e.target.checked ? 'enabled' : 'disabled'
+          'event_label': e.target.dataset.work,
+          'enabled': e.target.checked
         });
+      }
+      recomputeVisibility();
+    });
+    document.getElementById('work-filter-list').addEventListener('click', (e) => {
+      const button = e.target.closest('.work-filter-only');
+      if (!button) return;
+      document.querySelectorAll('#work-filter-list input[type="checkbox"]').forEach(input => {
+        input.checked = false;
+      });
+      if (button.dataset.filterKind === 'gundam') {
+        document.getElementById('chk-gundam').checked = true;
+      } else if (button.dataset.filterKind === 'pokefuta') {
+        document.getElementById('chk-pokemon').checked = true;
+      } else {
+        const selected = [...document.querySelectorAll('.character-work-checkbox')]
+          .find(input => input.dataset.work === button.dataset.work);
+        if (selected) selected.checked = true;
       }
       recomputeVisibility();
     });


### PR DESCRIPTION
## 概要

`gmanhole_map.html` の都道府県表の表示崩れを直し、作品単位で表示対象を選べるフィルタを追加します。

## 変更内容

- カード一覧用CSSが `<tbody>` に誤適用されないようセレクタを限定
- ガンダム、各キャラクター作品、ポケふたのチェックボックスを追加
- チェックボックスでは複数作品を表示可能
- 作品名クリックでは、その作品だけを単独表示
- 「座標共有/重複」の凡例、専用マーカー表示、ポップアップ注記を削除
- 都道府県・現在地検索・件数表示にも作品フィルタを反映

## 原因

共通スタイルの `#prefecture-table-body { display: grid; }` が、カード形式の都道府県一覧だけでなく、このページのテーブル行グループにも適用されていました。そのためブラウザ標準のテーブルレイアウトが崩れていました。

## 影響

都道府県表が通常の表として表示され、利用者は見たい作品を複数チェックしたり、作品名をクリックして1作品だけに絞り込めます。

## 確認

- `git diff --check`
- ローカルブラウザでデータ読込後に44行が `table-row-group` として描画されることを確認
- 表に横あふれがないことを確認
- 「ゾンビランドサガ」単独選択で32件表示
- 「ロマンシング サガ」を追加チェックして2作品64件表示
- 「座標共有/重複」の表示が残っていないことを確認

## 補足

`/import-photos` は実行を試みましたが、ローカル環境にR2認証情報がないため署名付きダウンロードは実行できませんでした。失敗時の写真JSON差分は戻しており、このPRには含めていません。
