### PR TITLE
feat: 週次写真取り込みをGitHub Actions化

### DIFF
--- a/.claude/commands/import-photos.md
+++ b/.claude/commands/import-photos.md
@@ -1,4 +1,8 @@
-Sync the latest manhole photos. Run these two steps in order:
+Sync the latest manhole photos manually.
+
+NOTE: 通常は `.github/workflows/import-manhole-photos.yml` が週次（JST 日曜 07:00）で export〜画像DL〜commit まで自動実行する。このスキルは即時反映したいときや Action が失敗したときの手動フォールバック。
+
+Run these two steps in order:
 
 1. Copy `../pokefuta/public/data/latest-manhole-photos.json` to both `apps/web/latest-manhole-photos.json` and `docs/latest-manhole-photos.json`
 2. Run `python3 apps/tools/import_latest_manhole_photos.py --presign-r2` from the project root

--- a/.github/workflows/import-manhole-photos.yml
+++ b/.github/workflows/import-manhole-photos.yml
@@ -1,0 +1,75 @@
+name: Weekly Manhole Photos Import
+
+# pokefuta.com の公開写真を Supabase からエクスポートし、ローカル画像として取り込む。
+# 従来の手動フロー（pokefuta 側 /export-photos → 本リポジトリ /import-photos）の自動化版。
+# 詳細仕様: docs/MANHOLE_DETAIL_SPEC.md
+
+on:
+  schedule:
+    # Run weekly on Saturday 22:00 UTC (JST Sunday 07:00)
+    - cron: '0 22 * * 6'
+  workflow_dispatch: # Allow manual trigger
+
+permissions:
+  contents: write
+  actions: write # pages-deploy の明示起動に必要
+
+jobs:
+  import:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Checkout pokefuta (export script)
+        uses: actions/checkout@v6
+        with:
+          repository: nishiokya/pokefuta
+          path: .pokefuta-src
+          sparse-checkout: tools
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests Pillow
+
+      - name: Export latest manhole photos from Supabase
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          R2_PUBLIC_URL: ${{ secrets.R2_PUBLIC_URL }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+        run: |
+          python .pokefuta-src/tools/export_latest_manhole_photos.py \
+            --output docs/latest-manhole-photos.json
+          cp docs/latest-manhole-photos.json apps/web/latest-manhole-photos.json
+
+      - name: Import photos (download, square-crop, cleanup)
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+        run: |
+          python apps/tools/import_latest_manhole_photos.py --presign-r2
+
+      - name: Commit and trigger Pages deploy
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs/latest-manhole-photos.json apps/web/latest-manhole-photos.json dataset/manhole/image
+          if git diff --cached --quiet; then
+            echo "No photo changes; skipping commit and deploy."
+            exit 0
+          fi
+          git commit -m "chore: weekly manhole photos import (export + local images)"
+          git push
+          # GITHUB_TOKEN の push では pages-deploy が発火しないため明示的に起動する
+          gh workflow run pages-deploy.yml --ref main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,11 @@
 manhole_titles.jsonは手動で更新している
 pokefuta.ndjsonはapps/scraperで更新している
-latest-manhole-photos.json　はpokefuta.comからもらっている（週次手動更新）
+latest-manhole-photos.json は import-manhole-photos.yml が Supabase から週次自動生成（画像DL込み。手動で回すときだけ `/import-photos` スキル）
 docs/api/*.json は bake-app-data.yml が Supabase から日次生成（pokefuta.com アプリの /api/manholes・/api/site-stats がこれを読む）
-- apps/web/ を更新したら `/import-photos` スキルを実行 → docs/ 同期 + dataset/manhole/image/ ダウンロード
 
 ## ディレクトリ構成
 
 - `apps/scraper/` — GitHub Actions から自動実行されるスクリプト群（update-pokefuta.yml / pages-deploy.yml）
   - `address_parser.py` / `manhole_titles.py` は上記スクリプトの内部ライブラリ
-- `apps/tools/` — 手動実行ツール・初期化アーカイブ（CI からは呼ばれない）
+- `apps/tools/` — 手動実行ツール・初期化アーカイブ（例外: import_latest_manhole_photos.py は import-manhole-photos.yml からも呼ばれる）
 - `apps/web/` — フロントエンド


### PR DESCRIPTION
## 概要

従来の手動フロー（pokefuta側 `/export-photos` → 本リポジトリ `/import-photos`）を週次のGitHub Actionsに置き換える。

## 仕組み（import-manhole-photos.yml, JST日曜07:00 + 手動トリガー可）

1. pokefuta リポジトリ（origin/main）の `tools/export_latest_manhole_photos.py` を sparse checkout し、Supabase から公開写真を直接エクスポート（`gallery` 配列付き）→ `docs/` と `apps/web/` に配置
2. `apps/tools/import_latest_manhole_photos.py --presign-r2` で代表＋ギャラリー画像をDL・スクエア720px化・不要ファイル掃除
3. 変更があれば github-actions[bot] がコミットし、`gh workflow run pages-deploy.yml` で明示デプロイ（bake-app-data.yml と同方式）

## 必要なsecrets

既存: `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY`（設定済み）
**追加が必要**: `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` / `R2_ENDPOINT` / `R2_PUBLIC_URL` / `R2_BUCKET`（ローカル `.env.local` と同値）

## テスト

ワークフローと同一の手順をローカルで実行し確認済み：
- マージ済みexportで142マンホール分を生成、33件が複数写真（最大4枚）
- presigned R2 で実DL成功（id=4 のギャラリー3枚 → 720x720 JPEG）

## ドキュメント

- CLAUDE.md: latest-manhole-photos.json の更新経路を自動化後の記述に変更
- /import-photos スキル: 手動フォールバック用として位置づけを明記

🤖 Generated with [Claude Code](https://claude.com/claude-code)