### PR TITLE
[codex] ヘッダーを主要3リンクの1行表示に整理

### DIFF
--- a/apps/scraper/inject_site_header.py
+++ b/apps/scraper/inject_site_header.py
@@ -17,22 +17,19 @@ HEADER_TEMPLATE = """<header class="site-header">
       <span class="site-header__brand-sub">DATABASE</span>
     </a>
     <nav class="site-header__nav" aria-label="{nav_aria}">
-      <a class="site-header__link" href="{page_base}">{nav_top}</a>
       <a class="site-header__link" href="{page_base}map.html">{nav_map}</a>
-      <a class="site-header__link" href="{page_base}summary/">{nav_summary}</a>
       <a class="site-header__link" href="{page_base}pokemon/">{nav_pokemon}</a>
-      <a class="site-header__link" href="{asset_base}nearby.html">{nav_nearby}</a>
       <a class="site-header__link" href="{asset_base}gmanhole_map.html">{nav_character}</a>
     </nav>
   </div>
 </header>"""
 
 NAV_LABELS = {
-    "ja": ("メインナビゲーション", "トップ", "地図", "全国一覧", "ポケモン", "現在地付近", "キャラMH"),
-    "en": ("Main navigation", "Home", "Map", "Summary", "Pokémon", "Nearby", "Character MH"),
-    "zh-TW": ("主導覽", "首頁", "地圖", "全國一覽", "神奇寶貝", "附近", "角色人孔蓋"),
-    "zh-CN": ("主导航", "首页", "地图", "全国一览", "宝可梦", "附近", "角色井盖"),
-    "ko": ("메인 내비게이션", "홈", "지도", "전국 목록", "포켓몬", "내 주변", "캐릭터 맨홀"),
+    "ja": ("メインナビゲーション", "地図", "ポケモン", "キャラマンホール"),
+    "en": ("Main navigation", "Map", "Pokémon", "Character Manholes"),
+    "zh-TW": ("主導覽", "地圖", "神奇寶貝", "角色人孔蓋"),
+    "zh-CN": ("主导航", "地图", "宝可梦", "角色井盖"),
+    "ko": ("메인 내비게이션", "지도", "포켓몬", "캐릭터 맨홀"),
 }
 
 
@@ -58,7 +55,7 @@ def inject(html: str, asset_base: str = "./", page_base: str | None = None) -> s
     labels = NAV_LABELS[_language(html)]
     substitutions = dict(
         zip(
-            ("nav_aria", "nav_top", "nav_map", "nav_summary", "nav_pokemon", "nav_nearby", "nav_character"),
+            ("nav_aria", "nav_map", "nav_pokemon", "nav_character"),
             labels,
         )
     )

