### PR TITLE
feat: トップ投稿フィードの投稿者名を公開スタンプ帳へのリンクに

### DIFF
--- a/apps/scraper/generate_top_feed.py
+++ b/apps/scraper/generate_top_feed.py
@@ -105,6 +105,7 @@ def build_top_feed(
             "city": record.get("city", ""),
             "pokemons": pokemons,
             "display_name": photo.get("display_name") or None,
+            "public_user_id": photo.get("public_user_id") or None,
             "comment": sanitize_comment(photo.get("comment")),
             "created_at": (photo.get("created_at") or "")[:10],
         })

--- a/apps/scraper/test_generate_top_feed.py
+++ b/apps/scraper/test_generate_top_feed.py
@@ -125,6 +125,25 @@ class BuildTopFeedTests(unittest.TestCase):
         self.assertEqual(entry["display_name"], "テスト太郎")
         self.assertEqual(entry["created_at"], "2026-06-01")
         self.assertEqual(entry["prefecture"], "鹿児島県")
+        self.assertIsNone(entry["public_user_id"])
+
+    def test_entry_public_user_id_passed_through_when_present(self):
+        photos = {
+            "1": _photo(
+                "1",
+                "2026-06-01T12:34:56+00:00",
+                public_user_id="11111111-2222-3333-4444-555555555555",
+            )
+        }
+        records = {"1": _record("1")}
+        self._touch_image("1")
+        feed = top_feed.build_top_feed(
+            {"photos": photos}, records, {}, image_dir=self.image_dir
+        )
+        entry = feed["photos"][0]
+        self.assertEqual(
+            entry["public_user_id"], "11111111-2222-3333-4444-555555555555"
+        )
 
     def test_stats_subset_ignores_non_int_values(self):
         site_stats = {

--- a/apps/web/assets/top-page.css
+++ b/apps/web/assets/top-page.css
@@ -399,6 +399,19 @@ a { color: inherit; text-decoration: none; }
   color: var(--top-text-muted);
 }
 
