### PR TITLE
feat: route prefecture links to landing pages

### DIFF
--- a/apps/scraper/generate_manhole_pages.py
+++ b/apps/scraper/generate_manhole_pages.py
@@ -23,6 +23,13 @@ from xml.sax.saxutils import escape
 sys.path.insert(0, str(Path(__file__).parent))
 from generate_pokemon_pages import _FORM_PREFIX, _normalize_katakana  # noqa: E402
 
+try:
+    from apps.scraper.prefectures import PREFECTURE_SLUGS  # noqa: E402
+except ModuleNotFoundError as exc:
+    if exc.name != "apps":
+        raise
+    from prefectures import PREFECTURE_SLUGS  # noqa: E402
+
 # Constants
 BASE_URL = "https://data.pokefuta.com/"
 GA_MEASUREMENT_ID = "G-K18NR4GZG2"
@@ -426,7 +433,8 @@ def generate_html(
 
     canonical_url = f"{BASE_URL}manholes/{quote(manhole_id)}/"
     map_url = f"{BASE_URL}?manhole={quote(manhole_id)}"
-    pref_url = f"{BASE_URL}?pref={quote(prefecture)}"
+    pref_page_slug = PREFECTURE_SLUGS.get(prefecture, "")
+    pref_url = f"/prefectures/{quote(pref_page_slug)}/" if pref_page_slug else f"{BASE_URL}?pref={quote(prefecture)}"
 
     # _js_json() serializes values for safe embedding inside <script> blocks:
     # json.dumps handles quotes/backslashes; the </  → <\/ replacement prevents
@@ -759,8 +767,7 @@ def generate_html(
         )
     if prefecture_site_url:
         link_cards.append(
-            f"<a class='link-card link-card--pref-site' href=\"{escape(prefecture_site_url)}\""
-            f" target=\"_blank\" rel=\"noopener noreferrer\">"
+            f"<a class='link-card link-card--pref-site' href=\"{escape(pref_url)}\">"
             f"{_icon('icon-link-prefecture', 'link-card-icon')}<span>{escape(prefecture)}の公式</span></a>"
         )
     if prefecture:

--- a/apps/scraper/generate_manhole_pages.py
+++ b/apps/scraper/generate_manhole_pages.py
@@ -735,9 +735,6 @@ def generate_html(
     jsonld_str = json.dumps(jsonld, ensure_ascii=False, indent=2)
 
     # Links grid: external + internal + photo upload (移設統合)
-    _pref_site_raw = manhole.get("prefecture_site_url", "") or ""
-    _pref_parsed = urlparse(_pref_site_raw)
-    prefecture_site_url = _pref_site_raw if _pref_parsed.scheme in ("http", "https") else ""
     link_cards: list[str] = []
     # Share first: X / LINE / Web Share
     _share_onclick = _attr_json({"manhole_id": manhole_id, "prefecture": prefecture, "city": city})
@@ -764,12 +761,6 @@ def generate_html(
             f" target=\"_blank\" rel=\"noopener noreferrer\""
             f" onclick=\"trackEvent('click_official_site', {onclick_params})\">"
             f"{_icon('icon-link-official', 'link-card-icon')}<span>公式サイト</span></a>"
-        )
-    if prefecture_site_url:
-        link_cards.append(
-            f"<a class='link-card link-card--pref-site' href=\"{escape(prefecture_site_url)}\""
-            f" target=\"_blank\" rel=\"noopener noreferrer\">"
-            f"{_icon('icon-link-prefecture', 'link-card-icon')}<span>{escape(prefecture)}の公式</span></a>"
         )
     if prefecture:
         link_cards.append(
@@ -1427,7 +1418,6 @@ def generate_html(
     .link-card span {{ display: block; }}
 
     .link-card--official   {{ background: #fff4f0; color: #c0392b; border-color: #f5c0b0; }}
-    .link-card--pref-site  {{ background: #f0fff4; color: #1a6b3c; border-color: #b0e8c8; }}
     .link-card--internal   {{ background: #f8f4ff; color: #5a3fa0; border-color: #d8c8f5; }}
     .link-card--share-x    {{ background: #f5f5f5; color: #444; border-color: #d8d8d8; }}
     .link-card--share-line {{ background: #f0faf5; color: #217a48; border-color: #b0e0c8; }}

--- a/apps/scraper/generate_manhole_pages.py
+++ b/apps/scraper/generate_manhole_pages.py
@@ -767,7 +767,8 @@ def generate_html(
         )
     if prefecture_site_url:
         link_cards.append(
-            f"<a class='link-card link-card--pref-site' href=\"{escape(pref_url)}\">"
+            f"<a class='link-card link-card--pref-site' href=\"{escape(prefecture_site_url)}\""
+            f" target=\"_blank\" rel=\"noopener noreferrer\">"
             f"{_icon('icon-link-prefecture', 'link-card-icon')}<span>{escape(prefecture)}の公式</span></a>"
         )
     if prefecture:

--- a/apps/scraper/generate_prefecture_pages.py
+++ b/apps/scraper/generate_prefecture_pages.py
@@ -8,7 +8,7 @@ import json
 from collections import Counter
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 from xml.sax.saxutils import escape
 
 try:
@@ -370,6 +370,24 @@ def _related_prefectures(prefecture: str) -> str:
     )
 
 
+def _prefecture_official_url(records: list[dict]) -> str:
+    for record in records:
+        candidate = str(record.get("prefecture_site_url", "") or "").strip()
+        if not candidate:
+            continue
+        try:
+            parsed = urlparse(candidate)
+        except ValueError:
+            continue
+        if parsed.scheme == "https" and parsed.netloc == "local.pokemon.jp":
+            return candidate
+    return ""
+
+
+def _escape_attr(value: str) -> str:
+    return escape(value, {'"': "&quot;"})
+
+
 def _hero_intro(
     prefecture: str,
     count: int,
@@ -421,6 +439,13 @@ def build_page(
     rank_label = f"全国{rank}位" if rank else "現在未設置"
     hero_intro = _hero_intro(prefecture, count, trivia_entry)
     hero_summary = _hero_summary(prefecture, count, records, trivia_entry)
+    official_url = _prefecture_official_url(records)
+    official_cta = (
+        f'<a class="button official" href="{_escape_attr(official_url)}" target="_blank" '
+        f'rel="noopener noreferrer" data-track="prefecture_official_click" '
+        f'data-destination="prefecture_official">{escape(prefecture)}公式を見る</a>'
+        if official_url else ""
+    )
     map_points = [
         {
             "id": str(record.get("id", "")),
@@ -531,6 +556,7 @@ def build_page(
     .button.secondary {{ background: #6b4aa2; }}
     .button.pokefuta {{ background: #b5483c; }}
     .button.photo {{ background: #2d846c; }}
+    .button.official {{ background: #8a5a20; }}
     section {{
       margin-top: 22px; padding: 20px; border: 1px solid rgba(93,67,35,.14);
       border-radius: 19px; background: #fffaf0;
@@ -637,6 +663,7 @@ def build_page(
             data-track="prefecture_visit_cta_click" data-destination="pokefuta_visits">訪問記録を残す</a>
           <a class="button photo" href="https://pokefuta.com/"
             data-track="prefecture_photo_cta_click" data-destination="pokefuta_photos">写真を見る</a>
+          {official_cta}
           <a class="button secondary" href="{escape(map_href)}"
             data-track="prefecture_map_click" data-destination="map">全国マップで見る</a>
         </div>

--- a/apps/web/map.template.html
+++ b/apps/web/map.template.html
@@ -1982,7 +1982,12 @@
         let siteCell = `<span class="prefecture-site-link prefecture-site-link--empty">${I.noSite}</span>`;
         if (siteUrl) {
           const anchor = document.createElement('a');
-          anchor.href = getPrefecturePageUrl(prefecture) || siteUrl;
+          const prefecturePageUrl = getPrefecturePageUrl(prefecture);
+          anchor.href = prefecturePageUrl || siteUrl;
+          if (!prefecturePageUrl) {
+            anchor.target = '_blank';
+            anchor.rel = 'noopener noreferrer';
+          }
           anchor.className = 'prefecture-site-link';
           anchor.textContent = `${prefecture}${UI_TEXT.prefectureSite}`;
           siteCell = anchor.outerHTML;

--- a/apps/web/map.template.html
+++ b/apps/web/map.template.html
@@ -804,6 +804,11 @@
       return safeId ? window.buildManholeCanonicalPath(safeId) : '';
     }
 
+    function getPrefecturePageUrl(prefecture) {
+      const slug = window.PREFECTURE_SLUG_MAP[prefecture];
+      return slug ? `/prefectures/${encodeURIComponent(slug)}/` : '';
+    }
+
     function getAbsoluteManholePageUrl(id) {
       const path = getManholePageUrl(id);
       return path ? new URL(path, window.location.origin).href : '';
@@ -1977,9 +1982,7 @@
         let siteCell = `<span class="prefecture-site-link prefecture-site-link--empty">${I.noSite}</span>`;
         if (siteUrl) {
           const anchor = document.createElement('a');
-          anchor.href = siteUrl;
-          anchor.target = '_blank';
-          anchor.rel = 'noopener noreferrer';
+          anchor.href = getPrefecturePageUrl(prefecture) || siteUrl;
           anchor.className = 'prefecture-site-link';
           anchor.textContent = `${prefecture}${UI_TEXT.prefectureSite}`;
           siteCell = anchor.outerHTML;
@@ -2132,7 +2135,7 @@
         .sort((a, b) => window.PREFECTURE_CODE_MAP[a].localeCompare(window.PREFECTURE_CODE_MAP[b]));
       links.innerHTML = prefectures.map(prefecture => {
         const count = prefectureCounts[prefecture] || 0;
-        const href = window.buildCanonicalPath(prefecture);
+        const href = getPrefecturePageUrl(prefecture) || window.buildCanonicalPath(prefecture);
         return `<a href="${href}" data-prefecture="${escapeHtml(prefecture)}">${escapeHtml(prefecture)}<span>${count}${window.I18N.countSuffix}</span></a>`;
       }).join('');
     }


### PR DESCRIPTION
## Summary
- Route map and generated manhole prefecture links to static /prefectures/{slug}/ landing pages when a slug is available.
- Add a prefecture landing-page CTA back to the official local.pokemon.jp page.
- Keep generated page imports working both as package imports and direct script execution.

## Verification
- python3 -m compileall apps/scraper/generate_manhole_pages.py apps/scraper/generate_prefecture_pages.py tools/build_i18n.py
- python3 tools/build_i18n.py
- python3 apps/scraper/generate_prefecture_pages.py
- python3 apps/scraper/generate_manhole_pages.py
- python3 -m unittest apps.scraper.test_collect_character_manholes
- git diff --check

## Known unrelated test failure
- python3 -m unittest apps.scraper.test_generate_summary_pages currently fails 4 existing assertions around apps/web/index.template.html expected popup/localization strings, outside this PR's changed files.