### PR TITLE
feat: 写真投稿CTAを pokefuta.com/upload?manhole_id={id} に変更

### DIFF
--- a/apps/scraper/generate_manhole_pages.py
+++ b/apps/scraper/generate_manhole_pages.py
@@ -492,7 +492,7 @@ def generate_html(
     has_photo_js = json.dumps(has_photo_bool)
 
     hero_photo_html = (
-        f"<a class='hero-photo-placeholder' href='https://pokefuta.com/visits'"
+        f"<a class='hero-photo-placeholder' href='https://pokefuta.com/upload?manhole_id={manhole_id}'"
         f" target='_blank' rel='noopener noreferrer'"
         f" onclick=\"trackEvent('click_photo_upload_placeholder', {_attr_json({'manhole_id': manhole_id, 'prefecture': prefecture, 'city': city, 'has_photo': False})})\">"
         f"<span class='placeholder-camera' aria-hidden='true'>📷</span>"
@@ -905,7 +905,7 @@ def generate_html(
     {pokemon_tags_html}
     {stats_html}
     <div class="hero-actions">
-      <a class="btn-photo-upload" href="https://pokefuta.com/visits" target="_blank" rel="noopener noreferrer" onclick="trackEvent('{_photo_event}', {_photo_cta_onclick})">{_icon('icon-link-photo', 'action-icon')}<span>{escape(_photo_label)}</span></a>
+      <a class="btn-photo-upload" href="https://pokefuta.com/upload?manhole_id={manhole_id}" target="_blank" rel="noopener noreferrer" onclick="trackEvent('{_photo_event}', {_photo_cta_onclick})">{_icon('icon-link-photo', 'action-icon')}<span>{escape(_photo_label)}</span></a>
     </div>
   </div>
 </div>

--- a/apps/web/map.html
+++ b/apps/web/map.html
@@ -1153,7 +1153,7 @@
       const manholeId = encodeURIComponent(String(d.id || ''));
       // 詳細導線は data.pokefuta.com の詳細ページに一本化（写真ギャラリー・pokefuta.com への導線は詳細ページ側が持つ）
       const manholeDetailUrl = `${window.SITE_BASE_URL}manholes/${manholeId}/`;
-      const uploadUrl = 'https://pokefuta.com/upload';
+      const uploadUrl = `https://pokefuta.com/upload?manhole_id=${manholeId}`;
       const safeIdJs = escapeJs(d.id);
       const safePrefectureJs = escapeJs(prefecture);
       const eventParams = `event_category:'popup_navigation',manhole_id:'${safeIdJs}',prefecture:'${safePrefectureJs}'`;

--- a/apps/web/map.template.html
+++ b/apps/web/map.template.html
@@ -1113,7 +1113,7 @@
       const manholeId = encodeURIComponent(String(d.id || ''));
       // 詳細導線は data.pokefuta.com の詳細ページに一本化（写真ギャラリー・pokefuta.com への導線は詳細ページ側が持つ）
       const manholeDetailUrl = `${window.SITE_BASE_URL}manholes/${manholeId}/`;
-      const uploadUrl = 'https://pokefuta.com/upload';
+      const uploadUrl = `https://pokefuta.com/upload?manhole_id=${manholeId}`;
       const safeIdJs = escapeJs(d.id);
       const safePrefectureJs = escapeJs(prefecture);
       const eventParams = `event_category:'popup_navigation',manhole_id:'${safeIdJs}',prefecture:'${safePrefectureJs}'`;


### PR DESCRIPTION
## 概要

写真投稿導線（詳細ページ hero CTA・写真なしplaceholder・マップポップアップ）を `pokefuta.com/visits` 固定リンクから **`pokefuta.com/upload?manhole_id={id}`** に変更し、どのマンホールの投稿かを pokefuta.com 側に引き継ぐ。

仕様 `docs/MANHOLE_DETAIL_SPEC.md` セクション4「写真を投稿（→ pokefuta.com）」の導線を実体化するもの。

## 対応PR（pokefuta repo）

- pokefuta.com 側の受け口（`?manhole_id=` ヒントカード表示＋GPS照合結果の一致/不一致表示、middleware のクエリ保持）は pokefuta repo の対応PRで実装。先にどちらをマージしても壊れない（パラメータ未対応でも従来どおり動く）。

## 検証

- test_generate_manhole_pages_gallery.py / test_generate_manhole_pages_gundam_tags.py → OK
- ページ生成で hero CTA（manhole 4 → `upload?manhole_id=4`）と placeholder（manhole 135 → `upload?manhole_id=135`）を確認
- map.html / map.template.html は双子を同期

🤖 Generated with [Claude Code](https://claude.com/claude-code)