### PR TITLE
feat: run-pokefuta-tracker スキル（ローカル起動・スモークテスト・スクリーンショットのドライバー）

### DIFF
--- a/.claude/skills/run-pokefuta-tracker/SKILL.md
+++ b/.claude/skills/run-pokefuta-tracker/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: run-pokefuta-tracker
+description: Build, run, smoke-test, and screenshot the pokefuta-tracker static site (data.pokefuta.com) locally. Use when asked to run/start the app or dev server, verify a change in the real browser, take a screenshot of a page, or smoke-test the site build.
+---
+
+# Run pokefuta-tracker
+
+静的サイト（GitHub Pages / data.pokefuta.com）。ソースは `apps/web/` + Python生成スクリプト（`apps/scraper/`）→ `dist/`（gitignore済み）に焼き込み、`python3 -m http.server` で配信する。エージェントは **`driver.sh`** で起動・スモーク・スクリーンショットまで一発で行う。パスはすべてリポジトリルート基準。
+
+## Run（エージェント用 — まずこれ）
+
+```bash
+.claude/skills/run-pokefuta-tracker/driver.sh
+```
+
+やること: `apps/web/` → `dist/` 同期 → :8000 で配信（nohupでデタッチ、シェルが死んでも生存）→ 主要9ページの curl スモーク（200+コンテンツマーカー）→ ヘッドレスChromeで3枚スクリーンショット。**最後に `ALL OK` が出て、サーバーは起動したまま残る。**
+
+- スクリーンショット出力先: `$TMPDIR/pokefuta-run/{index,design_manhole,prefecture}.png` — **必ず Read で目視確認する**（真っ白/エラーページならFAIL扱い）
+- ポート/出力先の変更: `PORT=8001 SS_DIR=/path driver.sh`
+- 停止: `.claude/skills/run-pokefuta-tracker/driver.sh stop`
+- 前提: `dist/` が存在すること。無ければ下の Build を先に実行。
+
+個別ページを追加でスクリーンショットしたい場合（driver.shの `shot` と同じパターン）:
+
+```bash
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --headless=new --disable-gpu \
+  --user-data-dir="$(mktemp -d)" --window-size=1280,900 --virtual-time-budget=8000 \
+  --screenshot=/tmp/page.png http://localhost:8000/summary/ >/dev/null 2>&1 &
+CPID=$!; for _ in $(seq 1 30); do [ -s /tmp/page.png ] && break; sleep 1; done; kill $CPID 2>/dev/null
+```
+
+## Prerequisites
+
+- Python 3（3.14で検証）。サイトビルドの外部依存は **Pillow のみ**（`generate_summary_ogp.py` 用）。確認: `python3 -c "import PIL"`
+- 無い場合: `python3 -m venv .venv && .venv/bin/pip install Pillow` して `python3` を `.venv/bin/python3` に読み替え
+- `pip3 install -r requirements.txt` は **Homebrew Python では失敗する**（PEP 668 externally-managed）。requirements.txt の bs4/cairosvg/requests はスクレイパー（CI）用で、ローカルのサイトビルドには不要
+- スクリーンショット: Google Chrome（`/Applications/Google Chrome.app`）
+
+## Build（クリーンチェックアウト → dist/ 生成、約1〜2分）
+
+pages-deploy.yml と同じ手順のローカル版。全部リポジトリルートで実行（検証済み）:
+
+```bash
+python3 apps/scraper/generate_prefecture_trivia.py --check
+python3 apps/scraper/generate_manhole_pages.py
+python3 apps/scraper/generate_pokemon_pages.py
+python3 apps/scraper/generate_pokemon_index_page.py
+python3 apps/scraper/generate_summary_ogp.py
+python3 apps/scraper/generate_summary_pages.py
+python3 apps/scraper/generate_prefecture_pages.py
+python3 apps/scraper/generate_sitemap.py
+cp apps/web/index.html dist/index.html
+cp apps/web/nearby_manholes.html dist/nearby.html
+cp apps/web/map.html dist/map.html
+cp apps/web/gmanhole_map.html dist/gmanhole_map.html
+cp apps/web/design_manhole.html dist/design_manhole.html
+cp apps/web/login.html dist/login.html
+cp apps/web/sitemap.xml dist/sitemap.xml
+cp apps/web/robots.txt dist/robots.txt
+python3 tools/build_i18n.py
+echo '<!doctype html><meta http-equiv="refresh" content="0; url=./nearby.html">' > dist/nearby_manholes.html
+python3 apps/scraper/inject_site_header.py dist
+mkdir -p dist/assets dist/manhole/image dist/api
+cp -r apps/web/assets/* dist/assets/
+cp -r dataset/manhole/image/* dist/manhole/image/
+cp docs/pokefuta.ndjson docs/gmanhole.ndjson docs/character_manholes.ndjson docs/latest-manhole-photos.json docs/pokemon_metadata.json dist/
+cp docs/api/*.json dist/api/
+python3 apps/scraper/generate_top_feed.py --output dist/api/top-feed.json
+```
+
+結果: dist/ ≈ 102MB、HTML 約3,300ページ。**スキップしてよいもの**: `generate_manhole_ogp.py`（マンホール別OGP画像。CI専用・遅い・ローカル表示に不要）。
+
+## Run（人間用）
+
+`/dev` コマンド（`.claude/commands/dev.md`）= 同期+配信のみの軽量版。または driver.sh を実行してブラウザで http://localhost:8000 を開く。
+
+## Test
+
+```bash
+cd apps/scraper && python3 -m unittest discover -p 'test_*.py'
+```
+
+65テスト・約0.1秒。**mainでも 4 failures + 2 errors が出るのが既知の状態**（summary系の古いテスト）。自分の変更の影響を見るときは main での結果と比較すること。pytest は入っていない（`python3 -m pytest` は No module named pytest）。
+
+## Gotchas（全部このマシンで実際に踏んだもの）
+
+- **Chrome `--headless=new --screenshot` はPNGを書いた後も終了しないことがある**（ページのタイマー/フェッチが生きている）。フォアグラウンドで待つとハングに見える。→ バックグラウンド起動してファイル出現をポーリングし kill（driver.sh の `shot` 参照）
+- **`--user-data-dir` を使い回すと2回目の起動がプロファイルロックで無限に待つ**。→ 毎回 `mktemp -d`
+- **ツール呼び出しのシェル内で `(cmd &)` で起動したサーバーは、そのシェルがタイムアウト/SIGTERMされるとプロセスグループごと死ぬ**。スクリーンショットが突然 `ERR_CONNECTION_REFUSED` になったらこれ。→ driver.sh は `nohup + disown` で起動する
+- **`apps/web/*.html` を dist へ同期すると `inject_site_header.py` の注入前ソースに戻る**。共通ヘッダーの見た目を確認したいときは同期後に `python3 apps/scraper/inject_site_header.py dist` を再実行
+- **「みんなの投稿」ギャラリー等はローカルでは出ない**。pokefuta.com のAPI（CORS/Supabase）に依存し、失敗時はセクションごと非表示になる仕様。ローカルで空でもバグではない
+- 地図タイル（OpenStreetMap）とLeafletはCDN読みなのでネット接続が必要。オフラインだと地図部分だけ空になる
+
+## Troubleshooting
+
+| 症状 | 原因と対処 |
+|---|---|
+| スクリーンショットが「このサイトにアクセスできません ERR_CONNECTION_REFUSED」 | サーバーが死んでいる（上記プロセスグループ問題）。driver.sh で立て直す |
+| `pip3 install -r requirements.txt` が `externally-managed-environment` で失敗 | 正常。ビルドに必要なのはPillowだけ。無ければ venv（Prerequisites参照） |
+| Chrome コマンドが返ってこない | 正常動作の範囲。PNGは大抵書き込み済み。ファイルを確認して kill |
+| `driver.sh` が `dist/ missing` | クリーンチェックアウト。Build セクションを先に実行 |

