### PR TITLE
Fix prefecture page navigation

### DIFF
--- a/apps/scraper/test_web_prefecture_links.py
+++ b/apps/scraper/test_web_prefecture_links.py
@@ -1,0 +1,31 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class WebPrefectureLinksTest(unittest.TestCase):
+    def test_top_prefecture_links_use_helper_relative_paths(self) -> None:
+        for filename in ("index.html", "index.template.html"):
+            with self.subTest(filename=filename):
+                source = (ROOT / "apps/web" / filename).read_text(encoding="utf-8")
+                self.assertIn("window.getPrefecturePageUrl = function(prefecture)", source)
+                self.assertIn('" href="\' + window.getPrefecturePageUrl(pref) + \'"', source)
+                self.assertNotIn('href="/prefectures/', source)
+
+    def test_map_copy_has_prefecture_page_helper(self) -> None:
+        source = (ROOT / "apps/web/map.html").read_text(encoding="utf-8")
+        self.assertIn("function getPrefecturePageUrl(prefecture)", source)
+        self.assertIn("return slug ? `prefectures/${encodeURIComponent(slug)}/` : '';", source)
+        self.assertIn("anchor.textContent = UI_TEXT.prefectureSite;", source)
+
+    def test_map_template_uses_localized_prefecture_paths(self) -> None:
+        source = (ROOT / "apps/web/map.template.html").read_text(encoding="utf-8")
+        self.assertIn("function getPrefecturePageUrl(prefecture)", source)
+        self.assertIn("%%BASE_PATH%%prefectures/${encodeURIComponent(slug)}/", source)
+        self.assertIn("anchor.textContent = UI_TEXT.prefectureSite;", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -54,7 +54,7 @@
     window.SITE_BASE_URL = 'https://data.pokefuta.com/';
     window.getPrefecturePageUrl = function(prefecture) {
       var slug = window.PREFECTURE_SLUG_MAP[prefecture];
-      return slug ? '/prefectures/' + encodeURIComponent(slug) + '/' : '';
+      return slug ? 'prefectures/' + encodeURIComponent(slug) + '/' : '';
     };
 
     // Redirect deep-links (?pref= / ?manhole= / ?tag= / ?view=) to map.html
@@ -646,7 +646,7 @@
             var cnt = prefCountMap[pref] || 0;
             var slug = slugMap[pref] || encodeURIComponent(pref);
             var isLast = i === PREF_ORDER.length - 1;
-            return '<a class="pref-link-item' + (isLast ? ' pref-link-item--last' : '') + '" href="/prefectures/' + slug + '/" onclick="trackEvent(\'click_pref_link\',{prefecture:\'' + pref + '\'})">'
+            return '<a class="pref-link-item' + (isLast ? ' pref-link-item--last' : '') + '" href="' + window.getPrefecturePageUrl(pref) + '" onclick="trackEvent(\'click_pref_link\',{prefecture:\'' + pref + '\'})">'
               + '<span class="pref-link-name">' + pref + '</span>'
               + (cnt ? '<span class="pref-link-count">' + cnt + '枚 →</span>' : '<span class="pref-link-count">→</span>')
               + '</a>';

--- a/apps/web/index.template.html
+++ b/apps/web/index.template.html
@@ -57,7 +57,7 @@
     window.SITE_BASE_URL = 'https://data.pokefuta.com/';
     window.getPrefecturePageUrl = function(prefecture) {
       var slug = window.PREFECTURE_SLUG_MAP[prefecture];
-      return slug ? '/prefectures/' + encodeURIComponent(slug) + '/' : '';
+      return slug ? '%%BASE_PATH%%prefectures/' + encodeURIComponent(slug) + '/' : '';
     };
 
     // Redirect deep-links (?pref= / ?manhole= / ?tag= / ?view=) to map.html
@@ -647,7 +647,7 @@
             var slug = slugMap[pref] || encodeURIComponent(pref);
             var isLast = i === PREF_ORDER.length - 1;
             var displayPref = (PREF_NAMES[pref] && PREF_NAMES[pref][PREF_LANG_KEY]) || pref;
-            return '<a class="pref-link-item' + (isLast ? ' pref-link-item--last' : '') + '" href="/prefectures/' + slug + '/" onclick="trackEvent(\'click_pref_link\',{prefecture:\'' + pref + '\'})">'
+            return '<a class="pref-link-item' + (isLast ? ' pref-link-item--last' : '') + '" href="' + window.getPrefecturePageUrl(pref) + '" onclick="trackEvent(\'click_pref_link\',{prefecture:\'' + pref + '\'})">'
               + '<span class="pref-link-name">' + displayPref + '</span>'
               + (cnt ? '<span class="pref-link-count">' + cnt + '枚 →</span>' : '<span class="pref-link-count">→</span>')
               + '</a>';

--- a/apps/web/map.html
+++ b/apps/web/map.html
@@ -832,6 +832,11 @@
       return safeId ? window.buildManholeCanonicalPath(safeId) : '';
     }
 
+    function getPrefecturePageUrl(prefecture) {
+      const slug = window.PREFECTURE_SLUG_MAP[prefecture];
+      return slug ? `prefectures/${encodeURIComponent(slug)}/` : '';
+    }
+
     function getAbsoluteManholePageUrl(id) {
       const path = getManholePageUrl(id);
       return path ? new URL(path, window.location.origin).href : '';

--- a/apps/web/map.template.html
+++ b/apps/web/map.template.html
@@ -792,7 +792,7 @@
 
     function getPrefecturePageUrl(prefecture) {
       const slug = window.PREFECTURE_SLUG_MAP[prefecture];
-      return slug ? `/prefectures/${encodeURIComponent(slug)}/` : '';
+      return slug ? `%%BASE_PATH%%prefectures/${encodeURIComponent(slug)}/` : '';
     }
 
     function getAbsoluteManholePageUrl(id) {


### PR DESCRIPTION
## Summary
- restore the missing prefecture page helper in `apps/web/map.html` so the prefecture table renders again
- use the shared helper for top-page prefecture links instead of hard-coded absolute `/prefectures/` paths
- keep template/localized output on `%%BASE_PATH%%prefectures/...` and add regression coverage

## Validation
- `git diff --check`
- `python3 tools/build_i18n.py`
- `python3 -m unittest apps.scraper.test_web_prefecture_links apps.scraper.test_inject_site_header apps.scraper.test_generate_prefecture_pages`
- Browser smoke test on local app: top rendered 47 prefecture links; map rendered 47 prefecture cards with no console errors
- Browser smoke test on dist-shaped fixture: top event links resolved to `prefectures/iwate/` and `prefectures/kochi/`; map rendered 47 prefecture cards