### PR TITLE
[codex] ヘッダー名とログイン導線を簡潔化

### DIFF
--- a/apps/scraper/inject_site_header.py
+++ b/apps/scraper/inject_site_header.py
@@ -13,15 +13,13 @@ STYLESHEET_TEMPLATE = '<link rel="stylesheet" href="{asset_base}assets/site-head
 HEADER_TEMPLATE = """<header class="site-header">
   <div class="site-header__inner">
     <a class="site-header__brand" href="{page_base}">
-      <span class="site-header__brand-name">ポケふた</span>
-      <span class="site-header__brand-sub">DATABASE</span>
+      <span class="site-header__brand-name">ポケふた図鑑</span>
     </a>
     <nav class="site-header__nav" aria-label="{nav_aria}">
       <a class="site-header__link" href="{page_base}map.html">{nav_map}</a>
       <a class="site-header__link" href="{page_base}pokemon/">{nav_pokemon}</a>
       <a class="site-header__link" href="{asset_base}gmanhole_map.html">{nav_character}</a>
-      <a class="site-header__link" href="https://pokefuta.com/visits">{nav_stamp}</a>
-      <a class="site-header__link" data-login-link data-login-page="{asset_base}login.html" href="https://pokefuta.com/login?from=data">{nav_login}</a>
+      <a class="site-header__link" data-login-link data-stamp-page="https://pokefuta.com/visits" data-stamp-label="{nav_stamp}" href="https://pokefuta.com/login?from=data">{nav_login}</a>
     </nav>
   </div>
 </header>"""

--- a/apps/scraper/inject_site_header.py
+++ b/apps/scraper/inject_site_header.py
@@ -19,7 +19,7 @@ HEADER_TEMPLATE = """<header class="site-header">
       <a class="site-header__link" href="{page_base}map.html">{nav_map}</a>
       <a class="site-header__link" href="{page_base}pokemon/">{nav_pokemon}</a>
       <a class="site-header__link" href="{asset_base}gmanhole_map.html">{nav_character}</a>
-      <a class="site-header__link" data-login-link data-stamp-page="https://pokefuta.com/visits" data-stamp-label="{nav_stamp}" href="https://pokefuta.com/login?from=data">{nav_login}</a>
+      <a class="site-header__link" data-login-link data-nav-target="login" data-stamp-page="https://pokefuta.com/visits" data-stamp-label="{nav_stamp}" href="https://pokefuta.com/login?from=data">{nav_login}</a>
     </nav>
   </div>
 </header>"""

--- a/apps/scraper/test_inject_site_header.py
+++ b/apps/scraper/test_inject_site_header.py
@@ -16,6 +16,8 @@ class InjectSiteHeaderTest(unittest.TestCase):
         result = inject("<!doctype html><html><head></head><body><main></main></body></html>")
         self.assertIn('href="./assets/site-header.css"', result)
         self.assertIn('class="site-header"', result)
+        self.assertIn('class="site-header__brand-name">ポケふた図鑑</span>', result)
+        self.assertNotIn("DATABASE", result)
         self.assertIn('href="./map.html">マップ</a>', result)
         self.assertIn('<body class="has-site-header">', result)
 
@@ -39,7 +41,9 @@ class InjectSiteHeaderTest(unittest.TestCase):
         result = inject(legacy)
         self.assertIn('href="./assets/site-header.css"', result)
         self.assertIn('class="site-header"', result)
-        self.assertIn('data-login-page="./login.html"', result)
+        self.assertIn('data-stamp-page="https://pokefuta.com/visits"', result)
+        self.assertIn('data-stamp-label="スタンプ帳"', result)
+        self.assertEqual(result.count("https://pokefuta.com/visits"), 1)
         self.assertIn('<body class="has-site-header top-page">', result)
         self.assertNotIn("top-app-bar", result)
         self.assertNotIn("ページ固有ヘッダー", result)
@@ -57,17 +61,17 @@ class InjectSiteHeaderTest(unittest.TestCase):
         self.assertIn('href="../../map.html">Map</a>', result)
         self.assertIn('href="../../pokemon/">Pokémon</a>', result)
         self.assertIn('href="../../../gmanhole_map.html">Character Manholes</a>', result)
-        self.assertIn('data-login-page="../../../login.html"', result)
+        self.assertIn('data-stamp-page="https://pokefuta.com/visits"', result)
+        self.assertIn('data-stamp-label="Stamp Book"', result)
         self.assertIn('href="https://pokefuta.com/login?from=data">Login</a>', result)
-        self.assertIn('href="https://pokefuta.com/visits">Stamp Book</a>', result)
         self.assertIn('src="../../../assets/session-badge.js"', result)
