### PR TITLE
feat: 写真投稿CTAに予告テキストとfrom=dataを追加

### DIFF
--- a/apps/scraper/generate_manhole_pages.py
+++ b/apps/scraper/generate_manhole_pages.py
@@ -492,7 +492,7 @@ def generate_html(
     has_photo_js = json.dumps(has_photo_bool)
 
     hero_photo_html = (
-        f"<a class='hero-photo-placeholder' href='https://pokefuta.com/upload?manhole_id={manhole_id}&from=data'"
+        f"<a class='hero-photo-placeholder' href='https://pokefuta.com/upload?manhole_id={manhole_id}&amp;from=data'"
         f" target='_blank' rel='noopener noreferrer'"
         f" onclick=\"trackEvent('click_photo_upload_placeholder', {_attr_json({'manhole_id': manhole_id, 'prefecture': prefecture, 'city': city, 'has_photo': False})})\">"
         f"<span class='placeholder-camera' aria-hidden='true'>📷</span>"
@@ -905,7 +905,7 @@ def generate_html(
     {pokemon_tags_html}
     {stats_html}
     <div class="hero-actions">
-      <a class="btn-photo-upload" href="https://pokefuta.com/upload?manhole_id={manhole_id}&from=data" target="_blank" rel="noopener noreferrer" onclick="trackEvent('{_photo_event}', {_photo_cta_onclick})">{_icon('icon-link-photo', 'action-icon')}<span>{escape(_photo_label)}</span></a>
+      <a class="btn-photo-upload" href="https://pokefuta.com/upload?manhole_id={manhole_id}&amp;from=data" target="_blank" rel="noopener noreferrer" onclick="trackEvent('{_photo_event}', {_photo_cta_onclick})">{_icon('icon-link-photo', 'action-icon')}<span>{escape(_photo_label)}</span></a>
       <p class="photo-upload-note">投稿は pokefuta.com で受付（無料ログイン・GPS付き写真が必要）</p>
     </div>
   </div>

--- a/apps/scraper/generate_manhole_pages.py
+++ b/apps/scraper/generate_manhole_pages.py
@@ -492,7 +492,7 @@ def generate_html(
     has_photo_js = json.dumps(has_photo_bool)
 
     hero_photo_html = (
-        f"<a class='hero-photo-placeholder' href='https://pokefuta.com/upload?manhole_id={manhole_id}'"
+        f"<a class='hero-photo-placeholder' href='https://pokefuta.com/upload?manhole_id={manhole_id}&from=data'"
         f" target='_blank' rel='noopener noreferrer'"
         f" onclick=\"trackEvent('click_photo_upload_placeholder', {_attr_json({'manhole_id': manhole_id, 'prefecture': prefecture, 'city': city, 'has_photo': False})})\">"
         f"<span class='placeholder-camera' aria-hidden='true'>📷</span>"
@@ -905,7 +905,8 @@ def generate_html(
     {pokemon_tags_html}
     {stats_html}
     <div class="hero-actions">
-      <a class="btn-photo-upload" href="https://pokefuta.com/upload?manhole_id={manhole_id}" target="_blank" rel="noopener noreferrer" onclick="trackEvent('{_photo_event}', {_photo_cta_onclick})">{_icon('icon-link-photo', 'action-icon')}<span>{escape(_photo_label)}</span></a>
+      <a class="btn-photo-upload" href="https://pokefuta.com/upload?manhole_id={manhole_id}&from=data" target="_blank" rel="noopener noreferrer" onclick="trackEvent('{_photo_event}', {_photo_cta_onclick})">{_icon('icon-link-photo', 'action-icon')}<span>{escape(_photo_label)}</span></a>
+      <p class="photo-upload-note">投稿は pokefuta.com で受付（無料ログイン・GPS付き写真が必要）</p>
     </div>
   </div>
 </div>
@@ -1350,6 +1351,14 @@ def generate_html(
       background: #ffe4ea;
       box-shadow: 0 3px 10px rgba(192,57,75,0.14);
       transform: translateY(-1px);
+    }}
+
+    .photo-upload-note {{
+      margin: -2px 0 0;
+      font-size: 11.5px;
+      line-height: 1.5;
+      text-align: center;
+      color: #8a7f72;
     }}
 
     .action-icon {{

--- a/apps/web/assets/pokefuta-map.css
+++ b/apps/web/assets/pokefuta-map.css
@@ -1271,9 +1271,19 @@ body.pokefuta-map-page {
 }
 
 .pokefuta-map-page .travel-popup-action--upload {
+  flex-direction: column;
+  gap: 1px;
+  padding: 6px 10px;
   background: linear-gradient(135deg, #168074, #0f6d64);
   color: #fff;
   box-shadow: 0 8px 18px rgba(15, 109, 100, .2);
+}
+
+.pokefuta-map-page .travel-popup-action-sub {
+  display: block;
+  font-size: .62rem;
+  font-weight: 700;
+  opacity: .85;
 }
 
 .pokefuta-map-page .travel-popup-action--maps {

--- a/apps/web/i18n/strings.en.json
+++ b/apps/web/i18n/strings.en.json
@@ -76,6 +76,7 @@
     "uploadPhoto": "Upload Photo",
     "photoViewCta": "View photo",
     "firstPhotoUploadCta": "Upload the first photo",
+    "firstPhotoUploadNote": "On pokefuta.com · free sign-in",
     "googleMapsCta": "Open in Google Maps",
     "shareButton": "Share",
     "typeLabel": "Type:",

--- a/apps/web/i18n/strings.ja.json
+++ b/apps/web/i18n/strings.ja.json
@@ -76,6 +76,7 @@
     "uploadPhoto": "写真を投稿",
     "photoViewCta": "写真を見る",
     "firstPhotoUploadCta": "最初の写真を投稿",
+    "firstPhotoUploadNote": "pokefuta.comで受付・無料ログイン",
     "googleMapsCta": "Google Mapsで行く",
     "shareButton": "シェア",
     "typeLabel": "タイプ:",

--- a/apps/web/i18n/strings.ko.json
+++ b/apps/web/i18n/strings.ko.json
@@ -76,6 +76,7 @@
     "uploadPhoto": "사진 업로드",
     "photoViewCta": "사진 보기",
     "firstPhotoUploadCta": "첫 사진 올리기",
+    "firstPhotoUploadNote": "pokefuta.com에서 업로드 · 무료 로그인",
     "googleMapsCta": "Google Maps에서 보기",
     "shareButton": "공유",
     "typeLabel": "타입:",

--- a/apps/web/i18n/strings.zh-CN.json
+++ b/apps/web/i18n/strings.zh-CN.json
@@ -76,6 +76,7 @@
     "uploadPhoto": "上传照片",
     "photoViewCta": "查看照片",
     "firstPhotoUploadCta": "上传第一张照片",
+    "firstPhotoUploadNote": "在 pokefuta.com 上传 · 免费登录",
     "googleMapsCta": "在 Google Maps 查看",
     "shareButton": "分享",
     "typeLabel": "属性：",

--- a/apps/web/i18n/strings.zh-TW.json
+++ b/apps/web/i18n/strings.zh-TW.json
@@ -76,6 +76,7 @@
     "uploadPhoto": "上傳照片",
     "photoViewCta": "查看照片",
     "firstPhotoUploadCta": "上傳第一張照片",
+    "firstPhotoUploadNote": "在 pokefuta.com 上傳 · 免費登入",
     "googleMapsCta": "在 Google Maps 查看",
     "shareButton": "分享",
     "typeLabel": "屬性：",

--- a/apps/web/map.html
+++ b/apps/web/map.html
@@ -1189,7 +1189,7 @@
       const primaryAction = hasPhoto
         ? `<a href="${manholeDetailUrl}" class="travel-popup-action travel-popup-action--primary"
               onclick="if(window.trackEvent){window.trackEvent('popup_click_detail',{${eventParams}});}">詳細を見る</a>`
-        : `<a href="${uploadUrl}" target="_blank" rel="noopener noreferrer" class="travel-popup-action travel-popup-action--primary travel-popup-action--upload"
+        : `<a href="${escapeHtml(uploadUrl)}" target="_blank" rel="noopener noreferrer" class="travel-popup-action travel-popup-action--primary travel-popup-action--upload"
               onclick="if(window.trackEvent){window.trackEvent('popup_click_upload',{${eventParams}});}">最初の写真を投稿<span class="travel-popup-action-sub">pokefuta.comで受付・無料ログイン</span></a>`;
       const mapsUrl = Number.isFinite(Number(d.lat)) && Number.isFinite(Number(d.lng))
         ? `https://www.google.com/maps?q=${encodeURIComponent(`${d.lat},${d.lng}`)}`

--- a/apps/web/map.html
+++ b/apps/web/map.html
@@ -1153,7 +1153,7 @@
       const manholeId = encodeURIComponent(String(d.id || ''));
       // 詳細導線は data.pokefuta.com の詳細ページに一本化（写真ギャラリー・pokefuta.com への導線は詳細ページ側が持つ）
       const manholeDetailUrl = `${window.SITE_BASE_URL}manholes/${manholeId}/`;
-      const uploadUrl = `https://pokefuta.com/upload?manhole_id=${manholeId}`;
+      const uploadUrl = `https://pokefuta.com/upload?manhole_id=${manholeId}&from=data`;
       const safeIdJs = escapeJs(d.id);
       const safePrefectureJs = escapeJs(prefecture);
       const eventParams = `event_category:'popup_navigation',manhole_id:'${safeIdJs}',prefecture:'${safePrefectureJs}'`;
@@ -1190,7 +1190,7 @@
         ? `<a href="${manholeDetailUrl}" class="travel-popup-action travel-popup-action--primary"
               onclick="if(window.trackEvent){window.trackEvent('popup_click_detail',{${eventParams}});}">詳細を見る</a>`
         : `<a href="${uploadUrl}" target="_blank" rel="noopener noreferrer" class="travel-popup-action travel-popup-action--primary travel-popup-action--upload"
-              onclick="if(window.trackEvent){window.trackEvent('popup_click_upload',{${eventParams}});}">最初の写真を投稿</a>`;
+              onclick="if(window.trackEvent){window.trackEvent('popup_click_upload',{${eventParams}});}">最初の写真を投稿<span class="travel-popup-action-sub">pokefuta.comで受付・無料ログイン</span></a>`;
       const mapsUrl = Number.isFinite(Number(d.lat)) && Number.isFinite(Number(d.lng))
         ? `https://www.google.com/maps?q=${encodeURIComponent(`${d.lat},${d.lng}`)}`
         : '';

--- a/apps/web/map.template.html
+++ b/apps/web/map.template.html
@@ -1149,7 +1149,7 @@
       const primaryAction = hasPhoto
         ? `<a href="${manholeDetailUrl}" class="travel-popup-action travel-popup-action--primary"
               onclick="if(window.trackEvent){window.trackEvent('popup_click_detail',{${eventParams}});}">${UI_TEXT.detailPageCta}</a>`
-        : `<a href="${uploadUrl}" target="_blank" rel="noopener noreferrer" class="travel-popup-action travel-popup-action--primary travel-popup-action--upload"
+        : `<a href="${escapeHtml(uploadUrl)}" target="_blank" rel="noopener noreferrer" class="travel-popup-action travel-popup-action--primary travel-popup-action--upload"
               onclick="if(window.trackEvent){window.trackEvent('popup_click_upload',{${eventParams}});}">${I.firstPhotoUploadCta}<span class="travel-popup-action-sub">${I.firstPhotoUploadNote}</span></a>`;
       const mapsUrl = Number.isFinite(Number(d.lat)) && Number.isFinite(Number(d.lng))
         ? `https://www.google.com/maps?q=${encodeURIComponent(`${d.lat},${d.lng}`)}`

--- a/apps/web/map.template.html
+++ b/apps/web/map.template.html
@@ -1113,7 +1113,7 @@
       const manholeId = encodeURIComponent(String(d.id || ''));
       // 詳細導線は data.pokefuta.com の詳細ページに一本化（写真ギャラリー・pokefuta.com への導線は詳細ページ側が持つ）
       const manholeDetailUrl = `${window.SITE_BASE_URL}manholes/${manholeId}/`;
-      const uploadUrl = `https://pokefuta.com/upload?manhole_id=${manholeId}`;
+      const uploadUrl = `https://pokefuta.com/upload?manhole_id=${manholeId}&from=data`;
       const safeIdJs = escapeJs(d.id);
       const safePrefectureJs = escapeJs(prefecture);
       const eventParams = `event_category:'popup_navigation',manhole_id:'${safeIdJs}',prefecture:'${safePrefectureJs}'`;
@@ -1150,7 +1150,7 @@
         ? `<a href="${manholeDetailUrl}" class="travel-popup-action travel-popup-action--primary"
               onclick="if(window.trackEvent){window.trackEvent('popup_click_detail',{${eventParams}});}">${UI_TEXT.detailPageCta}</a>`
         : `<a href="${uploadUrl}" target="_blank" rel="noopener noreferrer" class="travel-popup-action travel-popup-action--primary travel-popup-action--upload"
-              onclick="if(window.trackEvent){window.trackEvent('popup_click_upload',{${eventParams}});}">${I.firstPhotoUploadCta}</a>`;
+              onclick="if(window.trackEvent){window.trackEvent('popup_click_upload',{${eventParams}});}">${I.firstPhotoUploadCta}<span class="travel-popup-action-sub">${I.firstPhotoUploadNote}</span></a>`;
       const mapsUrl = Number.isFinite(Number(d.lat)) && Number.isFinite(Number(d.lng))
         ? `https://www.google.com/maps?q=${encodeURIComponent(`${d.lat},${d.lng}`)}`
         : '';


### PR DESCRIPTION
## 背景

data.pokefuta.com の写真投稿CTAを押すと、予告なしに別サイト（pokefuta.com）のログイン画面に飛ばされ、離脱要因になっていた。

## 変更内容

### 予告サブテキストの追加
- **詳細ページ**（generate_manhole_pages.py）: 「写真を投稿」ボタン直下に「投稿は pokefuta.com で受付（無料ログイン・GPS付き写真が必要）」の注記を追加（CSS `.photo-upload-note` 新設）
- **地図ポップアップ**: 「最初の写真を投稿」ボタン内にサブ行「pokefuta.comで受付・無料ログイン」を追加
  - map.html（日本語版）と map.template.html（i18nビルド用）の両方を同期
  - i18nキー `firstPhotoUploadNote` を5言語の strings に追加
  - ボタン2行化スタイルは共通 pokefuta-map.css に追加

### from=data パラメータの付与
全CTA（詳細ページボタン・写真プレースホルダー・地図ポップアップ）のURLを `pokefuta.com/upload?manhole_id={id}&from=data` に変更。pokefuta.com 側の middleware が `/login` に引き継ぎ、既存の「data.pokefuta.comから来た方へ」案内バナーが表示される（pokefuta 側は別PR）。

## 検証

- strings JSON 5ファイル妥当性チェックOK
- `tools/build_i18n.py` 実行成功（未置換マーカーなし）、dist/en・dist/ko の出力に `&from=data` とサブテキストを確認
- `generate_manhole_pages.py` py_compile 通過
- test_generate_summary_pages の失敗4件は変更前から存在する既存問題（stashで確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)