### PR TITLE
Move summary link into shared header

### DIFF
--- a/apps/scraper/generate_pokemon_index_page.py
+++ b/apps/scraper/generate_pokemon_index_page.py
@@ -288,8 +288,6 @@ INDEX_ENHANCEMENT_STRINGS: dict[str, dict] = {
         "kicker": "ポケモンマンホール データガイド",
         "hero_stat": "登場ポケモン",
         "hero_stat_unit": "体",
-        "summary_label": "サマリー",
-        "hero_summary": "{total}体の登場ポケモンから探せます。最多は{name}で、全国{count}枚のポケふたに登場します。",
         "fact_heading": "ポケモン別に見るポケふた雑学",
         "fact_rank_title": "いちばん多く登場するのは{name}",
         "fact_rank_body": "{name}は全国{count}枚のポケふたに登場し、登場数ランキング1位です。",
@@ -322,8 +320,6 @@ INDEX_ENHANCEMENT_STRINGS: dict[str, dict] = {
         "kicker": "Pokémon Manhole Data Guide",
         "hero_stat": "Featured Pokémon",
         "hero_stat_unit": "",
-        "summary_label": "Summary",
-        "hero_summary": "Browse {total} featured Pokémon. {name} appears most often, with {count} Pokefuta nationwide.",
         "fact_heading": "Pokefuta facts by Pokémon",
         "fact_rank_title": "{name} appears most often",
         "fact_rank_body": "{name} appears on {count} Pokefuta, the highest total in the current dataset.",
@@ -347,8 +343,6 @@ INDEX_ENHANCEMENT_STRINGS: dict[str, dict] = {
         "kicker": "宝可梦井盖数据指南",
         "hero_stat": "登场宝可梦",
         "hero_stat_unit": "只",
-        "summary_label": "摘要",
-        "hero_summary": "可从{total}只登场宝可梦中查找。登场最多的是{name}，全国共有{count}个宝可梦井盖。",
         "fact_heading": "按宝可梦了解井盖小知识",
         "fact_rank_title": "登场最多的是{name}",
         "fact_rank_body": "{name}在全国{count}个宝可梦井盖中登场，位居当前排行榜第一。",
@@ -372,8 +366,6 @@ INDEX_ENHANCEMENT_STRINGS: dict[str, dict] = {
         "kicker": "寶可夢人孔蓋資料指南",
         "hero_stat": "登場寶可夢",
         "hero_stat_unit": "隻",
-        "summary_label": "摘要",
-        "hero_summary": "可從{total}隻登場寶可夢中查找。登場最多的是{name}，全國共有{count}個寶可夢人孔蓋。",
         "fact_heading": "按寶可夢了解人孔蓋小知識",
         "fact_rank_title": "登場最多的是{name}",
         "fact_rank_body": "{name}在全國{count}個寶可夢人孔蓋中登場，位居目前排行榜第一。",
@@ -397,8 +389,6 @@ INDEX_ENHANCEMENT_STRINGS: dict[str, dict] = {
         "kicker": "포켓몬 맨홀 데이터 가이드",
         "hero_stat": "등장 포켓몬",
         "hero_stat_unit": "마리",
-        "summary_label": "요약",
-        "hero_summary": "등장 포켓몬 {total}마리에서 찾을 수 있습니다. 가장 많이 등장하는 포켓몬은 {name}으로, 전국 {count}개의 포케후타에 등장합니다.",
         "fact_heading": "포켓몬별 포케후타 상식",
         "fact_rank_title": "가장 많이 등장하는 포켓몬은 {name}",
         "fact_rank_body": "{name}은 전국 {count}개의 포케후타에 등장해 현재 순위 1위입니다.",
@@ -757,24 +747,6 @@ def generate_html(
     latest_photos = _build_latest_photo_cards(
         pokemon_index, photos_data, image_dir, lang_config, translate_pref, lang,
     )
-    top_card = cards[0] if cards else {
-        "name": strings["region_summary_unknown"],
-        "count": 0,
-        "href": map_href,
-    }
-    hero_summary_html = ""
-    if cards:
-        hero_summary = enhancement["hero_summary"].format(
-            total=total_count,
-            name=top_card["name"],
-            count=top_card["count"],
-        )
-        hero_summary_html = (
-            f'<div class="hero-summary" aria-label="{escape(enhancement["summary_label"])}">'
-            f'<span>{escape(enhancement["summary_label"])}</span>'
-            f'<p>{escape(hero_summary)}</p>'
-            f'</div>'
-        )
 
     def image_html(card: dict, class_name: str = "card-photo") -> str:
         image = card.get("latest_image")
@@ -951,6 +923,12 @@ def generate_html(
     popular_intro = escape(
         strings["popular_intro"].format(top3=top3_names, min_count=top3_min_count)
     )
+    top_card = cards[0] if cards else {
+        "name": strings["region_summary_unknown"],
+        "count": 0,
+        "href": map_href,
+    }
+
     fact_cards = [
         {
             "stat": strings["count_label"].format(count=top_card["count"]),
@@ -1210,28 +1188,6 @@ def generate_html(
       line-height: 1.75;
       margin-bottom: 0;
       max-width: 720px;
-    }}
-    .hero-summary {{
-      margin-top: 14px;
-      max-width: 560px;
-      padding: 12px 14px;
-      border: 1px solid rgba(87,64,143,.16);
-      border-radius: 14px;
-      background: rgba(255,255,255,.72);
-      color: #3a3128;
-    }}
-    .hero-summary span {{
-      display: block;
-      margin-bottom: 4px;
-      color: #57408f;
-      font-size: 12px;
-      font-weight: 900;
-    }}
-    .hero-summary p {{
-      margin: 0;
-      font-size: 14px;
-      font-weight: 750;
-      line-height: 1.6;
     }}
     .page-section {{
       margin-top: 22px;
@@ -1526,7 +1482,6 @@ def generate_html(
       .page-hero::after {{ width: 170px; height: 170px; right: -48px; bottom: -74px; }}
       .hero-badge {{ width: 104px; height: 104px; right: 56px; top: auto; bottom: 16px; }}
       .hero-badge strong {{ font-size: 27px; }}
-      .hero-summary {{ display: none; }}
       h1 {{ font-size: 24px; }}
       .hub-grid {{ grid-template-columns: 1fr; }}
       .fact-grid {{ grid-template-columns: 1fr; }}
@@ -1550,7 +1505,6 @@ def generate_html(
       <p class="hero-kicker">{escape(enhancement["kicker"])}</p>
       <h1>{h1}</h1>
       <p class="lead">{lead}</p>
-      {hero_summary_html}
     </div>
     <div class="hero-badge" aria-label="{escape(enhancement["hero_stat"])} {total_count}">
       <span>{escape(enhancement["hero_stat"])}</span>

--- a/apps/scraper/inject_site_header.py
+++ b/apps/scraper/inject_site_header.py
@@ -17,6 +17,7 @@ HEADER_TEMPLATE = """<header class="site-header">
     </a>
     <nav class="site-header__nav" aria-label="{nav_aria}">
       <a class="site-header__link" href="{page_base}map.html">{nav_map}</a>
+      <a class="site-header__link site-header__link--desktop" href="{page_base}summary/">{nav_summary}</a>
       <a class="site-header__link" href="{page_base}pokemon/">{nav_pokemon}</a>
       <a class="site-header__link" href="{asset_base}gmanhole_map.html">{nav_character}</a>
       <a class="site-header__link" data-login-link data-nav-target="login" data-stamp-page="https://pokefuta.com/visits" data-stamp-label="{nav_stamp}" href="https://pokefuta.com/login?from=data">{nav_login}</a>
@@ -28,11 +29,11 @@ SESSION_BADGE_SCRIPT_TEMPLATE = (
 )
 
 NAV_LABELS = {
-    "ja": ("メインナビゲーション", "マップ", "ポケモン", "キャラマンホール", "スタンプ帳", "ログイン"),
-    "en": ("Main navigation", "Map", "Pokémon", "Character Manholes", "Stamp Book", "Login"),
-    "zh-TW": ("主導覽", "地圖", "神奇寶貝", "角色人孔蓋", "集章冊", "登入"),
-    "zh-CN": ("主导航", "地图", "宝可梦", "角色井盖", "集章册", "登录"),
-    "ko": ("메인 내비게이션", "지도", "포켓몬", "캐릭터 맨홀", "스탬프북", "로그인"),
+    "ja": ("メインナビゲーション", "マップ", "サマリー", "ポケモン", "キャラマンホール", "スタンプ帳", "ログイン"),
+    "en": ("Main navigation", "Map", "Summary", "Pokémon", "Character Manholes", "Stamp Book", "Login"),
+    "zh-TW": ("主導覽", "地圖", "摘要", "神奇寶貝", "角色人孔蓋", "集章冊", "登入"),
+    "zh-CN": ("主导航", "地图", "摘要", "宝可梦", "角色井盖", "集章册", "登录"),
+    "ko": ("메인 내비게이션", "지도", "요약", "포켓몬", "캐릭터 맨홀", "스탬프북", "로그인"),
 }
 
 LEGACY_HEADER_RE = re.compile(
@@ -63,7 +64,7 @@ def inject(html: str, asset_base: str = "./", page_base: str | None = None) -> s
     labels = NAV_LABELS[_language(html)]
     substitutions = dict(
         zip(
-            ("nav_aria", "nav_map", "nav_pokemon", "nav_character", "nav_stamp", "nav_login"),
+            ("nav_aria", "nav_map", "nav_summary", "nav_pokemon", "nav_character", "nav_stamp", "nav_login"),
             labels,
         )
     )

--- a/apps/scraper/test_generate_pokemon_index_page.py
+++ b/apps/scraper/test_generate_pokemon_index_page.py
@@ -1,14 +1,8 @@
 import tempfile
-import sys
 import unittest
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).parent))
-
 from generate_pokemon_index_page import _build_latest_photo_cards
-from generate_pokemon_index_page import generate_html
-from generate_pokemon_index_page import LP_INDEX_STRINGS
-from generate_pokemon_pages import LANG_CONFIGS
 
 
 class LatestPhotoCardsTest(unittest.TestCase):
@@ -55,70 +49,6 @@ class LatestPhotoCardsTest(unittest.TestCase):
         self.assertEqual(cards[0]["href"], "/manholes/42/")
         self.assertEqual(cards[0]["title"], "Slowpoke / Pikachu")
         self.assertEqual(cards[0]["location"], "Kagawa 高松市")
-
-    def test_ja_index_hero_has_desktop_summary(self):
-        pokemon_index = {
-            "chansey": (
-                {"names": {"ja": "ラッキー", "en": "Chansey"}, "generation": 1},
-                [
-                    {
-                        "id": "1",
-                        "prefecture": "福島県",
-                        "city": "福島",
-                        "pokemons": ["ラッキー"],
-                    },
-                    {
-                        "id": "2",
-                        "prefecture": "福島県",
-                        "city": "郡山",
-                        "pokemons": ["ラッキー"],
-                    },
-                ],
-            ),
-            "eevee": (
-                {"names": {"ja": "イーブイ", "en": "Eevee"}, "generation": 1},
-                [
-                    {
-                        "id": "3",
-                        "prefecture": "鹿児島県",
-                        "city": "指宿",
-                        "pokemons": ["イーブイ"],
-                    }
-                ],
-            ),
-        }
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            html = generate_html(
-                pokemon_index,
-                "ja",
-                LANG_CONFIGS["ja"],
-                LP_INDEX_STRINGS["ja"],
-                lambda pref: pref,
-                {},
-                Path(tmpdir),
-            )
-
-        self.assertIn('class="hero-summary"', html)
-        self.assertIn("<span>サマリー</span>", html)
-        self.assertIn("2体の登場ポケモンから探せます。", html)
-        self.assertIn("最多はラッキーで、全国2枚のポケふたに登場します。", html)
-        self.assertIn(".hero-summary { display: none; }", html)
-
-    def test_ja_index_hero_summary_is_omitted_for_empty_data(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            html = generate_html(
-                {},
-                "ja",
-                LANG_CONFIGS["ja"],
-                LP_INDEX_STRINGS["ja"],
-                lambda pref: pref,
-                {},
-                Path(tmpdir),
-            )
-
-        self.assertNotIn('class="hero-summary"', html)
-        self.assertNotIn("所在地不明で、全国0枚", html)
 
 
 if __name__ == "__main__":

--- a/apps/scraper/test_generate_pokemon_index_page.py
+++ b/apps/scraper/test_generate_pokemon_index_page.py
@@ -6,6 +6,9 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent))
 
 from generate_pokemon_index_page import _build_latest_photo_cards
+from generate_pokemon_index_page import generate_html
+from generate_pokemon_index_page import LP_INDEX_STRINGS
+from generate_pokemon_pages import LANG_CONFIGS
 
 
 class LatestPhotoCardsTest(unittest.TestCase):
@@ -52,6 +55,35 @@ class LatestPhotoCardsTest(unittest.TestCase):
         self.assertEqual(cards[0]["href"], "/manholes/42/")
         self.assertEqual(cards[0]["title"], "Slowpoke / Pikachu")
         self.assertEqual(cards[0]["location"], "Kagawa 高松市")
+
+    def test_pokemon_index_does_not_render_hero_summary_panel(self):
+        pokemon_index = {
+            "slowpoke": (
+                {"names": {"ja": "ヤドン", "en": "Slowpoke"}, "generation": 1},
+                [
+                    {
+                        "id": "42",
+                        "title": "香川県/高松市",
+                        "prefecture": "香川県",
+                        "city": "高松市",
+                        "pokemons": ["ヤドン"],
+                    }
+                ],
+            ),
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            html = generate_html(
+                pokemon_index,
+                "ja",
+                LANG_CONFIGS["ja"],
+                LP_INDEX_STRINGS["ja"],
+                lambda pref: pref,
+                {},
+                Path(tmpdir),
+            )
+
+        self.assertNotIn('class="hero-summary"', html)
 
 
 if __name__ == "__main__":

--- a/apps/scraper/test_generate_pokemon_index_page.py
+++ b/apps/scraper/test_generate_pokemon_index_page.py
@@ -1,6 +1,9 @@
 import tempfile
+import sys
 import unittest
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
 
 from generate_pokemon_index_page import _build_latest_photo_cards
 

--- a/apps/scraper/test_inject_site_header.py
+++ b/apps/scraper/test_inject_site_header.py
@@ -19,6 +19,7 @@ class InjectSiteHeaderTest(unittest.TestCase):
         self.assertIn('class="site-header__brand-name">ポケふた図鑑</span>', result)
         self.assertNotIn("DATABASE", result)
         self.assertIn('href="./map.html">マップ</a>', result)
+        self.assertIn('href="./summary/">サマリー</a>', result)
         self.assertIn('<body class="has-site-header">', result)
 
     def test_preserves_existing_body_classes(self):
@@ -60,6 +61,7 @@ class InjectSiteHeaderTest(unittest.TestCase):
         result = inject(html, asset_base="../../../", page_base="../../")
         self.assertIn('href="../../../assets/site-header.css"', result)
         self.assertIn('href="../../map.html">Map</a>', result)
+        self.assertIn('href="../../summary/">Summary</a>', result)
         self.assertIn('href="../../pokemon/">Pokémon</a>', result)
         self.assertIn('href="../../../gmanhole_map.html">Character Manholes</a>', result)
         self.assertIn('data-stamp-page="https://pokefuta.com/visits"', result)
@@ -67,6 +69,7 @@ class InjectSiteHeaderTest(unittest.TestCase):
         self.assertIn('href="https://pokefuta.com/login?from=data">Login</a>', result)
         self.assertIn('src="../../../assets/session-badge.js"', result)
         self.assertEqual(result.count('class="site-header__link"'), 4)
+        self.assertEqual(result.count('class="site-header__link site-header__link--desktop"'), 1)
 
     def test_injects_login_link_for_japanese_page(self):
         result = inject("<!doctype html><html><head></head><body><main></main></body></html>")

--- a/apps/web/assets/site-header.css
+++ b/apps/web/assets/site-header.css
@@ -115,6 +115,10 @@ body.has-site-header {
     text-align: center;
     text-overflow: ellipsis;
   }
+
+  .site-header__link--desktop {
+    display: none;
+  }
 }
 
 /* Full-screen maps must reserve room for the shared header. */


### PR DESCRIPTION
## Summary
- remove the mistakenly added Pokemon index hero summary panel
- add the Summary link to the shared site header module
- hide the Summary link on mobile to preserve the compact header

## Validation
- python3 -m unittest test_inject_site_header.py test_generate_pokemon_index_page.py (cwd=apps/scraper)
- python3 apps/scraper/generate_pokemon_index_page.py
- python3 apps/scraper/inject_site_header.py dist
- local Playwright check for /pokemon/: desktop header Summary visible, mobile hidden, no hero-summary block, no horizontal overflow
- git diff --check