### PR TITLE
fix: latest_visit_at を shot_at → created_at に修正

### DIFF
--- a/apps/scraper/export_app_snapshot.py
+++ b/apps/scraper/export_app_snapshot.py
@@ -260,7 +260,7 @@ def build_site_stats() -> dict:
         "manholes_with_photos": manholes_with_photos,
         "latest_photo_at": fetch_first("photo", "created_at", "created_at.desc"),
         "latest_user_at": fetch_first("app_user", "created_at", "created_at.desc"),
-        "latest_visit_at": fetch_first("visit", "shot_at", "shot_at.desc"),
+        "latest_visit_at": fetch_first("visit", "created_at", "created_at.desc"),
         "posts_last_7d": fetch_count("photo", {"created_at": f"gte.{ago_7d}"}),
         "posts_last_30d": fetch_count("photo", {"created_at": f"gte.{ago_30d}"}),
         "auth_users": auth_users,


### PR DESCRIPTION
## Summary

- `export_app_snapshot.py` の `latest_visit_at` 取得を `shot_at` → `created_at` に変更
- `shot_at` はユーザー入力の撮影日時のため過去日付（例: 2025年）が入ることがあり、スナップショットの値が更新されなくなる問題を修正
- `latest_photo_at` / `latest_user_at` と同じく DB 挿入日時（`created_at`）を使うよう統一

## Test plan

- [ ] 次回 bake 実行後、`data.pokefuta.com/api/site-stats.json` の `latest_visit_at` が最新日付になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)