### PR TITLE
feat: ヘッダーに「スタンプ帳」リンク追加、表示名を pokefuta.com と統一

### DIFF
--- a/apps/scraper/inject_site_header.py
+++ b/apps/scraper/inject_site_header.py
@@ -20,6 +20,7 @@ HEADER_TEMPLATE = """<header class="site-header">
       <a class="site-header__link" href="{page_base}map.html">{nav_map}</a>
       <a class="site-header__link" href="{page_base}pokemon/">{nav_pokemon}</a>
       <a class="site-header__link" href="{asset_base}gmanhole_map.html">{nav_character}</a>
+      <a class="site-header__link" href="https://pokefuta.com/visits">{nav_stamp}</a>
       <a class="site-header__link" data-login-link data-login-page="{asset_base}login.html" href="https://pokefuta.com/login?from=data">{nav_login}</a>
     </nav>
   </div>
@@ -27,11 +28,11 @@ HEADER_TEMPLATE = """<header class="site-header">
 <script src="{asset_base}assets/session-badge.js" defer></script>"""
 
 NAV_LABELS = {
-    "ja": ("メインナビゲーション", "マップ", "ポケモン", "キャラマンホール", "ログイン"),
-    "en": ("Main navigation", "Map", "Pokémon", "Character Manholes", "Login"),
-    "zh-TW": ("主導覽", "地圖", "神奇寶貝", "角色人孔蓋", "登入"),
-    "zh-CN": ("主导航", "地图", "宝可梦", "角色井盖", "登录"),
-    "ko": ("메인 내비게이션", "지도", "포켓몬", "캐릭터 맨홀", "로그인"),
+    "ja": ("メインナビゲーション", "マップ", "ポケモン", "キャラマンホール", "スタンプ帳", "ログイン"),
+    "en": ("Main navigation", "Map", "Pokémon", "Character Manholes", "Stamp Book", "Login"),
+    "zh-TW": ("主導覽", "地圖", "神奇寶貝", "角色人孔蓋", "集章冊", "登入"),
+    "zh-CN": ("主导航", "地图", "宝可梦", "角色井盖", "集章册", "登录"),
+    "ko": ("메인 내비게이션", "지도", "포켓몬", "캐릭터 맨홀", "스탬프북", "로그인"),
 }
 
 
@@ -57,7 +58,7 @@ def inject(html: str, asset_base: str = "./", page_base: str | None = None) -> s
     labels = NAV_LABELS[_language(html)]
     substitutions = dict(
         zip(
-            ("nav_aria", "nav_map", "nav_pokemon", "nav_character", "nav_login"),
+            ("nav_aria", "nav_map", "nav_pokemon", "nav_character", "nav_stamp", "nav_login"),
             labels,
         )
     )

--- a/apps/scraper/test_inject_site_header.py
+++ b/apps/scraper/test_inject_site_header.py
@@ -42,13 +42,15 @@ class InjectSiteHeaderTest(unittest.TestCase):
         self.assertIn('href="../../../gmanhole_map.html">Character Manholes</a>', result)
         self.assertIn('data-login-page="../../../login.html"', result)
         self.assertIn('href="https://pokefuta.com/login?from=data">Login</a>', result)
+        self.assertIn('href="https://pokefuta.com/visits">Stamp Book</a>', result)
         self.assertIn('src="../../../assets/session-badge.js"', result)
-        self.assertEqual(result.count('class="site-header__link"'), 4)
+        self.assertEqual(result.count('class="site-header__link"'), 5)
 
     def test_injects_login_link_for_japanese_page(self):
         result = inject("<!doctype html><html><head></head><body><main></main></body></html>")
         self.assertIn('data-login-page="./login.html"', result)
         self.assertIn('href="https://pokefuta.com/login?from=data">ログイン</a>', result)
+        self.assertIn('href="https://pokefuta.com/visits">スタンプ帳</a>', result)
         self.assertIn('<script src="./assets/session-badge.js" defer></script>', result)
 
 

--- a/apps/web/assets/session-badge.js
+++ b/apps/web/assets/session-badge.js
@@ -67,10 +67,16 @@
     }
   }
 
+  // pokefuta.com の getDisplayName（Header.tsx / PCShell.tsx）と同じ優先順位:
+  // display_name → email前半 → 'トレーナー'
   function displayName(user) {
     var meta = user.user_metadata || {};
-    var name = meta.name || meta.full_name || (user.email ? user.email.split('@')[0] : '');
-    if (!name) return 'アカウント';
+    var name =
+      meta.display_name ||
+      meta.name ||
+      meta.full_name ||
+      (user.email ? user.email.split('@')[0] : '');
+    if (!name) return 'トレーナー';
     return name.length > 10 ? name.slice(0, 9) + '…' : name;
   }
 

--- a/apps/web/assets/session-badge.js
+++ b/apps/web/assets/session-badge.js
@@ -71,11 +71,7 @@
   // display_name → email前半 → 'トレーナー'
   function displayName(user) {
     var meta = user.user_metadata || {};
-    var name =
-      meta.display_name ||
-      meta.name ||
-      meta.full_name ||
-      (user.email ? user.email.split('@')[0] : '');
+    var name = meta.display_name || (user.email ? user.email.split('@')[0] : '');
     if (!name) return 'トレーナー';
     return name.length > 10 ? name.slice(0, 9) + '…' : name;
   }

--- a/apps/web/gmanhole_map.html
+++ b/apps/web/gmanhole_map.html
@@ -41,6 +41,7 @@
   <link rel="stylesheet" href="./assets/map.css" />
   <link rel="stylesheet" href="./assets/pokefuta-map.css?v=20260705-gmanhole-sheet" />
   <link rel="stylesheet" href="./assets/top-page.css?v=20260623d" />
+  <script src="./assets/session-badge.js" defer></script>
   <style>
     /* Franchise specific marker styling (DivIcon) */
     .fr-marker { width:30px; height:30px; border-radius:50%; display:flex; align-items:center; justify-content:center; font-size:15px; font-weight:600; color:#fff; box-shadow:0 0 0 2px #fff, 0 2px 6px rgba(0,0,0,.35); }
@@ -169,6 +170,8 @@
           <a class="top-nav-link" href="map.html" onclick="trackEvent('click_nav',{nav:'map',from:'gmanhole_map'})">マップ</a>
           <a class="top-nav-link" href="pokemon/" onclick="trackEvent('click_nav',{nav:'pokemon',from:'gmanhole_map'})">ポケモン</a>
           <a class="top-nav-link top-nav-link--active" href="gmanhole_map.html" aria-current="page">キャラマンホール</a>
+          <a class="top-nav-link" href="https://pokefuta.com/visits" onclick="trackEvent('click_nav',{nav:'stamp',from:'gmanhole_map'})">スタンプ帳</a>
+          <a class="top-nav-link" data-login-link data-login-page="./login.html" href="https://pokefuta.com/login?from=data" onclick="trackEvent('click_nav',{nav:'login',from:'gmanhole_map'})">ログイン</a>
         </nav>
       </div>
     </div>

--- a/apps/web/i18n/strings.en.json
+++ b/apps/web/i18n/strings.en.json
@@ -194,6 +194,7 @@
   "NAV_THEME": "Themes",
   "NAV_RANKING": "Ranking",
   "NAV_CHARACTER": "Character Manholes",
+  "NAV_STAMP": "Stamp Book",
   "NAV_LOGIN": "Login",
   "NAV_NEARBY": "Nearby",
   "TOP_H1": "Explore Poké Lids across Japan",

--- a/apps/web/i18n/strings.ja.json
+++ b/apps/web/i18n/strings.ja.json
@@ -23,6 +23,7 @@
   "NAV_SUMMARY": "全国一覧",
   "NAV_NEARBY": "現在地付近",
   "NAV_CHARACTER": "キャラMH",
+  "NAV_STAMP": "スタンプ帳",
   "NAV_LOGIN": "ログイン",
   "PREF_DIR_HEADING": "都道府県別のポケふた一覧",
   "PREF_DIR_DESC": "旅行先やお出かけ先の近くにあるポケふたを、都道府県別に探せます。",

--- a/apps/web/i18n/strings.ko.json
+++ b/apps/web/i18n/strings.ko.json
@@ -194,6 +194,7 @@
   "NAV_THEME": "테마",
   "NAV_RANKING": "랭킹",
   "NAV_CHARACTER": "캐릭터 맨홀",
+  "NAV_STAMP": "스탬프북",
   "NAV_LOGIN": "로그인",
   "NAV_NEARBY": "내 주변",
   "TOP_H1": "일본 전국 포케후타 탐색",

--- a/apps/web/i18n/strings.zh-CN.json
+++ b/apps/web/i18n/strings.zh-CN.json
@@ -194,6 +194,7 @@
   "NAV_THEME": "主题",
   "NAV_RANKING": "排行榜",
   "NAV_CHARACTER": "角色井盖",
+  "NAV_STAMP": "集章册",
   "NAV_LOGIN": "登录",
   "NAV_NEARBY": "附近",
   "TOP_H1": "探索日本全国宝可梦井盖",

--- a/apps/web/i18n/strings.zh-TW.json
+++ b/apps/web/i18n/strings.zh-TW.json
@@ -194,6 +194,7 @@
   "NAV_THEME": "主題",
   "NAV_RANKING": "排行榜",
   "NAV_CHARACTER": "角色人孔蓋",
+  "NAV_STAMP": "集章冊",
   "NAV_LOGIN": "登入",
   "NAV_NEARBY": "附近",
   "TOP_H1": "探索全日本神奇寶貝人孔蓋",

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -103,6 +103,7 @@
           <a class="top-nav-link" href="map.html" onclick="trackEvent('click_nav',{nav:'map'})">マップ</a>
           <a class="top-nav-link" href="pokemon/" onclick="trackEvent('click_nav',{nav:'pokemon'})">ポケモン</a>
           <a class="top-nav-link" href="gmanhole_map.html" onclick="trackEvent('click_nav',{nav:'character'})">キャラマンホール</a>
+          <a class="top-nav-link" href="https://pokefuta.com/visits" onclick="trackEvent('click_nav',{nav:'stamp'})">スタンプ帳</a>
           <a class="top-nav-link" data-login-link data-login-page="./login.html" href="https://pokefuta.com/login?from=data" onclick="trackEvent('click_nav',{nav:'login'})">ログイン</a>
         </nav>
       </div>

--- a/apps/web/index.template.html
+++ b/apps/web/index.template.html
@@ -106,6 +106,7 @@
           <a class="top-nav-link" href="%%BASE_PATH%%map.html" onclick="trackEvent('click_nav',{nav:'map'})">%%NAV_MAP%%</a>
           <a class="top-nav-link" href="%%BASE_PATH%%pokemon/" onclick="trackEvent('click_nav',{nav:'pokemon'})">%%NAV_POKEMON%%</a>
           <a class="top-nav-link" href="%%BASE_PATH%%gmanhole_map.html" onclick="trackEvent('click_nav',{nav:'character'})">%%NAV_CHARACTER%%</a>
+          <a class="top-nav-link" href="https://pokefuta.com/visits" onclick="trackEvent('click_nav',{nav:'stamp'})">%%NAV_STAMP%%</a>
           <a class="top-nav-link" data-login-link data-login-page="%%BASE_PATH%%login.html" href="https://pokefuta.com/login?from=data" onclick="trackEvent('click_nav',{nav:'login'})">%%NAV_LOGIN%%</a>
         </nav>
       </div>

--- a/apps/web/login.html
+++ b/apps/web/login.html
@@ -59,6 +59,7 @@
     .login-error { color: #b91c1c; font-size: 0.85rem; margin: 12px 0 0; min-height: 1.2em; }
     .login-status { font-size: 0.95rem; }
     .login-status strong { word-break: break-all; }
+    .login-sub { color: var(--pf-muted); font-size: 0.8rem; margin: 4px 0 0; word-break: break-all; }
     .login-links { margin-top: 20px; font-size: 0.85rem; color: var(--pf-muted); line-height: 1.8; }
     .login-links a { color: var(--pf-red); }
     .hidden { display: none; }
@@ -72,7 +73,8 @@
     <div class="login-card" id="card-loading">確認中…</div>
 
     <div class="login-card hidden" id="card-signed-in">
-      <p class="login-status">✅ ログイン中：<strong id="user-email"></strong></p>
+      <p class="login-status">✅ ログイン中：<strong id="user-name"></strong></p>
+      <p class="login-sub" id="user-email"></p>
       <button type="button" id="btn-mypage">訪問記録を見る（pokefuta.com）</button>
       <button type="button" class="secondary" id="btn-logout">ログアウト</button>
     </div>
@@ -104,9 +106,22 @@
       }
     };
 
+    // pokefuta.com の getDisplayName と同じ優先順位（session-badge.js と同じ）
+    const displayName = (user) => {
+      const meta = user.user_metadata || {};
+      return (
+        meta.display_name ||
+        meta.name ||
+        meta.full_name ||
+        (user.email ? user.email.split('@')[0] : '') ||
+        'トレーナー'
+      );
+    };
+
     async function render() {
       const user = await getUser();
       if (user) {
+        $('user-name').textContent = displayName(user);
         $('user-email').textContent = user.email || user.id;
         show('card-signed-in');
       } else {

--- a/apps/web/login.html
+++ b/apps/web/login.html
@@ -107,16 +107,8 @@
     };
 
     // pokefuta.com の getDisplayName と同じ優先順位（session-badge.js と同じ）
-    const displayName = (user) => {
-      const meta = user.user_metadata || {};
-      return (
-        meta.display_name ||
-        meta.name ||
-        meta.full_name ||
-        (user.email ? user.email.split('@')[0] : '') ||
-        'トレーナー'
-      );
-    };
+    const displayName = (user) =>
+      user.user_metadata?.display_name || user.email?.split('@')[0] || 'トレーナー';
 
     async function render() {
       const user = await getUser();


### PR DESCRIPTION
## 概要

pokefuta.com との薄い相互連携の data 側。pokefuta.com 側の対応 PR（「図鑑」→ data.pokefuta.com リンク追加）とセット。

- 全ページのヘッダーに「スタンプ帳」→ https://pokefuta.com/visits リンクを追加
  - 注入ヘッダー `inject_site_header.py` に nav_stamp を5言語で追加（map / login / nearby / pokemon 配下はデプロイ時に自動反映）
  - 手書きヘッダーの index.html / index.template.html（双子同期）/ gmanhole_map.html にも追加
  - i18n strings 全5言語に NAV_STAMP を追加
- gmanhole_map.html に欠落していたログインリンクと session-badge.js を追加
- 表示名ロジックを pokefuta.com の getDisplayName と統一: `user_metadata.display_name` 優先・fallback「トレーナー」（session-badge.js / login.html）。従来は name/full_name 優先・fallback「アカウント」で、同じユーザーでも両サイトで別名が出ていた
- login.html のログイン中カードを表示名＋メール併記に変更

## 検証

- `python3 -m unittest apps.scraper.test_inject_site_header` 6件パス
- `build_i18n.py` 全言語ビルド → 未置換 `%%KEY%%` なし
- dist へ `inject_site_header.py` 実行 → ko の map.html に 지도/포켓몬/캐릭터 맨홀/스탬프북/로그인 の5リンク確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)