### PR TITLE
fix: 自動コミット系ワークフローをPR経由に変更（mainのPR必須ルール対応）

### DIFF
--- a/.github/workflows/bake-app-data.yml
+++ b/.github/workflows/bake-app-data.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write # main は PR 必須ルールのため PR 経由でコミットする
   actions: write
 
 env:
@@ -33,7 +34,7 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
         run: python3 apps/scraper/export_app_snapshot.py
 
-      - name: Commit and trigger Pages deploy
+      - name: Commit via PR and trigger Pages deploy
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -44,7 +45,14 @@ jobs:
             echo "No snapshot changes; skipping commit and deploy."
             exit 0
           fi
+          # main は「PR必須」ルールのため直接 push できない。PR を作って即マージする
+          BRANCH="auto/app-data-snapshot-$(date -u +%Y%m%d%H%M%S)"
+          git checkout -b "$BRANCH"
           git commit -m "chore: daily app data snapshot (manholes / site-stats)"
-          git push
-          # GITHUB_TOKEN の push では pages-deploy が発火しないため明示的に起動する
+          git push origin "$BRANCH"
+          gh pr create --base main --head "$BRANCH" \
+            --title "chore: daily app data snapshot" \
+            --body "bake-app-data.yml による自動更新（docs/api/*.json）"
+          gh pr merge "$BRANCH" --squash --delete-branch
+          # GITHUB_TOKEN の merge では pages-deploy が発火しないため明示的に起動する
           gh workflow run pages-deploy.yml --ref main

--- a/.github/workflows/import-manhole-photos.yml
+++ b/.github/workflows/import-manhole-photos.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write # main は PR 必須ルールのため PR 経由でコミットする
   actions: write # pages-deploy の明示起動に必要
 
 jobs:
@@ -58,7 +59,7 @@ jobs:
         run: |
           python apps/tools/import_latest_manhole_photos.py --presign-r2
 
-      - name: Commit and trigger Pages deploy
+      - name: Commit via PR and trigger Pages deploy
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -69,7 +70,14 @@ jobs:
             echo "No photo changes; skipping commit and deploy."
             exit 0
           fi
+          # main は「PR必須」ルールのため直接 push できない。PR を作って即マージする
+          BRANCH="auto/manhole-photos-$(date -u +%Y%m%d%H%M%S)"
+          git checkout -b "$BRANCH"
           git commit -m "chore: weekly manhole photos import (export + local images)"
-          git push
-          # GITHUB_TOKEN の push では pages-deploy が発火しないため明示的に起動する
+          git push origin "$BRANCH"
+          gh pr create --base main --head "$BRANCH" \
+            --title "chore: weekly manhole photos import" \
+            --body "import-manhole-photos.yml による自動更新（export + ギャラリー画像DL）"
+          gh pr merge "$BRANCH" --squash --delete-branch
+          # GITHUB_TOKEN の merge では pages-deploy が発火しないため明示的に起動する
           gh workflow run pages-deploy.yml --ref main


### PR DESCRIPTION
mainブランチのルールセット（Changes must be made through a pull request）により
github-actions[bot] の直接pushが拒否されるため、auto/ブランチにpush →
gh pr create → gh pr merge --squash の流れに変更。
昨夜の import-manhole-photos.yml 初回実行がこれで失敗していた
（export・画像DLは成功、最後のpushのみ拒否）。bake-app-data.yml も同じ問題を持つため同時修正。

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
