### PR TITLE
feat: マンホール詳細に「みんなの写真」ギャラリー追加（複数写真対応）

### DIFF
--- a/.claude/commands/import-photos.md
+++ b/.claude/commands/import-photos.md
@@ -11,4 +11,9 @@ Prerequisite: `.env.local` must contain the following variables:
 - `R2_ENDPOINT` (or `R2_PUBLIC_URL`)
 - `R2_BUCKET` (optional)
 
-Then report the summary line (imported / skipped / failed counts) and confirm the file count in `dataset/manhole/image/`.
+Then report the summary line (imported / skipped / failed / gallery_imported / gallery_kept / gallery_removed counts) and confirm the file count in `dataset/manhole/image/`.
+
+Notes:
+- 代表写真は `{id}_latest.jpeg`、ギャラリー写真（photos JSON の `gallery` 配列、代表を除く）は `{id}_{photo_id先頭8桁}.jpeg` に保存される
+- 既存のギャラリーファイルは再ダウンロードされない（冪等）。エクスポートから外れた photo_id のファイルは自動削除される
+- 詳細仕様: `docs/MANHOLE_DETAIL_SPEC.md`

--- a/apps/scraper/generate_manhole_pages.py
+++ b/apps/scraper/generate_manhole_pages.py
@@ -13,6 +13,7 @@ import datetime
 import json
 import logging
 import math
+import re
 import sys
 from pathlib import Path
 from typing import Any, Optional
@@ -542,6 +543,34 @@ def generate_html(
             f"{credit_html}"
             f"{comment_html}"
             f"</div>"
+        )
+
+    # "みんなの写真" gallery: extra local thumbnails beyond the hero photo
+    gallery_html = ""
+    gallery_items = (photo.get("gallery_local") or []) if photo else []
+    if gallery_items:
+        thumbs = ""
+        for g in gallery_items:
+            g_credit = str(g.get("display_name") or "")[:20]
+            credit_span = (
+                f"<span class='gallery-credit'>📷 {escape(g_credit)}</span>" if g_credit else ""
+            )
+            thumbs += (
+                f"<figure class='gallery-item'>"
+                f"<img src=\"{escape(g['url'])}\" alt=\"{escape(h1)}の写真\" loading=\"lazy\">"
+                f"{credit_span}"
+                f"</figure>"
+            )
+        _gallery_more_onclick = _attr_json({"manhole_id": manhole_id, "prefecture": prefecture, "city": city})
+        gallery_html = (
+            f"<section class='gallery-section section-card'>"
+            f"<h2>みんなの写真</h2>"
+            f"<div class='gallery-grid'>{thumbs}</div>"
+            f"<a class='gallery-more' href='https://pokefuta.com/manhole/{quote(manhole_id)}'"
+            f" target='_blank' rel='noopener noreferrer'"
+            f" onclick=\"trackEvent('click_gallery_more', {_gallery_more_onclick})\">"
+            f"すべての写真を見る →</a>"
+            f"</section>"
         )
 
     # Per-manhole generated OGP takes priority over photo URL
@@ -1657,6 +1686,40 @@ def generate_html(
       font-weight: 600;
       color: #1d9bf0;
     }}
+    .gallery-grid {{
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+      gap: 8px;
+    }}
+    .gallery-item {{
+      margin: 0;
+      position: relative;
+    }}
+    .gallery-item img {{
+      width: 100%;
+      aspect-ratio: 1 / 1;
+      object-fit: cover;
+      border-radius: 10px;
+      display: block;
+    }}
+    .gallery-credit {{
+      position: absolute;
+      left: 6px;
+      bottom: 6px;
+      font-size: 10px;
+      color: #fff;
+      background: rgba(0, 0, 0, .45);
+      padding: 1px 6px;
+      border-radius: 8px;
+    }}
+    .gallery-more {{
+      display: inline-block;
+      margin-top: 10px;
+      font-size: 13px;
+      font-weight: 600;
+      color: #1a73e8;
+      text-decoration: none;
+    }}
   </style>
 </head>
 <body>