-        self.assertEqual(result.count('class="site-header__link"'), 5)
+        self.assertEqual(result.count('class="site-header__link"'), 4)
 
     def test_injects_login_link_for_japanese_page(self):
         result = inject("<!doctype html><html><head></head><body><main></main></body></html>")
-        self.assertIn('data-login-page="./login.html"', result)
+        self.assertIn('data-stamp-page="https://pokefuta.com/visits"', result)
         self.assertIn('href="https://pokefuta.com/login?from=data">ログイン</a>', result)
-        self.assertIn('href="https://pokefuta.com/visits">スタンプ帳</a>', result)
+        self.assertEqual(result.count("https://pokefuta.com/visits"), 1)
         self.assertIn('<script src="./assets/session-badge.js" defer></script>', result)
 
 

--- a/apps/scraper/test_inject_site_header.py
+++ b/apps/scraper/test_inject_site_header.py
@@ -43,6 +43,7 @@ class InjectSiteHeaderTest(unittest.TestCase):
         self.assertIn('class="site-header"', result)
         self.assertIn('data-stamp-page="https://pokefuta.com/visits"', result)
         self.assertIn('data-stamp-label="スタンプ帳"', result)
+        self.assertIn('data-nav-target="login"', result)
         self.assertEqual(result.count("https://pokefuta.com/visits"), 1)
         self.assertIn('<body class="has-site-header top-page">', result)
         self.assertNotIn("top-app-bar", result)