+.hero-footer-name-link {
+  position: relative;
+  z-index: 3; /* above .hero-featured-overlay (z-index: 2), which can visually extend over the footer */
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.hero-footer-name-link:hover,
+.hero-footer-name-link:focus-visible {
+  text-decoration: underline;
+}
+
 .hero-footer-cta {
   font-size: 12.5px;
   font-weight: 700;

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -87,7 +87,7 @@
   </script>
   <!-- End GA -->
   <link rel="stylesheet" href="./assets/theme.css" />
-  <link rel="stylesheet" href="./assets/top-page.css?v=20260711a" />
+  <link rel="stylesheet" href="./assets/top-page.css?v=20260711b" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
   <link rel="icon" href="./assets/pokefuta-marker.svg" type="image/svg+xml" />
   <script src="./assets/session-badge.js" defer></script>
@@ -381,7 +381,7 @@
       setText('hero-media-label', hero.mediaLabel);
       setText('hero-featured-title', hero.title);
       setText('hero-featured-place', hero.place);
-      setText('hero-footer-text', hero.footerText);
+      setFooterText(hero);
       setText('hero-footer-cta', hero.footerCta);
 
       hero.small.forEach(function(s, i) {
@@ -422,11 +422,23 @@
       statNote: '📷 これまでに {count}/{total}ヶ所のポケふたに写真が届きました'
     };
 
+    var PUBLIC_USER_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
     function communityHero(photos) {
       function names(p) { return (p.pokemons || []).slice(0, 2).join('・'); }
       function place(p) { return (p.title || '').replace('/', ' '); }
       var f = photos[0];
       var footerText = '📷 ' + (f.display_name ? TF_STRINGS.by.replace('{name}', f.display_name) + ' · ' : '') + (f.created_at || '');
+      var footerName = null;
+      if (f.display_name && f.public_user_id && PUBLIC_USER_ID_RE.test(f.public_user_id)) {
+        var byParts = TF_STRINGS.by.split('{name}');
+        footerName = {
+          prefix: '📷 ' + byParts[0],
+          name: f.display_name,
+          suffix: byParts[1] + ' · ' + (f.created_at || ''),
+          publicUserId: f.public_user_id
+        };
+      }
       return {
         id: f.id, community: true,
         imgAlt: (names(f) || place(f)) + 'のポケふた投稿写真',
@@ -436,6 +448,7 @@
         title: f.comment || names(f) || place(f),
         place: f.comment && names(f) ? place(f) + ' ／ ' + names(f) : place(f),
         footerText: footerText,
+        footerName: footerName,
         footerCta: TF_STRINGS.cta,
         href: 'map.html?manhole=' + encodeURIComponent(f.id),
         small: photos.slice(1, 3).map(function(p) {
@@ -693,6 +706,27 @@
     function setText(id, val) {
       var el = document.getElementById(id);
       if (el) el.textContent = val;
+    }
+    function setFooterText(hero) {
+      var el = document.getElementById('hero-footer-text');
+      if (!el) return;
+      if (!hero.footerName) { el.textContent = hero.footerText; return; }
+      var fn = hero.footerName;
+      el.textContent = '';
+      el.appendChild(document.createTextNode(fn.prefix));
+      var nameLink = document.createElement('a');
+      nameLink.href = 'https://pokefuta.com/users/' + encodeURIComponent(fn.publicUserId) + '/visits';
+      nameLink.className = 'hero-footer-name-link';
+      nameLink.target = '_blank';
+      nameLink.rel = 'noopener';
+      nameLink.textContent = fn.name;
+      nameLink.addEventListener('click', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        window.open('https://pokefuta.com/users/' + encodeURIComponent(fn.publicUserId) + '/visits', '_blank', 'noopener');
+      });
+      el.appendChild(nameLink);
+      el.appendChild(document.createTextNode(fn.suffix));
     }
     function setNum(id, val) {
       var el = document.getElementById(id);

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -714,16 +714,24 @@
       var fn = hero.footerName;
       el.textContent = '';
       el.appendChild(document.createTextNode(fn.prefix));
-      var nameLink = document.createElement('a');
-      nameLink.href = 'https://pokefuta.com/users/' + encodeURIComponent(fn.publicUserId) + '/visits';
+      var profileUrl = 'https://pokefuta.com/users/' + encodeURIComponent(fn.publicUserId) + '/visits';
+      var nameLink = document.createElement('span');
       nameLink.className = 'hero-footer-name-link';
-      nameLink.target = '_blank';
-      nameLink.rel = 'noopener';
+      nameLink.setAttribute('role', 'link');
+      nameLink.setAttribute('tabindex', '0');
+      nameLink.setAttribute('aria-label', fn.name + 'さんの公開スタンプ帳を開く');
       nameLink.textContent = fn.name;
       nameLink.addEventListener('click', function(e) {
         e.preventDefault();
         e.stopPropagation();
-        window.open('https://pokefuta.com/users/' + encodeURIComponent(fn.publicUserId) + '/visits', '_blank', 'noopener');
+        window.open(profileUrl, '_blank', 'noopener,noreferrer');
+      });
+      nameLink.addEventListener('keydown', function(e) {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          e.stopPropagation();
+          window.open(profileUrl, '_blank', 'noopener,noreferrer');
+        }
       });
       el.appendChild(nameLink);
       el.appendChild(document.createTextNode(fn.suffix));

--- a/apps/web/index.template.html
+++ b/apps/web/index.template.html
@@ -90,7 +90,7 @@
   </script>
   <!-- End GA -->
   <link rel="stylesheet" href="%%BASE_PATH%%assets/theme.css" />
-  <link rel="stylesheet" href="%%BASE_PATH%%assets/top-page.css?v=20260711a" />
+  <link rel="stylesheet" href="%%BASE_PATH%%assets/top-page.css?v=20260711b" />
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
   <link rel="icon" href="%%BASE_PATH%%assets/pokefuta-marker.svg" type="image/svg+xml" />
   <script src="%%BASE_PATH%%assets/session-badge.js" defer></script>
@@ -380,7 +380,7 @@
       setText('hero-media-label', hero.mediaLabel);
       setText('hero-featured-title', hero.title);
       setText('hero-featured-place', hero.place);
-      setText('hero-footer-text', hero.footerText);
+      setFooterText(hero);
       setText('hero-footer-cta', hero.footerCta);
 
       hero.small.forEach(function(s, i) {
@@ -421,11 +421,23 @@
       statNote: '%%STAT_PHOTOGRAPHED_NOTE%%'
     };
 
+    var PUBLIC_USER_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
     function communityHero(photos) {
       function names(p) { return (p.pokemons || []).slice(0, 2).join('・'); }
       function place(p) { return (p.title || '').replace('/', ' '); }
       var f = photos[0];
       var footerText = '📷 ' + (f.display_name ? TF_STRINGS.by.replace('{name}', f.display_name) + ' · ' : '') + (f.created_at || '');
+      var footerName = null;
+      if (f.display_name && f.public_user_id && PUBLIC_USER_ID_RE.test(f.public_user_id)) {
+        var byParts = TF_STRINGS.by.split('{name}');
+        footerName = {
+          prefix: '📷 ' + byParts[0],
+          name: f.display_name,
+          suffix: byParts[1] + ' · ' + (f.created_at || ''),
+          publicUserId: f.public_user_id
+        };
+      }
       return {
         id: f.id, community: true,
         imgAlt: (names(f) || place(f)) + 'のポケふた投稿写真',
@@ -435,6 +447,7 @@
         title: f.comment || names(f) || place(f),
         place: f.comment && names(f) ? place(f) + ' ／ ' + names(f) : place(f),
         footerText: footerText,
+        footerName: footerName,
         footerCta: TF_STRINGS.cta,
         href: BASE_PATH + 'map.html?manhole=' + encodeURIComponent(f.id),
         small: photos.slice(1, 3).map(function(p) {
@@ -692,6 +705,27 @@
     function setText(id, val) {
       var el = document.getElementById(id);
       if (el) el.textContent = val;
+    }
+    function setFooterText(hero) {
+      var el = document.getElementById('hero-footer-text');
+      if (!el) return;
+      if (!hero.footerName) { el.textContent = hero.footerText; return; }
+      var fn = hero.footerName;
+      el.textContent = '';
+      el.appendChild(document.createTextNode(fn.prefix));
+      var nameLink = document.createElement('a');
+      nameLink.href = 'https://pokefuta.com/users/' + encodeURIComponent(fn.publicUserId) + '/visits';
+      nameLink.className = 'hero-footer-name-link';
+      nameLink.target = '_blank';
+      nameLink.rel = 'noopener';
+      nameLink.textContent = fn.name;
+      nameLink.addEventListener('click', function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        window.open('https://pokefuta.com/users/' + encodeURIComponent(fn.publicUserId) + '/visits', '_blank', 'noopener');
+      });
+      el.appendChild(nameLink);
+      el.appendChild(document.createTextNode(fn.suffix));
     }
     function setNum(id, val) {
       var el = document.getElementById(id);

--- a/apps/web/index.template.html
+++ b/apps/web/index.template.html
@@ -713,16 +713,24 @@
       var fn = hero.footerName;
       el.textContent = '';
       el.appendChild(document.createTextNode(fn.prefix));
-      var nameLink = document.createElement('a');
-      nameLink.href = 'https://pokefuta.com/users/' + encodeURIComponent(fn.publicUserId) + '/visits';
+      var profileUrl = 'https://pokefuta.com/users/' + encodeURIComponent(fn.publicUserId) + '/visits';
+      var nameLink = document.createElement('span');
       nameLink.className = 'hero-footer-name-link';
-      nameLink.target = '_blank';
-      nameLink.rel = 'noopener';
+      nameLink.setAttribute('role', 'link');
+      nameLink.setAttribute('tabindex', '0');
+      nameLink.setAttribute('aria-label', fn.name + 'さんの公開スタンプ帳を開く');
       nameLink.textContent = fn.name;
       nameLink.addEventListener('click', function(e) {
         e.preventDefault();
         e.stopPropagation();
-        window.open('https://pokefuta.com/users/' + encodeURIComponent(fn.publicUserId) + '/visits', '_blank', 'noopener');
+        window.open(profileUrl, '_blank', 'noopener,noreferrer');
+      });
+      nameLink.addEventListener('keydown', function(e) {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          e.stopPropagation();
+          window.open(profileUrl, '_blank', 'noopener,noreferrer');
+        }
       });
       el.appendChild(nameLink);
       el.appendChild(document.createTextNode(fn.suffix));


### PR DESCRIPTION
## 概要
トップページのコミュニティ投稿フィードで、投稿者名クリックで本人の公開スタンプ帳（`https://pokefuta.com/users/<id>/visits`、pokefuta#177 で新設）を新規タブで開けるようにする。

- `generate_top_feed.py`: 上流 JSON の `public_user_id` を top-feed.json にパススルー
- `index.html` / `index.template.html`（双子に同一編集）: `public_user_id` が UUID 形式のときのみ投稿者名を `<a>` 化。DOM は `createElement`/`textContent` で構築（innerHTML 不使用、ユーザー名の XSS 安全）。クリックは `preventDefault`/`stopPropagation` で新規タブ、ヒーローカード自体のナビは維持
- `top-page.css`: リンクに `z-index: 3` を付与（`.hero-featured-overlay` (z-index:2) がフッターまで覆いクリックを奪うのを実ブラウザ検証で発見・修正）。キャッシュバスター更新

## フォールバック
`public_user_id` が無い/不正な場合は従来どおりのプレーンテキスト表示。現行の（id なし）top-feed.json のままでも表示・挙動は不変なので先行マージ可能。リンクは pokefuta#177 デプロイ後、日次の写真取り込みで JSON に id が入ると自然に出現する。

## 検証
- `test_generate_top_feed.py` 10/10 pass（summary テスト4件+2エラーは main 由来の既知問題）
- Playwright 実ブラウザ確認: id あり→正しい URL を新規タブで開く・コンソールエラーなし、id なし→従来表示でカード遷移も無変化、不正 id→プレーンテキスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)