### PR TITLE
fix: ignore initial crawl month in prefecture summaries

### DIFF
--- a/apps/scraper/generate_prefecture_pages.py
+++ b/apps/scraper/generate_prefecture_pages.py
@@ -29,6 +29,7 @@ DEFAULT_TRIVIA = ROOT / "dataset" / "prefecture_trivia.json"
 DEFAULT_OUTPUT = ROOT / "dist" / "prefectures"
 BASE_URL = "https://data.pokefuta.com"
 OG_IMAGE = f"{BASE_URL}/assets/ogp/pokefuta_summary_ogp.png"
+RELIABLE_FIRST_SEEN_START = datetime.fromisoformat("2025-11-01T00:00:00+00:00")
 
 REGIONS: list[tuple[str, list[str]]] = [
     ("北海道・東北", PREFECTURE_ORDER[0:7]),
@@ -180,6 +181,16 @@ def _format_year_month(date: datetime) -> str:
     return f"{date.year}年{date.month}月"
 
 
+def _first_reliable_month(records: list[dict]) -> str:
+    first_dates = [date for record in records if (date := _record_date(record))]
+    if not first_dates:
+        return ""
+    first_date = min(first_dates)
+    if first_date < RELIABLE_FIRST_SEEN_START:
+        return ""
+    return _format_year_month(first_date)
+
+
 def _hero_summary(
     prefecture: str,
     count: int,
@@ -195,8 +206,7 @@ def _hero_summary(
         if str(record.get("city", "")).strip()
     }
     municipalities = (trivia_entry or {}).get("municipality_count", 0) or len(cities)
-    first_dates = [date for record in records if (date := _record_date(record))]
-    first_month = _format_year_month(min(first_dates)) if first_dates else ""
+    first_month = _first_reliable_month(records)
     if first_month:
         return (
             f"{prefecture}は{first_month}にポケふた初登場。"

--- a/apps/scraper/test_generate_prefecture_pages.py
+++ b/apps/scraper/test_generate_prefecture_pages.py
@@ -117,6 +117,19 @@ class GeneratePrefecturePagesTest(unittest.TestCase):
         self.assertIn("現在は6自治体で6枚を巡れます。", html)
         self.assertIn(".hero-summary { display: none; }", html)
 
+    def test_prefecture_summary_omits_initial_crawl_month(self) -> None:
+        records = [r for r in self.records if r.get("prefecture") == "福井県"]
+        html = MODULE.build_page(
+            "福井県",
+            "fukui",
+            records,
+            MODULE.build_rankings(self.records)["福井県"],
+            self.pokemon_slugs,
+            self.trivia["福井県"],
+        )
+        self.assertIn("福井県では16自治体で17枚のポケふたを巡れます。", html)
+        self.assertNotIn("福井県は2025年10月にポケふた初登場。", html)
+
     def test_tied_counts_share_rank(self) -> None:
         records = [
             {"id": "1", "status": "active", "prefecture": "青森県"},


### PR DESCRIPTION
## Summary
- Stop showing prefecture first-appearance months when the earliest detected date is before 2025-11-01.
- Keep reliable post-initial-crawl months, such as Nagano 2026-07, visible.
- Add regression coverage for omitting the 2025-10 initial crawl month.

## Validation
- python3 -m unittest apps.scraper.test_generate_prefecture_pages
- python3 apps/scraper/generate_prefecture_pages.py
- rg -n "2025年10月にポケふた初登場" dist/prefectures || true
- rg -n "長野県は2026年7月にポケふた初登場|福井県では16自治体で17枚" dist/prefectures/nagano/index.html dist/prefectures/fukui/index.html