--- a/.claude/skills/run-pokefuta-tracker/driver.sh
+++ b/.claude/skills/run-pokefuta-tracker/driver.sh
@@ -9,7 +9,7 @@ ROOT="$(git rev-parse --show-toplevel)" || { echo "[driver] ERROR: not in a git 
 PORT="${PORT:-8000}"
 SS_DIR="${SS_DIR:-${TMPDIR:-/tmp}/pokefuta-run}"
 CHROME="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
-command -v "$CHROME" >/dev/null 2>&1 || CHROME="$(command -v google-chrome || command -v chromium || true)"
+[ -x "$CHROME" ] || CHROME="$(command -v google-chrome || command -v chromium || true)"
 
 kill_port() {
   local pid; pid=$(lsof -ti:"$PORT" 2>/dev/null)
@@ -30,6 +30,7 @@ cp apps/web/gmanhole_map.html dist/gmanhole_map.html
 cp apps/web/design_manhole.html dist/design_manhole.html
 cp apps/web/login.html dist/login.html 2>/dev/null || true
 cp apps/web/robots.txt dist/robots.txt
+cp apps/web/sitemap.xml dist/sitemap.xml 2>/dev/null || true
 cp -r apps/web/assets/. dist/assets/
 # docs/ の公開データも同期（古いdistだと api/*.json が欠けていることがある）
 mkdir -p dist/api

--- a/.claude/skills/run-pokefuta-tracker/driver.sh
+++ b/.claude/skills/run-pokefuta-tracker/driver.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# pokefuta-tracker 静的サイトのローカル起動 + スモークテスト + スクリーンショット。
+# Usage:
+#   driver.sh          # sync → serve → curl smoke → screenshots → サーバーは起動したまま
+#   driver.sh stop     # ポートのサーバーを停止
+# 環境変数: PORT (default 8000), SS_DIR (スクリーンショット出力先, default $TMPDIR/pokefuta-run)
+set -u
+ROOT="$(git rev-parse --show-toplevel)" || { echo "[driver] ERROR: not in a git repo"; exit 1; }
+PORT="${PORT:-8000}"
+SS_DIR="${SS_DIR:-${TMPDIR:-/tmp}/pokefuta-run}"
+CHROME="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+command -v "$CHROME" >/dev/null 2>&1 || CHROME="$(command -v google-chrome || command -v chromium || true)"
+
+kill_port() {
+  local pid; pid=$(lsof -ti:"$PORT" 2>/dev/null)
+  [ -n "$pid" ] && kill $pid 2>/dev/null && echo "[driver] stopped server on :$PORT"
+}
+
+if [ "${1:-}" = "stop" ]; then kill_port; exit 0; fi
+
+[ -d "$ROOT/dist" ] || { echo "[driver] ERROR: dist/ missing — SKILL.md の Build セクションを先に実行"; exit 1; }
+mkdir -p "$SS_DIR" "$ROOT/dist/assets"
+
+# ── apps/web → dist 同期（pages-deploy.yml と同じマッピング）──
+cd "$ROOT"
+cp apps/web/index.html dist/index.html
+cp apps/web/nearby_manholes.html dist/nearby.html
+cp apps/web/map.html dist/map.html 2>/dev/null || true
+cp apps/web/gmanhole_map.html dist/gmanhole_map.html
+cp apps/web/design_manhole.html dist/design_manhole.html
+cp apps/web/login.html dist/login.html 2>/dev/null || true
+cp apps/web/robots.txt dist/robots.txt
+cp -r apps/web/assets/. dist/assets/
+# docs/ の公開データも同期（古いdistだと api/*.json が欠けていることがある）
+mkdir -p dist/api
+cp docs/api/*.json dist/api/ 2>/dev/null || true
+cp docs/pokefuta.ndjson docs/gmanhole.ndjson docs/character_manholes.ndjson docs/latest-manhole-photos.json docs/pokemon_metadata.json dist/ 2>/dev/null || true
+echo "[driver] synced apps/web + docs data -> dist"
+
+# ── サーバー起動（nohup で完全にデタッチ: 呼び出し元シェルが死んでも生き残る）──
+kill_port
+nohup python3 -m http.server "$PORT" --directory "$ROOT/dist" >/dev/null 2>&1 &
+disown 2>/dev/null || true
+sleep 1
+curl -sf -o /dev/null "http://localhost:$PORT/" || { echo "[driver] ERROR: server failed to start"; exit 1; }
+echo "[driver] serving dist/ at http://localhost:$PORT"
+
+# ── curl スモーク: ステータス + コンテンツマーカー ──
+FAIL=0
+check() { # path marker
+  local body; body=$(curl -sf "http://localhost:$PORT$1")
+  if [ $? -ne 0 ]; then echo "[smoke] FAIL $1 (not 200)"; FAIL=1; return; fi
+  if echo "$body" | grep -q "$2"; then echo "[smoke] ok   $1"; else echo "[smoke] FAIL $1 (marker '$2' not found)"; FAIL=1; fi
+}
+check /                     "ポケふた"
+check /design_manhole.html  "FAQPage"
+check /gmanhole_map.html    "キャラマンホール"
+check /summary/             "ポケふた"
+check /robots.txt           "Sitemap:"
+check /api/site-stats.json  '"manholes"'
+check /pokefuta.ndjson      '"id"'
+first_manhole=$(ls dist/manholes 2>/dev/null | head -1)
+[ -n "$first_manhole" ] && check "/manholes/$first_manhole/" "ポケふた" || echo "[smoke] skip /manholes/ (未生成)"
+first_pref=$(ls dist/prefectures 2>/dev/null | head -1)
+[ -n "$first_pref" ] && check "/prefectures/$first_pref/" "ポケふた" || echo "[smoke] skip /prefectures/ (未生成)"
+
+# ── スクリーンショット（Chromeは撮影後も終了しないことがある → ファイル出現を待って kill）──
+shot() { # path outfile
+  [ -n "$CHROME" ] || { echo "[ss] skip $1 (chrome not found)"; return; }
+  local out="$SS_DIR/$2" prof; prof=$(mktemp -d)
+  rm -f "$out"
+  "$CHROME" --headless=new --disable-gpu --user-data-dir="$prof" \
+    --window-size=1280,900 --virtual-time-budget=8000 --hide-scrollbars \
+    --screenshot="$out" "http://localhost:$PORT$1" >/dev/null 2>&1 &
+  local cpid=$!
+  for _ in $(seq 1 30); do [ -s "$out" ] && break; sleep 1; done
+  sleep 1
+  kill "$cpid" 2>/dev/null; wait "$cpid" 2>/dev/null
+  rm -rf "$prof"
+  if [ -s "$out" ]; then echo "[ss] $out"; else echo "[ss] FAIL $1"; FAIL=1; fi
+}
+shot /                    index.png
+shot /design_manhole.html design_manhole.png
+[ -n "$first_pref" ] && shot "/prefectures/$first_pref/" "prefecture.png"
+
+echo
+if [ "$FAIL" = 0 ]; then echo "[driver] ALL OK — server still running on :$PORT ('driver.sh stop' で停止)"; else echo "[driver] FAILURES above — server on :$PORT"; exit 1; fi


### PR DESCRIPTION
## 概要
エージェント（Claude Code）や開発者がこのサイトをローカルで「起動して・叩いて・目視確認する」ための run スキルを追加。

## 内容
- `.claude/skills/run-pokefuta-tracker/driver.sh` — 一発実行のドライバー:
  1. `apps/web/` と docs 公開データ（api/*.json, *.ndjson）を `dist/` に同期
  2. `python3 -m http.server` を nohup でデタッチ起動（:8000）
  3. 主要9ページを curl スモーク（200 + コンテンツマーカー検証）
  4. ヘッドレスChromeでトップ / design_manhole / 都道府県ページをスクリーンショット
- `SKILL.md` — クリーンチェックアウトからの dist ビルド手順（git worktree で実地検証済み、外部依存はPillowのみ）、実際に踏んだGotchas（Chrome headlessが終了しない問題、プロファイルロック、プロセスグループ死亡等）

## 検証
- クリーンworktreeでゼロからビルド（3,299 HTML / 102MB）→ driver.sh 全項目 ALL OK
- 本リポジトリの既存 dist でも実行し、api/*.json 欠落ケースを発見して同期処理に反映
- スクリーンショット3枚を目視確認（トップの地図クラスタ・LP・都道府県ページすべて正常描画）

🤖 Generated with [Claude Code](https://claude.com/claude-code)