--- a/apps/web/assets/session-badge.js
+++ b/apps/web/assets/session-badge.js
@@ -75,6 +75,7 @@
       var link = links[i];
       if (user) {
         link.textContent = link.getAttribute('data-stamp-label') || 'スタンプ帳';
+        link.setAttribute('data-nav-target', 'stamp');
         var stampPage = link.getAttribute('data-stamp-page');
         if (stampPage) link.href = stampPage;
       } else {

--- a/apps/web/assets/session-badge.js
+++ b/apps/web/assets/session-badge.js
@@ -6,10 +6,10 @@
 // （「PV に比例して Supabase を読ませない」方針）。
 // あくまで表示用の判定で、本当の認証はアプリ側のサーバーが行う。
 //
-// 対象要素: <a data-login-link data-login-page="<login.htmlへの相対パス>">
+// 対象要素: <a data-login-link data-stamp-page="..." data-stamp-label="...">
 //  - 未ログイン: href に現在ページへの redirect パラメータを付与
 //    （pokefuta.com/login がログイン後にこのページへ戻す）
-//  - ログイン中: 表示名に差し替え、リンク先を login.html（アカウントカード）に変更
+//  - ログイン中: 「スタンプ帳」に差し替え、スタンプ帳へリンク
 (function () {
   'use strict';
 
@@ -67,15 +67,6 @@
     }
   }
 
-  // pokefuta.com の getDisplayName（Header.tsx / PCShell.tsx）と同じ優先順位:
-  // display_name → email前半 → 'トレーナー'
-  function displayName(user) {
-    var meta = user.user_metadata || {};
-    var name = meta.display_name || (user.email ? user.email.split('@')[0] : '');
-    if (!name) return 'トレーナー';
-    return name.length > 10 ? name.slice(0, 9) + '…' : name;
-  }
-
   function apply() {
     var links = document.querySelectorAll('[data-login-link]');
     if (!links.length) return;
@@ -83,10 +74,9 @@
     for (var i = 0; i < links.length; i++) {
       var link = links[i];
       if (user) {
-        link.textContent = '👤 ' + displayName(user);
-        if (user.email) link.title = user.email;
-        var loginPage = link.getAttribute('data-login-page');
-        if (loginPage) link.href = loginPage;
+        link.textContent = link.getAttribute('data-stamp-label') || 'スタンプ帳';
+        var stampPage = link.getAttribute('data-stamp-page');
+        if (stampPage) link.href = stampPage;
       } else {
         try {
           var url = new URL(link.href);

--- a/apps/web/gmanhole_map.html
+++ b/apps/web/gmanhole_map.html
@@ -162,16 +162,14 @@
   <header class="top-app-bar">
     <div class="top-app-bar-inner">
       <a class="top-brand" href="./" onclick="trackEvent('click_nav',{nav:'home',from:'gmanhole_map'})">
-        <span class="brand-name">ポケふた</span>
-        <span class="brand-sub">DATABASE</span>
+        <span class="brand-name">ポケふた図鑑</span>
       </a>
       <div class="top-nav-right">
         <nav class="top-nav" aria-label="メインナビ">
           <a class="top-nav-link" href="map.html" onclick="trackEvent('click_nav',{nav:'map',from:'gmanhole_map'})">マップ</a>
           <a class="top-nav-link" href="pokemon/" onclick="trackEvent('click_nav',{nav:'pokemon',from:'gmanhole_map'})">ポケモン</a>
           <a class="top-nav-link top-nav-link--active" href="gmanhole_map.html" aria-current="page">キャラマンホール</a>
-          <a class="top-nav-link" href="https://pokefuta.com/visits" onclick="trackEvent('click_nav',{nav:'stamp',from:'gmanhole_map'})">スタンプ帳</a>
-          <a class="top-nav-link" data-login-link data-login-page="./login.html" href="https://pokefuta.com/login?from=data" onclick="trackEvent('click_nav',{nav:'login',from:'gmanhole_map'})">ログイン</a>
+          <a class="top-nav-link" data-login-link data-stamp-page="https://pokefuta.com/visits" data-stamp-label="スタンプ帳" href="https://pokefuta.com/login?from=data" onclick="trackEvent('click_nav',{nav:'login',from:'gmanhole_map'})">ログイン</a>
         </nav>
       </div>
     </div>

--- a/apps/web/gmanhole_map.html
+++ b/apps/web/gmanhole_map.html
@@ -169,7 +169,7 @@
           <a class="top-nav-link" href="map.html" onclick="trackEvent('click_nav',{nav:'map',from:'gmanhole_map'})">マップ</a>
           <a class="top-nav-link" href="pokemon/" onclick="trackEvent('click_nav',{nav:'pokemon',from:'gmanhole_map'})">ポケモン</a>
           <a class="top-nav-link top-nav-link--active" href="gmanhole_map.html" aria-current="page">キャラマンホール</a>
-          <a class="top-nav-link" data-login-link data-stamp-page="https://pokefuta.com/visits" data-stamp-label="スタンプ帳" href="https://pokefuta.com/login?from=data" onclick="trackEvent('click_nav',{nav:'login',from:'gmanhole_map'})">ログイン</a>
+          <a class="top-nav-link" data-login-link data-nav-target="login" data-stamp-page="https://pokefuta.com/visits" data-stamp-label="スタンプ帳" href="https://pokefuta.com/login?from=data" onclick="trackEvent('click_nav',{nav:this.dataset.navTarget,from:'gmanhole_map'})">ログイン</a>
         </nav>
       </div>
     </div>

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -102,7 +102,7 @@
           <a class="top-nav-link" href="map.html" onclick="trackEvent('click_nav',{nav:'map'})">マップ</a>
           <a class="top-nav-link" href="pokemon/" onclick="trackEvent('click_nav',{nav:'pokemon'})">ポケモン</a>
           <a class="top-nav-link" href="gmanhole_map.html" onclick="trackEvent('click_nav',{nav:'character'})">キャラマンホール</a>
-          <a class="top-nav-link" data-login-link data-stamp-page="https://pokefuta.com/visits" data-stamp-label="スタンプ帳" href="https://pokefuta.com/login?from=data" onclick="trackEvent('click_nav',{nav:'login'})">ログイン</a>
+          <a class="top-nav-link" data-login-link data-nav-target="login" data-stamp-page="https://pokefuta.com/visits" data-stamp-label="スタンプ帳" href="https://pokefuta.com/login?from=data" onclick="trackEvent('click_nav',{nav:this.dataset.navTarget})">ログイン</a>
         </nav>
       </div>
     </div>

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -95,16 +95,14 @@
     <div class="top-app-bar-inner">
       <a class="top-brand" href="./" onclick="trackEvent('click_nav',{nav:'top'})">
         <span class="sec-num nav-num"></span>
-        <span class="brand-name">ポケふた</span>
-        <span class="brand-sub">DATABASE</span>
+        <span class="brand-name">ポケふた図鑑</span>
       </a>
       <div class="top-nav-right">
         <nav class="top-nav" aria-label="メインナビ">
           <a class="top-nav-link" href="map.html" onclick="trackEvent('click_nav',{nav:'map'})">マップ</a>
           <a class="top-nav-link" href="pokemon/" onclick="trackEvent('click_nav',{nav:'pokemon'})">ポケモン</a>
           <a class="top-nav-link" href="gmanhole_map.html" onclick="trackEvent('click_nav',{nav:'character'})">キャラマンホール</a>
-          <a class="top-nav-link" href="https://pokefuta.com/visits" onclick="trackEvent('click_nav',{nav:'stamp'})">スタンプ帳</a>
-          <a class="top-nav-link" data-login-link data-login-page="./login.html" href="https://pokefuta.com/login?from=data" onclick="trackEvent('click_nav',{nav:'login'})">ログイン</a>
+          <a class="top-nav-link" data-login-link data-stamp-page="https://pokefuta.com/visits" data-stamp-label="スタンプ帳" href="https://pokefuta.com/login?from=data" onclick="trackEvent('click_nav',{nav:'login'})">ログイン</a>
         </nav>
       </div>
     </div>

--- a/apps/web/index.template.html
+++ b/apps/web/index.template.html
@@ -98,16 +98,14 @@
     <div class="top-app-bar-inner">
       <a class="top-brand" href="%%BASE_PATH%%index.html" onclick="trackEvent('click_nav',{nav:'top'})">
         <span class="sec-num nav-num"></span>
-        <span class="brand-name">ポケふた</span>
-        <span class="brand-sub">DATABASE</span>
+        <span class="brand-name">ポケふた図鑑</span>
       </a>
       <div class="top-nav-right">
         <nav class="top-nav" aria-label="%%NAV_ARIA%%">
           <a class="top-nav-link" href="%%BASE_PATH%%map.html" onclick="trackEvent('click_nav',{nav:'map'})">%%NAV_MAP%%</a>
           <a class="top-nav-link" href="%%BASE_PATH%%pokemon/" onclick="trackEvent('click_nav',{nav:'pokemon'})">%%NAV_POKEMON%%</a>
           <a class="top-nav-link" href="%%BASE_PATH%%gmanhole_map.html" onclick="trackEvent('click_nav',{nav:'character'})">%%NAV_CHARACTER%%</a>
-          <a class="top-nav-link" href="https://pokefuta.com/visits" onclick="trackEvent('click_nav',{nav:'stamp'})">%%NAV_STAMP%%</a>
-          <a class="top-nav-link" data-login-link data-login-page="%%BASE_PATH%%login.html" href="https://pokefuta.com/login?from=data" onclick="trackEvent('click_nav',{nav:'login'})">%%NAV_LOGIN%%</a>
+          <a class="top-nav-link" data-login-link data-stamp-page="https://pokefuta.com/visits" data-stamp-label="%%NAV_STAMP%%" href="https://pokefuta.com/login?from=data" onclick="trackEvent('click_nav',{nav:'login'})">%%NAV_LOGIN%%</a>
         </nav>
       </div>
     </div>

--- a/apps/web/index.template.html
+++ b/apps/web/index.template.html
@@ -105,7 +105,7 @@
           <a class="top-nav-link" href="%%BASE_PATH%%map.html" onclick="trackEvent('click_nav',{nav:'map'})">%%NAV_MAP%%</a>
           <a class="top-nav-link" href="%%BASE_PATH%%pokemon/" onclick="trackEvent('click_nav',{nav:'pokemon'})">%%NAV_POKEMON%%</a>
           <a class="top-nav-link" href="%%BASE_PATH%%gmanhole_map.html" onclick="trackEvent('click_nav',{nav:'character'})">%%NAV_CHARACTER%%</a>
-          <a class="top-nav-link" data-login-link data-stamp-page="https://pokefuta.com/visits" data-stamp-label="%%NAV_STAMP%%" href="https://pokefuta.com/login?from=data" onclick="trackEvent('click_nav',{nav:'login'})">%%NAV_LOGIN%%</a>
+          <a class="top-nav-link" data-login-link data-nav-target="login" data-stamp-page="https://pokefuta.com/visits" data-stamp-label="%%NAV_STAMP%%" href="https://pokefuta.com/login?from=data" onclick="trackEvent('click_nav',{nav:this.dataset.navTarget})">%%NAV_LOGIN%%</a>
         </nav>
       </div>
     </div>


### PR DESCRIPTION
## 変更内容

- ヘッダー名を「ポケふた DATABASE」から「ポケふた図鑑」へ短縮
- 常時表示されていた「スタンプ帳」リンクを削除
- 未ログイン時は「ログイン」、ログイン済みの場合だけ「スタンプ帳」を表示
- ログイン済みのユーザー名・メールアドレス表示を削除
- 共通ヘッダー生成テストを新仕様へ更新

## 目的

モバイルを含むヘッダーの横幅を抑え、ログイン状態に応じた導線を重複なく分かりやすく表示するためです。

## 動作

- 未ログイン: 「ログイン」→ pokefuta.com のログイン画面
- ログイン済み: 「スタンプ帳」→ pokefuta.com/visits

## 確認

- `node --check apps/web/assets/session-badge.js`
- `python3 -m unittest apps/scraper/test_inject_site_header.py`
- `python3 tools/build_i18n.py`
- `git diff --check`
