### PR TITLE
[codex] 共通ヘッダーのページ余白を統一

### DIFF
--- a/apps/web/assets/site-header.css
+++ b/apps/web/assets/site-header.css
@@ -1,9 +1,16 @@
 /* Shared site header, injected into every built HTML page. */
 :root { --site-header-height: 52px; }
 
+body.has-site-header {
+  padding-top: 0 !important;
+  overflow-x: clip;
+}
+
 .site-header {
   position: relative;
   z-index: 10000;
+  width: 100vw;
+  margin-inline: calc(50% - 50vw);
   flex: 0 0 auto;
   background: rgba(250, 246, 236, .96);
   border-bottom: 1px solid #ece5d2;

--- a/apps/web/assets/site-header.css
+++ b/apps/web/assets/site-header.css
@@ -2,7 +2,8 @@
 :root { --site-header-height: 52px; }
 
 body.has-site-header {
-  padding-top: 0 !important;
+  padding-top: 0;
+  overflow-x: hidden;
   overflow-x: clip;
 }
 


### PR DESCRIPTION
## 変更内容

- `body.has-site-header` の上paddingを解除し、共通ヘッダーを画面上端へ揃える
- 共通ヘッダーをviewport全幅にし、本文の左右paddingに影響されないようにする
- `overflow-x: clip` で全幅化による横スクロールを防止

## 背景

`/` はbody paddingが0ですが、`map.html` や `gmanhole_map.html` はデスクトップ時に16pxのbody paddingがあり、共通ヘッダーまで上・左右へ16px内側に表示されていました。

## 影響

本文の左右paddingは維持したまま、全ページの共通ヘッダーが画面上端・全幅で揃います。

## 確認

- `python3 -m unittest apps.scraper.test_inject_site_header`（7 tests passed）
- `/` と `map.html` でヘッダーの top / left / right がすべて0px
- 横方向のoverflowなし
- `git diff --check` 成功
