### PR TITLE
Add desktop summary to prefecture pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+manhole_titles.jsonは手動で更新している
+pokefuta.ndjsonはapps/scraperで更新している
+latest-manhole-photos.json　はpokefuta.comからもらっている（週次手動更新）
+- apps/web/ を更新したら `/import-photos` スキルを実行 → docs/ 同期 + dataset/manhole/image/ ダウンロード
+
+## ディレクトリ構成
+
+- `apps/scraper/` — GitHub Actions から自動実行されるスクリプト群（update-pokefuta.yml / pages-deploy.yml）
+  - `address_parser.py` / `manhole_titles.py` は上記スクリプトの内部ライブラリ
+- `apps/tools/` — 手動実行ツール・初期化アーカイブ（CI からは呼ばれない）
+- `apps/web/` — フロントエンド

--- a/apps/scraper/generate_prefecture_pages.py
+++ b/apps/scraper/generate_prefecture_pages.py
@@ -430,7 +430,7 @@ def build_page(
     }}
     .hero-kicker {{ margin: 0; color: #6b4aa2; font-size: .8rem; font-weight: 900; }}
     h1 {{ margin: 4px 0 8px; font-size: clamp(2rem, 7vw, 3.5rem); line-height: 1.15; }}
-    .hero p:last-of-type {{ max-width: 720px; margin: 0; color: #574b41; font-weight: 650; }}
+    .hero-main > p:last-of-type {{ max-width: 720px; margin: 0; color: #574b41; font-weight: 650; }}
     .hero-summary {{
       position: relative; z-index: 1; padding: 16px 18px; border-radius: 17px;
       background: rgba(255,255,255,.74); color: #3a3128;

--- a/apps/scraper/generate_prefecture_pages.py
+++ b/apps/scraper/generate_prefecture_pages.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 from collections import Counter
+from datetime import datetime
 from pathlib import Path
 from urllib.parse import quote
 from xml.sax.saxutils import escape
@@ -163,6 +164,47 @@ def _trivia_html(prefecture: str, trivia_entry: dict | None, count: int) -> str:
     )
 
 
+def _record_date(record: dict) -> datetime | None:
+    for key in ("first_seen", "added_at", "last_updated"):
+        value = str(record.get(key, "")).strip()
+        if not value:
+            continue
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            continue
+    return None
+
+
+def _format_year_month(date: datetime) -> str:
+    return f"{date.year}年{date.month}月"
+
+
+def _hero_summary(
+    prefecture: str,
+    count: int,
+    records: list[dict],
+    trivia_entry: dict | None,
+) -> str:
+    if not count:
+        return f"{prefecture}は現在未設置。新しい設置情報を追跡中です。"
+
+    cities = {
+        str(record.get("city", "")).strip()
+        for record in records
+        if str(record.get("city", "")).strip()
+    }
+    municipalities = (trivia_entry or {}).get("municipality_count", 0) or len(cities)
+    first_dates = [date for record in records if (date := _record_date(record))]
+    first_month = _format_year_month(min(first_dates)) if first_dates else ""
+    if first_month:
+        return (
+            f"{prefecture}は{first_month}にポケふた初登場。"
+            f"現在は{municipalities}自治体で{count}枚を巡れます。"
+        )
+    return f"{prefecture}では{municipalities}自治体で{count}枚のポケふたを巡れます。"
+
+
 def _pokemon_card(name: str, count: int, pokemon_slugs: dict[str, str]) -> str:
     slug = pokemon_slugs.get(name) or pokemon_slugs.get(_normalize_katakana(name))
     content = (
@@ -302,6 +344,7 @@ def build_page(
     )
     rank_label = f"全国{rank}位" if rank else "現在未設置"
     hero_intro = _hero_intro(prefecture, count, trivia_entry)
+    hero_summary = _hero_summary(prefecture, count, records, trivia_entry)
     map_points = [
         {
             "id": str(record.get("id", "")),
@@ -374,6 +417,8 @@ def build_page(
     .breadcrumb a {{ text-decoration: none; }}
     .hero {{
       position: relative; overflow: hidden; margin-top: 14px; padding: 28px;
+      display: grid; grid-template-columns: minmax(0, 1fr) 280px; gap: 22px;
+      align-items: center;
       border: 1px solid rgba(93,67,35,.15); border-radius: 24px;
       background: linear-gradient(135deg, #fffaf0, #f0e9fb);
       box-shadow: 0 14px 32px rgba(77,56,30,.08);
@@ -386,6 +431,16 @@ def build_page(
     .hero-kicker {{ margin: 0; color: #6b4aa2; font-size: .8rem; font-weight: 900; }}
     h1 {{ margin: 4px 0 8px; font-size: clamp(2rem, 7vw, 3.5rem); line-height: 1.15; }}
     .hero p:last-of-type {{ max-width: 720px; margin: 0; color: #574b41; font-weight: 650; }}
+    .hero-summary {{
+      position: relative; z-index: 1; padding: 16px 18px; border-radius: 17px;
+      background: rgba(255,255,255,.74); color: #3a3128;
+      box-shadow: inset 0 0 0 1px rgba(93,67,35,.11);
+    }}
+    .hero-summary span {{
+      display: block; margin-bottom: 6px; color: #6b4aa2;
+      font-size: .76rem; font-weight: 900;
+    }}
+    .hero-summary p {{ margin: 0; font-size: .96rem; font-weight: 800; }}
     .stats {{ display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; margin-top: 18px; }}
     .stat {{ padding: 14px; border-radius: 15px; background: rgba(255,255,255,.72); }}
     .stat span {{ display: block; color: #75685c; font-size: .76rem; font-weight: 850; }}
@@ -461,7 +516,8 @@ def build_page(
     footer {{ margin-top: 24px; color: #75685c; font-size: .8rem; text-align: center; }}
     .leaflet-popup-content a {{ font-weight: 850; }}
     @media (max-width: 700px) {{
-      .hero {{ padding: 22px 18px; }}
+      .hero {{ display: block; padding: 22px 18px; }}
+      .hero-summary {{ display: none; }}
       .pokemon-grid, .pokemon-more-grid, .manhole-grid {{ grid-template-columns: 1fr; }}
       #prefecture-map {{ height: 360px; }}
       section {{ padding: 16px; }}
@@ -476,21 +532,27 @@ def build_page(
       <span>{escape(prefecture)}</span>
     </nav>
     <header class="hero">
-      <p class="hero-kicker">都道府県別 ポケふたガイド</p>
-      <h1>{escape(prefecture)}のポケふた</h1>
-      <p>{escape(hero_intro)}</p>
-      <div class="stats" aria-label="{escape(prefecture)}の集計">
-        <div class="stat"><span>設置枚数</span><strong>{count}枚</strong></div>
-        <div class="stat"><span>全国順位</span><strong>{escape(rank_label)}</strong></div>
+      <div class="hero-main">
+        <p class="hero-kicker">都道府県別 ポケふたガイド</p>
+        <h1>{escape(prefecture)}のポケふた</h1>
+        <p>{escape(hero_intro)}</p>
+        <div class="stats" aria-label="{escape(prefecture)}の集計">
+          <div class="stat"><span>設置枚数</span><strong>{count}枚</strong></div>
+          <div class="stat"><span>全国順位</span><strong>{escape(rank_label)}</strong></div>
+        </div>
+        <div class="hero-actions">
+          <a class="button" href="#manhole-list">マンホール一覧を見る</a>
+          <a class="button pokefuta" href="https://pokefuta.com/visits"
+            data-track="prefecture_visit_cta_click" data-destination="pokefuta_visits">訪問記録を残す</a>
+          <a class="button photo" href="https://pokefuta.com/"
+            data-track="prefecture_photo_cta_click" data-destination="pokefuta_photos">写真を見る</a>
+          <a class="button secondary" href="{escape(map_href)}"
+            data-track="prefecture_map_click" data-destination="map">全国マップで見る</a>
+        </div>
       </div>
-      <div class="hero-actions">
-        <a class="button" href="#manhole-list">マンホール一覧を見る</a>
-        <a class="button pokefuta" href="https://pokefuta.com/visits"
-          data-track="prefecture_visit_cta_click" data-destination="pokefuta_visits">訪問記録を残す</a>
-        <a class="button photo" href="https://pokefuta.com/"
-          data-track="prefecture_photo_cta_click" data-destination="pokefuta_photos">写真を見る</a>
-        <a class="button secondary" href="{escape(map_href)}"
-          data-track="prefecture_map_click" data-destination="map">全国マップで見る</a>
+      <div class="hero-summary" aria-label="{escape(prefecture)}のサマリー">
+        <span>サマリー</span>
+        <p>{escape(hero_summary)}</p>
       </div>
     </header>
 

--- a/apps/scraper/test_generate_prefecture_pages.py
+++ b/apps/scraper/test_generate_prefecture_pages.py
@@ -102,6 +102,21 @@ class GeneratePrefecturePagesTest(unittest.TestCase):
             html,
         )
 
+    def test_nagano_desktop_header_summary_mentions_first_month(self) -> None:
+        records = [r for r in self.records if r.get("prefecture") == "長野県"]
+        html = MODULE.build_page(
+            "長野県",
+            "nagano",
+            records,
+            MODULE.build_rankings(self.records)["長野県"],
+            self.pokemon_slugs,
+            self.trivia["長野県"],
+        )
+        self.assertIn('class="hero-summary"', html)
+        self.assertIn("長野県は2026年7月にポケふた初登場。", html)
+        self.assertIn("現在は6自治体で6枚を巡れます。", html)
+        self.assertIn(".hero-summary { display: none; }", html)
+
     def test_tied_counts_share_rank(self) -> None:
         records = [
             {"id": "1", "status": "active", "prefecture": "青森県"},


### PR DESCRIPTION
## Summary
- add a desktop-only summary panel to generated prefecture page headers
- derive the summary from the earliest recorded Pokefuta date and municipality count
- add coverage for the Nagano first-appearance summary
- include repository AGENTS.md instructions already present in the local work

## Validation
- python3 -m unittest apps/scraper/test_generate_prefecture_pages.py apps/scraper/test_inject_site_header.py
- git diff --check origin/main...HEAD

## Notes
- Rebasing onto the latest origin/main produced conflicts in generated/data files; I resolved those by keeping origin/main data and narrowing this PR to the header summary implementation plus tests.