@@ -1665,6 +1728,8 @@ def generate_html(
     {back_btn_html}
 
     {hero_card_html}
+
+    {gallery_html}
 
     {visit_cta_html}
 
@@ -1754,8 +1819,24 @@ def generate_all_pages(
         local_url = id_to_image_url.get(manhole_id)
         norm_id = normalize_id(manhole_id)
         user_photo = photos.get(norm_id) or {}
+
+        # Gallery thumbnails beyond the hero (local files downloaded by
+        # import_latest_manhole_photos.py as {id}_{photo_id[:8]}.jpeg)
+        gallery_local: list[dict] = []
+        rep_photo_id = user_photo.get("photo_id")
+        for item in user_photo.get("gallery") or []:
+            if not isinstance(item, dict) or item.get("photo_id") == rep_photo_id:
+                continue
+            slug = re.sub(r"[^0-9a-fA-F]", "", str(item.get("photo_id") or ""))[:8].lower()
+            if len(slug) == 8 and (image_dir / f"{manhole_id}_{slug}.jpeg").exists():
+                gallery_local.append({
+                    "url": f"{BASE_URL}manhole/image/{manhole_id}_{slug}.jpeg",
+                    "display_name": item.get("display_name"),
+                    "shot_at": item.get("shot_at"),
+                })
+
         photo: Optional[dict] = (
-            {**user_photo, "url": local_url, "original_url": local_url}
+            {**user_photo, "url": local_url, "original_url": local_url, "gallery_local": gallery_local}
             if local_url else None
         )
 

--- a/apps/scraper/test_generate_manhole_pages_gallery.py
+++ b/apps/scraper/test_generate_manhole_pages_gallery.py
@@ -1,0 +1,87 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).with_name("generate_manhole_pages.py")
+SPEC = importlib.util.spec_from_file_location("generate_manhole_pages", MODULE_PATH)
+pages = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(pages)
+
+
+def _manhole() -> dict:
+    return {
+        "id": "1",
+        "prefecture": "鹿児島県",
+        "city": "指宿",
+        "address": "鹿児島県指宿市湊1丁目1-1",
+        "lat": 31.237194,
+        "lng": 130.642861,
+        "pokemons": ["イーブイ"],
+        "titles": [],
+        "tags": [],
+    }
+
+
+def _photo(gallery_local: list[dict]) -> dict:
+    local_url = f"{pages.BASE_URL}manhole/image/1_latest.jpeg"
+    return {
+        "photo_id": "rep11111-0000",
+        "url": local_url,
+        "original_url": local_url,
+        "display_name": "いろはす",
+        "shot_at": "2026-06-07T00:00:00+00:00",
+        "comment": None,
+        "gallery_local": gallery_local,
+    }
+
+
+def _generate(photo: dict | None) -> str:
+    return pages.generate_html(
+        manhole=_manhole(),
+        photo=photo,
+        pokemon_meta={},
+        nearby=[],
+        same_pref=[],
+        pref_total=0,
+        same_pokemon=[],
+        id_to_image_url={},
+    )
+
+
+class GallerySectionTests(unittest.TestCase):
+    def test_gallery_section_rendered_with_items(self):
+        gallery_local = [
+            {
+                "url": f"{pages.BASE_URL}manhole/image/1_abcd1234.jpeg",
+                "display_name": "たこ",
+                "shot_at": "2026-05-01T00:00:00+00:00",
+            },
+            {
+                "url": f"{pages.BASE_URL}manhole/image/1_ef012345.jpeg",
+                "display_name": None,
+                "shot_at": None,
+            },
+        ]
+        html = _generate(_photo(gallery_local))
+
+        self.assertIn("みんなの写真", html)
+        self.assertIn("manhole/image/1_abcd1234.jpeg", html)
+        self.assertIn("manhole/image/1_ef012345.jpeg", html)
+        self.assertIn("📷 たこ", html)
+        self.assertIn("https://pokefuta.com/manhole/1", html)
+        self.assertIn("すべての写真を見る", html)
+        self.assertIn("click_gallery_more", html)
+
+    def test_no_gallery_section_without_items(self):
+        html = _generate(_photo([]))
+        self.assertNotIn("みんなの写真", html)
+        self.assertNotIn("click_gallery_more", html)
+
+    def test_no_gallery_section_without_photo(self):
+        html = _generate(None)
+        self.assertNotIn("みんなの写真", html)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/tools/import_latest_manhole_photos.py
+++ b/apps/tools/import_latest_manhole_photos.py
@@ -329,6 +329,14 @@ def main() -> int:
                 slug = gallery_photo_slug(item.get("photo_id"))
                 if not slug:
                     continue
+                # Register as expected before resolving the URL so an existing
+                # local file survives cleanup even when this run can't reach it.
+                gallery_path = output_dir / f"{manhole_id}_{slug}.jpeg"
+                expected_gallery.add(gallery_path.name)
+                if gallery_path.exists():
+                    gallery_kept += 1
+                    continue
+
                 item_storage_key = get_storage_key(item)
                 if args.presign_r2 and item_storage_key:
                     item_url = presign_r2_get_object(item_storage_key, args.presign_expires)
@@ -339,12 +347,6 @@ def main() -> int:
                 item_url = validate_url(item_url) if item_url else None
                 if not item_url:
                     continue
-
-                gallery_path = output_dir / f"{manhole_id}_{slug}.jpeg"
-                expected_gallery.add(gallery_path.name)
-                if gallery_path.exists():
-                    gallery_kept += 1
-                    continue
                 try:
                     image = download_image(session, item_url, args.timeout)
                     cropped = crop_to_square(image, args.size)
@@ -353,7 +355,6 @@ def main() -> int:
                     print(f"imported gallery id={manhole_id} -> {gallery_path}")
                 except Exception as exc:
                     failed += 1
-                    expected_gallery.discard(gallery_path.name)
                     print(f"failed gallery id={manhole_id} url={redact_url(item_url)}: {exc}")
 
         if args.limit and attempted >= args.limit:

--- a/apps/tools/import_latest_manhole_photos.py
+++ b/apps/tools/import_latest_manhole_photos.py
@@ -216,6 +216,14 @@ def sanitize_id(raw_id: Any) -> str | None:
     return match.group(0) if match else None
 
 
+def gallery_photo_slug(photo_id: Any) -> str | None:
+    text = re.sub(r"[^0-9a-fA-F]", "", str(photo_id or ""))
+    return text[:8].lower() if len(text) >= 8 else None
+
+
+GALLERY_FILE_RE = re.compile(r"^(\d+)_([0-9a-f]{8})\.jpeg$")
+
+
 def validate_url(raw_url: str) -> str | None:
     parsed = urlparse(raw_url)
     if parsed.scheme not in {"http", "https"} or not parsed.netloc:
@@ -281,6 +289,9 @@ def main() -> int:
     attempted = 0
     skipped = 0
     failed = 0
+    gallery_imported = 0
+    gallery_kept = 0
+    expected_gallery: set[str] = set()
 
     for record in iter_records(payload):
         manhole_id = sanitize_id(pick_first(record, ID_KEYS))
@@ -309,10 +320,58 @@ def main() -> int:
             failed += 1
             print(f"failed id={manhole_id} url={redact_url(url)}: {exc}")
 
+        # Extra public shots beyond the hero (gallery entries share the hero pipeline)
+        gallery = record.get("gallery")
+        if isinstance(gallery, list):
+            for item in gallery:
+                if not isinstance(item, dict) or item.get("photo_id") == record.get("photo_id"):
+                    continue
+                slug = gallery_photo_slug(item.get("photo_id"))
+                if not slug:
+                    continue
+                item_storage_key = get_storage_key(item)
+                if args.presign_r2 and item_storage_key:
+                    item_url = presign_r2_get_object(item_storage_key, args.presign_expires)
+                elif args.public_base_url and item_storage_key:
+                    item_url = args.public_base_url.rstrip("/") + "/" + item_storage_key
+                else:
+                    item_url = item.get("url")
+                item_url = validate_url(item_url) if item_url else None
+                if not item_url:
+                    continue
+
+                gallery_path = output_dir / f"{manhole_id}_{slug}.jpeg"
+                expected_gallery.add(gallery_path.name)
+                if gallery_path.exists():
+                    gallery_kept += 1
+                    continue
+                try:
+                    image = download_image(session, item_url, args.timeout)
+                    cropped = crop_to_square(image, args.size)
+                    cropped.save(gallery_path, "JPEG", quality=args.quality, optimize=True, progressive=True)
+                    gallery_imported += 1
+                    print(f"imported gallery id={manhole_id} -> {gallery_path}")
+                except Exception as exc:
+                    failed += 1
+                    expected_gallery.discard(gallery_path.name)
+                    print(f"failed gallery id={manhole_id} url={redact_url(item_url)}: {exc}")
+
         if args.limit and attempted >= args.limit:
             break
 
-    print(f"summary imported={imported} skipped={skipped} failed={failed} output_dir={output_dir}")
+    removed = 0
+    if not args.limit:
+        for path in sorted(output_dir.iterdir()):
+            if GALLERY_FILE_RE.match(path.name) and path.name not in expected_gallery:
+                path.unlink()
+                removed += 1
+                print(f"removed stale gallery file {path.name}")
+
+    print(
+        f"summary imported={imported} skipped={skipped} failed={failed} "
+        f"gallery_imported={gallery_imported} gallery_kept={gallery_kept} gallery_removed={removed} "
+        f"output_dir={output_dir}"
+    )
     return 1 if failed else 0
 
 

--- a/docs/MANHOLE_DETAIL_SPEC.md
+++ b/docs/MANHOLE_DETAIL_SPEC.md
@@ -54,13 +54,13 @@ data.pokefuta.com（tracker）と pokefuta.com のマンホール詳細ページ
     "url": "...",
     "...": "...",
     "gallery": [
-      { "photo_id": "...", "url": "...", "shot_at": "...", "created_at": "...", "user_display_name": "..." }
+      { "photo_id": "...", "url": "...", "storage_key": "...", "shot_at": "...", "created_at": "...", "display_name": "..." }
     ]
   }
 }
 ```
 
-- 対象は `is_public = true` の写真のみ。`user_display_name` は display_name 優先（サイト全体の表示名ルールに合わせる）。
+- 対象は `is_public = true` の写真のみ。撮影者名のキーは既存の代表写真と同じ `display_name`（app_user の display_name を引く）。
 
 ### 取り込み拡張（tracker repo: `apps/tools/import_latest_manhole_photos.py`）
 

--- a/docs/MANHOLE_DETAIL_SPEC.md
+++ b/docs/MANHOLE_DETAIL_SPEC.md
@@ -1,0 +1,85 @@
+# マンホール詳細ページ 共通仕様
+
+data.pokefuta.com（tracker）と pokefuta.com のマンホール詳細ページを共通化するための仕様。
+
+## 方針
+
+- **未ログイン時の構成は tracker 側（現行の `generate_manhole_pages.py` の出力）に寄せる。**
+  未ログイン訪問者の意図（場所を調べる・行く・周辺を回遊する）に合い、SEO資産もこちらにあるため。
+- pokefuta.com の強みである「みんなの写真」ギャラリーと投稿CTAは共通仕様に取り込む（tracker へ逆輸入）。
+- ログイン時の体験（写真図鑑・訪問記録・コメント投稿）は pokefuta.com 専用レイヤーとして共通構成の上に重ねる。tracker はログインレイヤーを持たない。
+
+## 共通セクション構成（上から順）
+
+| # | セクション | 内容 | 未ログイン | pokefuta.com ログイン時 |
+|---|---|---|---|---|
+| 1 | 戻る導線 | 全国マップ／一覧へ戻る | 共通 | 共通 |
+| 2 | ヒーロー | 代表写真＋撮影者クレジット、タイトル(h1)、バッジ（レア・初期等）、タグ、統計チップ（県内枚数・30km圏内件数） | 共通 | 「あなたの写真」があればそちらを優先表示＋写真図鑑ステータス |
+| 3 | みんなの写真 | 公開写真ギャラリー（代表含め最大5枚）。全量は pokefuta.com へのリンクで誘導 | 共通（**新設**） | 自分の写真バッジ付き、「別の構図を追加する」CTA |
+| 4 | アクション | 「写真を投稿」（→ pokefuta.com、未ログインはログインCTA文言）／「Google Mapsで行き方を見る」 | 共通 | 投稿フォームへ直行 |
+| 5 | 設置場所 | 都道府県・市区町村・施設・住所 | 共通 | 共通 |
+| 6 | 登場ポケモン | 4言語名・タイプ・世代・「同じポケふたを見る」 | 共通 | 共通 |
+| 7 | 次に寄れるポケふた | 距離付き近隣リスト（5件） | 共通 | 共通 |
+| 8 | 同じポケモンのポケふた | 全国の同ポケモン設置 | 共通 | 共通 |
+| 9 | 県内のポケふた | 同県リスト | 共通 | 共通 |
+| 10 | リンク・共有 | X/LINE/Web Share、公式サイト、県マップ、全国マップ | 共通 | 共通 |
+| 11 | コメント | 閲覧＋投稿 | pokefuta.com のみ（閲覧可、投稿はログイン） | pokefuta.com のみ |
+
+- tracker は 1–10 を静的HTMLに焼き込む（現行どおり日次）。
+- pokefuta.com は同じ順序・同じ見出しで描画し、11 とログインレイヤーを追加する。
+
+## データソース対応表
+
+| セクション | tracker 側ソース | pokefuta.com 側ソース |
+|---|---|---|
+| ヒーロー・ギャラリー | `docs/latest-manhole-photos.json`（拡張版）＋ `dataset/manhole/image/` | `/api/manholes/[id]`（公開写真） |
+| タイトル・バッジ・タグ・設置場所 | `docs/pokefuta.ndjson` ＋ `manhole_titles.json` | `docs/api/manholes.json`（bake-app-data.yml 焼き込み） |
+| 登場ポケモン | `docs/pokemon_metadata.json` ＋ `pokemon_types_bilingual.json` | 同スナップショット or 既存API |
+| 近隣・同ポケモン・県内 | `docs/pokefuta.ndjson`（生成時に計算） | 同スナップショットから計算 |
+
+## 複数写真の扱い
+
+現行の `latest-manhole-photos.json` は 1マンホール=最新1枚。以下のとおり拡張する。
+
+### エクスポート拡張（pokefuta repo: `tools/export_latest_manhole_photos.py`）
+
+- `photos[manhole_id]` の既存フィールド（代表＝最新1枚）は**そのまま維持**（後方互換）。
+- 各エントリに `gallery` 配列を追加：代表を含む公開写真を新しい順に**最大5枚**。
+
+```jsonc
+"photos": {
+  "1": {
+    "manhole_id": 1,
+    "photo_id": "...",        // 代表（最新）— 従来どおり
+    "url": "...",
+    "...": "...",
+    "gallery": [
+      { "photo_id": "...", "url": "...", "shot_at": "...", "created_at": "...", "user_display_name": "..." }
+    ]
+  }
+}
+```
+
+- 対象は `is_public = true` の写真のみ。`user_display_name` は display_name 優先（サイト全体の表示名ルールに合わせる）。
+
+### 取り込み拡張（tracker repo: `apps/tools/import_latest_manhole_photos.py`）
+
+- 代表: 現行どおり `dataset/manhole/image/{id}_latest.jpeg`。
+- ギャラリー: `dataset/manhole/image/{id}_{photo_idの先頭8桁(hex)}.jpeg`。代表と重複する photo_id はスキップ。既存ファイルは再ダウンロードしない（冪等）。
+- **リポジトリ肥大対策**: ギャラリー画像も代表と同じスクエア720px・JPEG品質82に縮小して保存。エクスポートから外れた photo_id のファイルは自動削除（`--limit` 指定時は削除しない）。
+
+### ページ生成（tracker repo: `generate_manhole_pages.py`）
+
+- `gallery` が2枚以上のときのみセクション3を描画。代表をヒーロー、残りをサムネイルグリッド。
+- 末尾に「すべての写真を見る → pokefuta.com/manhole/{id}」リンク。
+- `gallery` 未定義・1枚以下は現行と同じ見た目（後方互換）。
+
+## 実装ステップ
+
+1. **pokefuta repo**: `tools/export_latest_manhole_photos.py` に `gallery` 追加（後方互換）
+2. **tracker repo**: `apps/tools/import_latest_manhole_photos.py` のギャラリーDL＋縮小＋掃除
+3. **tracker repo**: `generate_manhole_pages.py` にギャラリーセクション追加
+4. **pokefuta repo**: `ManholePage.tsx` の未ログイン時レイアウトを本仕様のセクション順に再構成（近隣・同ポケモン・県内セクションの新設を含む）
+5. `.claude/commands/import-photos.md` の手順・確認事項を更新
+
+1〜3 と 4 は独立して進められる。1→2→3 の順でデータから先に通す。


### PR DESCRIPTION
## 概要

pokefuta.com とのマンホール詳細ページ共通化（仕様: `docs/MANHOLE_DETAIL_SPEC.md`、本PRで追加）の tracker 側実装。

latest-manhole-photos.json は従来「1マンホール=最新1枚」だったため、複数写真があるマンホールの情報が落ちていた。pokefuta 側のエクスポート拡張（`gallery` 配列・公開写真・最大5枚）に対応する。

## 変更内容

- **apps/tools/import_latest_manhole_photos.py**
  - `gallery` 配列の写真（代表と重複する photo_id は除外）を `{id}_{photo_id先頭8桁}.jpeg` としてDL
  - 既存のスクエア720px/q82パイプラインを共用、既存ファイルは再DLしない（冪等）
  - エクスポートから外れた photo_id のファイルは自動削除（`--limit` 時はスキップ）
  - サマリーに gallery_imported / gallery_kept / gallery_removed を追加
- **apps/scraper/generate_manhole_pages.py**
  - ローカルにギャラリー画像があるマンホールのみ、ヒーロー直下に「みんなの写真」セクション（サムネイルグリッド＋撮影者クレジット）を描画
  - 「すべての写真を見る → pokefuta.com/manhole/{id}」リンク（`click_gallery_more` 計測付き）
  - `gallery` 未定義・1枚以下は現行と同一出力（後方互換）
- **docs/MANHOLE_DETAIL_SPEC.md**: 共通セクション構成・データソース対応表・複数写真仕様
- **.claude/commands/import-photos.md**: サマリー項目・命名規則を追記

## テスト

- import: DL/保持/掃除/切り出し（720x720）をスタブでスモークテスト済み
- generate: 実データ3件でE2E生成し、ギャラリーあり/代表のみ/写真なしの3パターンを確認
- 既存テスト（test_generate_manhole_pages_gundam_tags.py）パス

## 関連

- pokefuta 側PR（export の gallery 拡張・ManholePage 再構成）と対になる。ギャラリー反映には pokefuta 側で /export-photos → 本リポジトリで /import-photos の実行が必要（次回週次更新で反映）

🤖 Generated with [Claude Code](https://claude.com/claude-code)