### PR TITLE
chore: 写真取り込みActionを週次から日次に変更（JST 07:00）

### DIFF
--- a/.claude/commands/import-photos.md
+++ b/.claude/commands/import-photos.md
@@ -1,6 +1,6 @@
 Sync the latest manhole photos manually.
 
-NOTE: 通常は `.github/workflows/import-manhole-photos.yml` が週次（JST 日曜 07:00）で export〜画像DL〜commit まで自動実行する。このスキルは即時反映したいときや Action が失敗したときの手動フォールバック。
+NOTE: 通常は `.github/workflows/import-manhole-photos.yml` が日次（JST 07:00）で export〜画像DL〜commit まで自動実行する。このスキルは即時反映したいときや Action が失敗したときの手動フォールバック。
 
 Run these two steps in order:
 

--- a/.github/workflows/import-manhole-photos.yml
+++ b/.github/workflows/import-manhole-photos.yml
@@ -1,4 +1,4 @@
-name: Weekly Manhole Photos Import
+name: Daily Manhole Photos Import
 
 # pokefuta.com の公開写真を Supabase からエクスポートし、ローカル画像として取り込む。
 # 従来の手動フロー（pokefuta 側 /export-photos → 本リポジトリ /import-photos）の自動化版。
@@ -6,8 +6,8 @@ name: Weekly Manhole Photos Import
 
 on:
   schedule:
-    # Run weekly on Saturday 22:00 UTC (JST Sunday 07:00)
-    - cron: '0 22 * * 6'
+    # Run daily at 22:00 UTC (JST 07:00)
+    - cron: '0 22 * * *'
   workflow_dispatch: # Allow manual trigger
 
 permissions:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 manhole_titles.jsonは手動で更新している
 pokefuta.ndjsonはapps/scraperで更新している
-latest-manhole-photos.json は import-manhole-photos.yml が Supabase から週次自動生成（画像DL込み。手動で回すときだけ `/import-photos` スキル）
+latest-manhole-photos.json は import-manhole-photos.yml が Supabase から日次自動生成（画像DL込み。手動で回すときだけ `/import-photos` スキル）
 docs/api/*.json は bake-app-data.yml が Supabase から日次生成（pokefuta.com アプリの /api/manholes・/api/site-stats がこれを読む）
 
 ## ディレクトリ構成


### PR DESCRIPTION
import-manhole-photos.yml の cron を `0 22 * * 6`（週次・JST日曜07:00）から `0 22 * * *`（日次・JST07:00）に変更。CLAUDE.md と /import-photos スキルの記述も日次に更新。

🤖 Generated with [Claude Code](https://claude.com/claude-code)