--- a/apps/scraper/inject_site_header.py
+++ b/apps/scraper/inject_site_header.py
@@ -25,7 +25,7 @@ HEADER_TEMPLATE = """<header class="site-header">
 </header>"""
 
 NAV_LABELS = {
-    "ja": ("メインナビゲーション", "地図", "ポケモン", "キャラマンホール"),
+    "ja": ("メインナビゲーション", "マップ", "ポケモン", "キャラマンホール"),
     "en": ("Main navigation", "Map", "Pokémon", "Character Manholes"),
     "zh-TW": ("主導覽", "地圖", "神奇寶貝", "角色人孔蓋"),
     "zh-CN": ("主导航", "地图", "宝可梦", "角色井盖"),

--- a/apps/scraper/test_inject_site_header.py
+++ b/apps/scraper/test_inject_site_header.py
@@ -16,6 +16,7 @@ class InjectSiteHeaderTest(unittest.TestCase):
         result = inject("<!doctype html><html><head></head><body><main></main></body></html>")
         self.assertIn('href="./assets/site-header.css"', result)
         self.assertIn('class="site-header"', result)
+        self.assertIn('href="./map.html">マップ</a>', result)
         self.assertIn('<body class="has-site-header">', result)
 
     def test_preserves_existing_body_classes(self):

--- a/apps/scraper/test_inject_site_header.py
+++ b/apps/scraper/test_inject_site_header.py
@@ -37,7 +37,9 @@ class InjectSiteHeaderTest(unittest.TestCase):
         result = inject(html, asset_base="../../../", page_base="../../")
         self.assertIn('href="../../../assets/site-header.css"', result)
         self.assertIn('href="../../map.html">Map</a>', result)
-        self.assertIn('href="../../../nearby.html">Nearby</a>', result)
+        self.assertIn('href="../../pokemon/">Pokémon</a>', result)
+        self.assertIn('href="../../../gmanhole_map.html">Character Manholes</a>', result)
+        self.assertEqual(result.count('class="site-header__link"'), 3)
 
 
 if __name__ == "__main__":

--- a/apps/web/assets/site-header.css
+++ b/apps/web/assets/site-header.css
@@ -76,30 +76,28 @@
 }
 
 @media (max-width: 720px) {
-  :root { --site-header-height: 71px; }
+  :root { --site-header-height: 53px; }
 
   .site-header__inner {
-    min-height: 0;
-    padding: 8px 10px 7px;
-    display: block;
+    min-height: 52px;
+    padding: 8px 10px;
+    gap: 8px;
   }
 
   .site-header__brand {
-    justify-content: center;
-    margin-bottom: 7px;
+    flex: 0 0 auto;
   }
 
   .site-header__brand-name { font-size: 16px; }
 
   .site-header__nav {
-    display: grid;
-    grid-template-columns: repeat(6, minmax(0, 1fr));
-    gap: 3px;
-    margin: 0;
+    gap: 4px;
+    min-width: 0;
+    margin-left: auto;
   }
 
   .site-header__link {
-    padding: 6px 1px;
+    padding: 6px 5px;
     overflow: hidden;
     border-radius: 7px;
     background: #eeeaf7;

--- a/apps/web/assets/top-page.css
+++ b/apps/web/assets/top-page.css
@@ -118,24 +118,24 @@ a { color: inherit; text-decoration: none; }
 
 @media (max-width: 959px) {
   .top-app-bar-inner {
-    flex-wrap: wrap;
-    gap: 7px 10px;
-    padding: 8px 10px 7px;
+    gap: 8px;
+    padding: 8px 10px;
   }
 
-  .top-brand { flex: 1 1 auto; }
-  .top-nav-right { display: contents; }
+  .top-brand { flex: 0 0 auto; }
+  .top-nav-right {
+    display: block;
+    min-width: 0;
+    margin-left: auto;
+  }
 
   .top-nav {
-    order: 3;
-    flex: 0 0 100%;
-    display: grid;
-    grid-template-columns: repeat(6, minmax(0, 1fr));
-    gap: 3px;
+    display: flex;
+    gap: 4px;
   }
 
   .top-nav-link {
-    padding: 6px 1px;
+    padding: 6px 5px;
     overflow: hidden;
     border-radius: 7px;
     background: var(--top-purple-pale);

--- a/apps/web/gmanhole_map.html
+++ b/apps/web/gmanhole_map.html
@@ -166,14 +166,10 @@
       </a>
       <div class="top-nav-right">
         <nav class="top-nav" aria-label="メインナビ">
-          <a class="top-nav-link" href="./" onclick="trackEvent('click_nav',{nav:'home',from:'gmanhole_map'})">トップ</a>
           <a class="top-nav-link" href="map.html" onclick="trackEvent('click_nav',{nav:'map',from:'gmanhole_map'})">全国マップ</a>
-          <a class="top-nav-link" href="summary/" onclick="trackEvent('click_nav',{nav:'summary',from:'gmanhole_map'})">全国一覧</a>
           <a class="top-nav-link" href="pokemon/" onclick="trackEvent('click_nav',{nav:'pokemon',from:'gmanhole_map'})">ポケモン</a>
-          <a class="top-nav-link" href="nearby.html" onclick="trackEvent('click_nav',{nav:'nearby',from:'gmanhole_map'})">近くのマンホール</a>
           <a class="top-nav-link top-nav-link--active" href="gmanhole_map.html" aria-current="page">キャラマンホール</a>
         </nav>
-        <span class="top-count-badge">キャラMH <b id="appbar-count">—</b> 枚</span>
       </div>
     </div>
   </header>

--- a/apps/web/gmanhole_map.html
+++ b/apps/web/gmanhole_map.html
@@ -166,7 +166,7 @@
       </a>
       <div class="top-nav-right">
         <nav class="top-nav" aria-label="メインナビ">
-          <a class="top-nav-link" href="map.html" onclick="trackEvent('click_nav',{nav:'map',from:'gmanhole_map'})">全国マップ</a>
+          <a class="top-nav-link" href="map.html" onclick="trackEvent('click_nav',{nav:'map',from:'gmanhole_map'})">マップ</a>
           <a class="top-nav-link" href="pokemon/" onclick="trackEvent('click_nav',{nav:'pokemon',from:'gmanhole_map'})">ポケモン</a>
           <a class="top-nav-link top-nav-link--active" href="gmanhole_map.html" aria-current="page">キャラマンホール</a>
         </nav>

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -92,23 +92,17 @@
   <!-- ===== APP BAR ===== -->
   <header class="top-app-bar">
     <div class="top-app-bar-inner">
-      <div class="top-brand">
+      <a class="top-brand" href="./" onclick="trackEvent('click_nav',{nav:'top'})">
         <span class="sec-num nav-num"></span>
         <span class="brand-name">ポケふた</span>
         <span class="brand-sub">DATABASE</span>
-      </div>
+      </a>
       <div class="top-nav-right">
         <nav class="top-nav" aria-label="メインナビ">
-          <a class="top-nav-link" href="./" onclick="trackEvent('click_nav',{nav:'top'})">トップ</a>
           <a class="top-nav-link" href="map.html" onclick="trackEvent('click_nav',{nav:'map'})">地図</a>
-          <a class="top-nav-link" href="summary/" onclick="trackEvent('click_nav',{nav:'summary'})">全国一覧</a>
           <a class="top-nav-link" href="pokemon/" onclick="trackEvent('click_nav',{nav:'pokemon'})">ポケモン</a>
-          <a class="top-nav-link" href="nearby.html" onclick="trackEvent('click_nav',{nav:'nearby'})">現在地付近</a>
-          <a class="top-nav-link" href="gmanhole_map.html" onclick="trackEvent('click_nav',{nav:'character'})">キャラMH</a>
+          <a class="top-nav-link" href="gmanhole_map.html" onclick="trackEvent('click_nav',{nav:'character'})">キャラマンホール</a>
         </nav>
-        <a href="map.html" class="top-count-badge" id="top-count-badge" onclick="trackEvent('click_appbar_count')">
-          全国 <b id="appbar-count">—</b> 枚
-        </a>
       </div>
     </div>
   </header>

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -99,7 +99,7 @@
       </a>
       <div class="top-nav-right">
         <nav class="top-nav" aria-label="メインナビ">
-          <a class="top-nav-link" href="map.html" onclick="trackEvent('click_nav',{nav:'map'})">地図</a>
+          <a class="top-nav-link" href="map.html" onclick="trackEvent('click_nav',{nav:'map'})">マップ</a>
           <a class="top-nav-link" href="pokemon/" onclick="trackEvent('click_nav',{nav:'pokemon'})">ポケモン</a>
           <a class="top-nav-link" href="gmanhole_map.html" onclick="trackEvent('click_nav',{nav:'character'})">キャラマンホール</a>
         </nav>

--- a/apps/web/index.template.html
+++ b/apps/web/index.template.html
@@ -95,23 +95,17 @@
   <!-- ===== APP BAR ===== -->
   <header class="top-app-bar">
     <div class="top-app-bar-inner">
-      <div class="top-brand">
+      <a class="top-brand" href="%%BASE_PATH%%index.html" onclick="trackEvent('click_nav',{nav:'top'})">
         <span class="sec-num nav-num"></span>
         <span class="brand-name">ポケふた</span>
         <span class="brand-sub">DATABASE</span>
-      </div>
+      </a>
       <div class="top-nav-right">
         <nav class="top-nav" aria-label="%%NAV_ARIA%%">
-          <a class="top-nav-link" href="%%BASE_PATH%%index.html" onclick="trackEvent('click_nav',{nav:'top'})">%%NAV_TOP%%</a>
           <a class="top-nav-link" href="%%BASE_PATH%%map.html" onclick="trackEvent('click_nav',{nav:'map'})">%%NAV_MAP%%</a>
-          <a class="top-nav-link" href="%%BASE_PATH%%summary/" onclick="trackEvent('click_nav',{nav:'summary'})">%%NAV_SUMMARY%%</a>
           <a class="top-nav-link" href="%%BASE_PATH%%pokemon/" onclick="trackEvent('click_nav',{nav:'pokemon'})">%%NAV_POKEMON%%</a>
-          <a class="top-nav-link" href="%%BASE_PATH%%nearby.html" onclick="trackEvent('click_nav',{nav:'nearby'})">%%NAV_NEARBY%%</a>
           <a class="top-nav-link" href="%%BASE_PATH%%gmanhole_map.html" onclick="trackEvent('click_nav',{nav:'character'})">%%NAV_CHARACTER%%</a>
         </nav>
-        <a href="%%BASE_PATH%%map.html" class="top-count-badge" id="top-count-badge" onclick="trackEvent('click_appbar_count')">
-          %%APPBAR_PREFIX%%<b id="appbar-count">—</b>%%APPBAR_SUFFIX%%
-        </a>
       </div>
     </div>
   </header>


### PR DESCRIPTION
## 変更内容

- ポケふたロゴをトップページへのリンクに変更
- ヘッダーリンクを「マップ」「ポケモン」「キャラマンホール」の3つに整理
- 枚数バッジと重複するTOPリンクを削除
- トップ、多言語生成ページ、キャラマンホールページを同じ1行構成に統一
- モバイル地図の高さ計算を1行ヘッダーに合わせて調整

## 確認内容

- `python3 -m unittest apps/scraper/test_inject_site_header.py`
- `python3 tools/build_i18n.py`
- 共通ヘッダー注入の冪等性確認
- 360px幅でトップ・英語地図・キャラマンホールを確認（1行表示、横はみ出しなし）
- `git diff --check`

## 補足

`/import-photos` はローカルにR2認証情報がないため実行していません。写真データの変更は含みません。
