### PR TITLE
feat: 未設置ポケふたを「設置前」として判別・表示

### DIFF
--- a/apps/scraper/generate_manhole_pages.py
+++ b/apps/scraper/generate_manhole_pages.py
@@ -499,15 +499,27 @@ def generate_html(
     has_photo_bool = bool(photo_url)
     has_photo_js = json.dumps(has_photo_bool)
 
-    hero_photo_html = (
-        f"<a class='hero-photo-placeholder' href='https://pokefuta.com/upload?manhole_id={manhole_id}&amp;from=data'"
-        f" target='_blank' rel='noopener noreferrer'"
-        f" onclick=\"trackEvent('click_photo_upload_placeholder', {_attr_json({'manhole_id': manhole_id, 'prefecture': prefecture, 'city': city, 'has_photo': False})})\">"
-        f"<span class='placeholder-camera' aria-hidden='true'>📷</span>"
-        f"<span class='placeholder-title'>まだ写真がありません</span>"
-        f"<span class='placeholder-sub'>最初の旅写真を投稿する</span>"
-        f"</a>"
-    )
+    is_preinstall = manhole.get("installed") is False
+    if is_preinstall:
+        _preinstall_note = manhole.get("installation_note") or ""
+        _preinstall_note_html = escape(_preinstall_note) if _preinstall_note else "設置予定"
+        hero_photo_html = (
+            f"<div class='hero-photo-placeholder hero-photo-preinstall'>"
+            f"<span class='placeholder-camera' aria-hidden='true'>🚧</span>"
+            f"<span class='placeholder-title'>設置前のポケふたです</span>"
+            f"<span class='placeholder-sub'>{_preinstall_note_html}</span>"
+            f"</div>"
+        )
+    else:
+        hero_photo_html = (
+            f"<a class='hero-photo-placeholder' href='https://pokefuta.com/upload?manhole_id={manhole_id}&amp;from=data'"
+            f" target='_blank' rel='noopener noreferrer'"
+            f" onclick=\"trackEvent('click_photo_upload_placeholder', {_attr_json({'manhole_id': manhole_id, 'prefecture': prefecture, 'city': city, 'has_photo': False})})\">"
+            f"<span class='placeholder-camera' aria-hidden='true'>📷</span>"
+            f"<span class='placeholder-title'>まだ写真がありません</span>"
+            f"<span class='placeholder-sub'>最初の旅写真を投稿する</span>"
+            f"</a>"
+        )
 
     if photo_url:
         og_image = photo_url
@@ -607,6 +619,8 @@ def generate_html(
     # HERO card: stats badges
     title_keys: set[str] = {t["key"] for t in titles}
     badges: list[str] = []
+    if is_preinstall:
+        badges.append("<span class='hero-badge hero-badge-pre'>🚧 設置前</span>")
     added_at = manhole.get("added_at", "") or ""
     try:
         added_year = datetime.date.fromisoformat(added_at[:10]).year
@@ -639,7 +653,13 @@ def generate_html(
     # HERO card: share JS data (Python-serialized to avoid injection)
     _title_hashtags = " ".join(t["hashtag"] for t in titles if t.get("hashtag"))
     _base_hashtags = f"{_title_hashtags} #ポケふた #ポケモンマンホール".strip()
-    if has_photo_bool and pokemons:
+    if is_preinstall and pokemons:
+        _x_text = (
+            f"設置前のポケふた（{pokemon_text}）。\n\n"
+            f"{prefecture}{city}に設置予定です。設置されたら会いに行こう！\n\n"
+            f"{_base_hashtags}"
+        )
+    elif has_photo_bool and pokemons:
         _x_text = (
             f"{prefecture}{city}のポケふたを発見！\n\n"
             f"登場ポケモン: {pokemon_text}\n"
@@ -873,10 +893,20 @@ def generate_html(
         f"← 全国マップへ戻る</a>"
     )
 
-    # Hero photo upload CTA
+    # Hero photo upload CTA — suppressed entirely for 設置前 (notice is already shown in hero_photo_html)
     _photo_event = "click_photo_upload" if has_photo_bool else "click_photo_upload_placeholder"
     _photo_label = "写真を投稿" if has_photo_bool else "最初の旅写真を投稿する"
     _photo_cta_onclick = _attr_json({"manhole_id": manhole_id, "prefecture": prefecture, "city": city, "has_photo": has_photo_bool})
+    hero_actions_html = (
+        ""
+        if is_preinstall
+        else (
+            f'<div class="hero-actions">'
+            f'<a class="btn-photo-upload" href="https://pokefuta.com/upload?manhole_id={manhole_id}&amp;from=data" target="_blank" rel="noopener noreferrer" onclick="trackEvent(\'{_photo_event}\', {_photo_cta_onclick})">{_icon("icon-link-photo", "action-icon")}<span>{escape(_photo_label)}</span></a>'
+            f'<p class="photo-upload-note">投稿は pokefuta.com で受付（無料ログイン・GPS付き写真が必要）</p>'
+            f'</div>'
+        )
+    )
 
     # Visit CTA (Google Maps full-width card)
     visit_cta_html = ""
@@ -903,10 +933,7 @@ def generate_html(
     <h1 class="hero-title">{escape(h1)}</h1>
     {pokemon_tags_html}
     {stats_html}
-    <div class="hero-actions">
-      <a class="btn-photo-upload" href="https://pokefuta.com/upload?manhole_id={manhole_id}&amp;from=data" target="_blank" rel="noopener noreferrer" onclick="trackEvent('{_photo_event}', {_photo_cta_onclick})">{_icon('icon-link-photo', 'action-icon')}<span>{escape(_photo_label)}</span></a>
-      <p class="photo-upload-note">投稿は pokefuta.com で受付（無料ログイン・GPS付き写真が必要）</p>
-    </div>
+    {hero_actions_html}
   </div>
 </div>
 """
@@ -1244,6 +1271,21 @@ def generate_html(
       text-underline-offset: 3px;
     }}
 
+    .hero-photo-preinstall {{
+      background: linear-gradient(135deg, #f0ede6 0%, #e6e1d5 100%);
+      border-color: #b8ab8e;
+      cursor: default;
+    }}
+
+    .hero-photo-preinstall .placeholder-title {{
+      color: #6b5d44;
+    }}
+
+    .hero-photo-preinstall .placeholder-sub {{
+      color: #8a7d63;
+      text-decoration: none;
+    }}
+
     .hero-body {{
       padding: 20px 20px 24px;
     }}
@@ -1570,6 +1612,12 @@ def generate_html(
       background: #fff0f0;
       border-color: #ff6b6b;
       color: #c0392b;
+    }}
+
+    .hero-badge-pre {{
+      background: #f1ede4;
+      border-color: #b8ab8e;
+      color: #6b5d44;
     }}
 
     .back-btn {{

--- a/apps/scraper/generate_prefecture_pages.py
+++ b/apps/scraper/generate_prefecture_pages.py
@@ -341,12 +341,17 @@ def _manhole_cards(records: list[dict]) -> str:
             if image_path.exists()
             else '<span class="manhole-placeholder" aria-hidden="true">●</span>'
         )
+        preinstall_badge_html = (
+            '<span class="manhole-preinstall-badge">🚧 設置前</span>'
+            if record.get("installed") is False
+            else ""
+        )
         cards.append(
             f'<a class="manhole-card" href="/manholes/{quote(mid)}/" '
             f'data-track="prefecture_manhole_click" data-position="{position}" '
             f'data-destination="{escape(mid)}">'
             f'{image_html}<span class="manhole-copy"><strong>{escape(city)}</strong>'
-            f'<small>{escape(pokemons)}</small></span></a>'
+            f'<small>{escape(pokemons)}</small>{preinstall_badge_html}</span></a>'
         )
     return "".join(cards)
 
@@ -598,6 +603,11 @@ def build_page(
     .manhole-copy {{ min-width: 0; }}
     .manhole-copy strong, .manhole-copy small {{ display: block; }}
     .manhole-copy small {{ overflow: hidden; color: #75685c; text-overflow: ellipsis; white-space: nowrap; }}
+    .manhole-preinstall-badge {{
+      display: inline-block; margin-top: 4px; padding: 2px 8px;
+      border-radius: 999px; background: #f1ede4; color: #6b5d44;
+      font-size: .74rem; font-weight: 700; white-space: nowrap;
+    }}
     .trivia-card {{
       border-left: 5px solid #7e6ba9;
       background: linear-gradient(135deg, #fffaf0, #f4effd);

--- a/apps/scraper/test_generate_manhole_pages_preinstall.py
+++ b/apps/scraper/test_generate_manhole_pages_preinstall.py
@@ -1,0 +1,87 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).with_name("generate_manhole_pages.py")
+SPEC = importlib.util.spec_from_file_location("generate_manhole_pages", MODULE_PATH)
+pages = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(pages)
+
+
+def _manhole(**overrides) -> dict:
+    base = {
+        "id": "1",
+        "prefecture": "長野県",
+        "city": "岡谷",
+        "address": "長野県岡谷市",
+        "lat": 36.0,
+        "lng": 138.0,
+        "pokemons": ["ピカチュウ"],
+        "titles": [],
+        "tags": [],
+    }
+    base.update(overrides)
+    return base
+
+
+def _generate(manhole: dict) -> str:
+    return pages.generate_html(
+        manhole=manhole,
+        photo=None,
+        pokemon_meta={},
+        nearby=[],
+        same_pref=[],
+        pref_total=0,
+        same_pokemon=[],
+        id_to_image_url={},
+    )
+
+
+BADGE_MARKUP = "<span class='hero-badge hero-badge-pre'>🚧 設置前</span>"
+
+
+class PreinstallRenderingTests(unittest.TestCase):
+    def test_preinstall_shows_badge_and_notice_without_upload_link(self):
+        manhole = _manhole(
+            installed=False,
+            installation_note="2026年8月上旬までに設置予定。",
+        )
+        html = _generate(manhole)
+        self.assertIn(BADGE_MARKUP, html)
+        self.assertIn("設置前のポケふたです", html)
+        self.assertIn("2026年8月上旬までに設置予定。", html)
+        # No upload CTA (placeholder link nor the secondary hero-actions button)
+        # must be rendered anywhere on the page when 設置前.
+        self.assertNotIn("pokefuta.com/upload", html)
+        self.assertNotIn('<div class="hero-actions">', html)
+
+    def test_preinstall_without_note_uses_default_text(self):
+        manhole = _manhole(installed=False)
+        html = _generate(manhole)
+        self.assertIn(BADGE_MARKUP, html)
+        self.assertIn(
+            "<span class='placeholder-sub'>設置予定</span>",
+            html,
+        )
+
+    def test_normal_installed_absent_has_no_preinstall_markers(self):
+        # Absent 'installed' field must be treated as installed=True (default rule).
+        manhole = _manhole()
+        html = _generate(manhole)
+        self.assertNotIn(BADGE_MARKUP, html)
+        self.assertNotIn("設置前のポケふたです", html)
+        self.assertIn("pokefuta.com/upload", html)
+        self.assertIn("hero-actions", html)
+
+    def test_normal_installed_true_has_no_preinstall_markers(self):
+        manhole = _manhole(installed=True)
+        html = _generate(manhole)
+        self.assertNotIn(BADGE_MARKUP, html)
+        self.assertNotIn("設置前のポケふたです", html)
+        self.assertIn("pokefuta.com/upload", html)
+        self.assertIn("hero-actions", html)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/scraper/test_generate_prefecture_pages.py
+++ b/apps/scraper/test_generate_prefecture_pages.py
@@ -174,6 +174,30 @@ class GeneratePrefecturePagesTest(unittest.TestCase):
         self.assertIn("福井県では16自治体で17枚のポケふたを巡れます。", html)
         self.assertNotIn("福井県は2025年10月にポケふた初登場。", html)
 
+    def test_manhole_card_shows_preinstall_badge(self) -> None:
+        records = [
+            {
+                "id": "9001",
+                "city": "岡谷",
+                "pokemons": ["ピカチュウ"],
+                "installed": False,
+                "installation_note": "2026年8月上旬までに設置予定。",
+            }
+        ]
+        html = MODULE._manhole_cards(records)
+        self.assertIn(
+            '<span class="manhole-preinstall-badge">🚧 設置前</span>', html
+        )
+
+    def test_manhole_card_normal_has_no_preinstall_badge(self) -> None:
+        # installed absent and installed True must both be treated as installed.
+        records = [
+            {"id": "9002", "city": "岡谷", "pokemons": ["ピカチュウ"]},
+            {"id": "9003", "city": "伊那", "pokemons": ["イーブイ"], "installed": True},
+        ]
+        html = MODULE._manhole_cards(records)
+        self.assertNotIn("manhole-preinstall-badge", html)
+
     def test_tied_counts_share_rank(self) -> None:
         records = [
             {"id": "1", "status": "active", "prefecture": "青森県"},

--- a/apps/scraper/test_update_pokefuta.py
+++ b/apps/scraper/test_update_pokefuta.py
@@ -26,5 +26,61 @@ class UpdatePokefutaParseDetailTest(unittest.TestCase):
         self.assertEqual("岡谷", MODULE.strip_municipality_suffix("岡谷市"))
 
 
+class UpdatePokefutaApplyInstallStatusTest(unittest.TestCase):
+    def test_scheduled_not_yet_installed(self) -> None:
+        record = {"id": "481"}
+        idx = {"481": {"manhole_no": "481", "installation_date": "2026年8月上旬までに設置予定。"}}
+        result = MODULE.apply_install_status(record, idx)
+        self.assertFalse(result)
+        self.assertFalse(record["installed"])
+        self.assertEqual(record["installation_note"], "2026年8月上旬までに設置予定。")
+
+    def test_installed_empty_note(self) -> None:
+        record = {"id": "484"}
+        idx = {"484": {"manhole_no": "484", "installation_date": ""}}
+        result = MODULE.apply_install_status(record, idx)
+        self.assertFalse(result)
+        self.assertTrue(record["installed"])
+        self.assertNotIn("installation_note", record)
+
+    def test_id_124_edge_case_not_fooled_by_yotei(self) -> None:
+        record = {"id": "124"}
+        note = "移設済み（ポケストップは順次移設予定）"
+        idx = {"124": {"manhole_no": "124", "installation_date": note}}
+        result = MODULE.apply_install_status(record, idx)
+        self.assertFalse(result)
+        self.assertTrue(record["installed"])
+        self.assertEqual(record["installation_note"], note)
+
+    def test_viewing_caveat_still_installed(self) -> None:
+        record = {"id": "1"}
+        note = "公園の開園時間外には、ポケふたをご覧いただくことができません。"
+        idx = {"1": {"manhole_no": "1", "installation_date": note}}
+        result = MODULE.apply_install_status(record, idx)
+        self.assertFalse(result)
+        self.assertTrue(record["installed"])
+        self.assertEqual(record["installation_note"], note)
+
+    def test_transition_returns_true_when_already_had_field(self) -> None:
+        record = {"id": "481", "installed": True}
+        idx = {"481": {"manhole_no": "481", "installation_date": "2026年8月上旬までに設置予定。"}}
+        result = MODULE.apply_install_status(record, idx)
+        self.assertTrue(result)
+        self.assertFalse(record["installed"])
+
+    def test_first_time_set_returns_false(self) -> None:
+        record = {"id": "481"}
+        idx = {"481": {"manhole_no": "481", "installation_date": "2026年8月上旬までに設置予定。"}}
+        result = MODULE.apply_install_status(record, idx)
+        self.assertFalse(result)
+
+    def test_id_not_in_index_returns_false_and_untouched(self) -> None:
+        record = {"id": "999", "title": "unchanged"}
+        idx = {"481": {"manhole_no": "481", "installation_date": ""}}
+        result = MODULE.apply_install_status(record, idx)
+        self.assertFalse(result)
+        self.assertEqual(record, {"id": "999", "title": "unchanged"})
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/apps/scraper/update_pokefuta.py
+++ b/apps/scraper/update_pokefuta.py
@@ -459,6 +459,63 @@ def now_iso() -> str:
     return datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
 
 
+def fetch_install_status(base: str, logger: logging.Logger) -> Dict[str, Dict]:
+    """公式検索JSON API から設置状況を取得し manhole_no でインデックス化する。
+
+    取得や解析に失敗しても更新処理全体を止めないよう、例外時は空辞書を返す。
+    """
+    base_root = base.rstrip('/')
+    if not base_root.endswith('/manhole'):
+        base_root = re.sub(r'/manhole/.*$', '/manhole', base_root)
+        if not base_root.endswith('/manhole'):
+            base_root += '/manhole'
+    url = f"{base_root}/search/?mode=json"
+
+    idx: Dict[str, Dict] = {}
+    try:
+        text = fetch(url, logger, HEADERS)
+        if text is None:
+            logger.warning("fetch_install_status: no response from %s", url)
+            return {}
+        data = json.loads(text)
+        rows = data.get('list', []) if isinstance(data, dict) else []
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            no = row.get('manhole_no')
+            if not no:
+                continue
+            idx[str(no)] = row
+    except Exception as e:
+        logger.warning("fetch_install_status: failed to load/parse %s: %s", url, e)
+        return {}
+    return idx
+
+
+def apply_install_status(record: Dict, install_idx: Dict[str, Dict]) -> bool:
+    """検索APIの設置状況をレコードにマージする。
+
+    installed が既存値から遷移した場合(初回付与を除く)のみ True を返す。
+    """
+    row = install_idx.get(str(record.get('id')))
+    if not row:
+        return False
+
+    note = (row.get('installation_date') or '').strip()
+    installed = "設置予定" not in note
+
+    had = 'installed' in record
+    old = record.get('installed')
+
+    record['installed'] = installed
+    if note:
+        record['installation_note'] = note
+    else:
+        record.pop('installation_note', None)
+
+    return had and old != installed
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--base', default=DEFAULT_BASE, help='Base top page URL')
@@ -477,6 +534,9 @@ def main():
     title_data, city_links = load_manhole_titles_json(dataset_dir)
     city_url_idx = build_city_url_index(city_links)
     logger.info("Loaded %d manholes, %d city_links from manhole_titles.json", len(title_data), len(city_links))
+
+    install_idx = fetch_install_status(args.base, logger)
+    logger.info("Loaded %d install-status rows from search API", len(install_idx))
 
     existing = load_existing(args.out)
     by_id: Dict[str, Dict] = {r['id']: r for r in existing if 'id' in r}
@@ -500,6 +560,9 @@ def main():
         r.setdefault('is_prefecture_site', False)
         if apply_title_metadata(r, title_data):
             changed.setdefault(r['id'], {})['title_metadata'] = True
+        if apply_install_status(r, install_idx):
+            r['last_updated'] = now_iso()
+            changed.setdefault(r['id'], {})['install_status'] = True
         # Always sync city_url from city_links (source of truth, no last_updated bump)
         pref = r.get('prefecture', '')
         city = r.get('city', '')
@@ -553,6 +616,7 @@ def main():
             for _f in ('parking', 'nearby_spots', 'source_urls', 'address_raw', 'address_norm'):
                 parsed.pop(_f, None)
             apply_title_metadata(parsed, title_data)
+            apply_install_status(parsed, install_idx)
             # Sync city_url from city_links for new records
             pref = parsed.get('prefecture', '')
             city = parsed.get('city', '')

--- a/apps/scraper/update_pokefuta.py
+++ b/apps/scraper/update_pokefuta.py
@@ -42,6 +42,7 @@ from address_parser import extract_address_from_html
 # Constants (unified with scrape_pokefuta.py)
 DEFAULT_BASE = "https://local.pokemon.jp/manhole/"
 HEADERS = {"User-Agent": "pokefuta-tracker-updater (+https://github.com/nishiokya/pokefuta-tracker)"}
+HEADERS_JA = {**HEADERS, "Accept-Language": "ja,ja-JP;q=0.9"}
 HEADERS_EN = {**HEADERS, "Accept-Language": "en-US,en;q=0.9"}
 HEADERS_ZH = {**HEADERS, "Accept-Language": "zh-CN,zh;q=0.9"}
 
@@ -473,7 +474,8 @@ def fetch_install_status(base: str, logger: logging.Logger) -> Dict[str, Dict]:
 
     idx: Dict[str, Dict] = {}
     try:
-        text = fetch(url, logger, HEADERS)
+        # installation_date の日本語表記("設置予定")で判定するため日本語レスポンスに固定する
+        text = fetch(url, logger, HEADERS_JA)
         if text is None:
             logger.warning("fetch_install_status: no response from %s", url)
             return {}

--- a/apps/web/assets/map.css
+++ b/apps/web/assets/map.css
@@ -160,6 +160,18 @@
 .popup-photo--missing .popup-photo__missing {
   display: flex;
 }
+.popup-photo--preinstall .popup-photo__missing {
+  display: flex;
+}
+.popup-photo__preinstall {
+  background: #f1ede4;
+}
+.popup-photo__preinstall b {
+  color: #6b5d44;
+}
+.popup-photo__preinstall span {
+  color: #8a7d63;
+}
 .popup-meta {
   display: grid;
   gap: 3px;

--- a/apps/web/assets/pokefuta-map.css
+++ b/apps/web/assets/pokefuta-map.css
@@ -1322,6 +1322,12 @@ body.pokefuta-map-page {
   white-space: nowrap;
 }
 
+.pokefuta-map-page .travel-popup-badge--pre {
+  background: #f1ede4;
+  border: 1px solid #b8ab8e;
+  color: #6b5d44;
+}
+
 .pokefuta-map-page .travel-popup-tag-icons {
   display: flex;
   flex-wrap: wrap;

--- a/apps/web/i18n/strings.en.json
+++ b/apps/web/i18n/strings.en.json
@@ -77,6 +77,7 @@
     "photoViewCta": "View photo",
     "firstPhotoUploadCta": "Upload the first photo",
     "firstPhotoUploadNote": "On pokefuta.com · free sign-in",
+    "preinstall": "Coming soon",
     "googleMapsCta": "Open in Google Maps",
     "shareButton": "Share",
     "typeLabel": "Type:",

--- a/apps/web/i18n/strings.en.json
+++ b/apps/web/i18n/strings.en.json
@@ -78,6 +78,7 @@
     "firstPhotoUploadCta": "Upload the first photo",
     "firstPhotoUploadNote": "On pokefuta.com · free sign-in",
     "preinstall": "Coming soon",
+    "preinstallScheduled": "Scheduled for installation",
     "googleMapsCta": "Open in Google Maps",
     "shareButton": "Share",
     "typeLabel": "Type:",

--- a/apps/web/i18n/strings.ja.json
+++ b/apps/web/i18n/strings.ja.json
@@ -77,6 +77,7 @@
     "photoViewCta": "写真を見る",
     "firstPhotoUploadCta": "最初の写真を投稿",
     "firstPhotoUploadNote": "pokefuta.comで受付・無料ログイン",
+    "preinstall": "設置前",
     "googleMapsCta": "Google Mapsで行く",
     "shareButton": "シェア",
     "typeLabel": "タイプ:",

--- a/apps/web/i18n/strings.ja.json
+++ b/apps/web/i18n/strings.ja.json
@@ -78,6 +78,7 @@
     "firstPhotoUploadCta": "最初の写真を投稿",
     "firstPhotoUploadNote": "pokefuta.comで受付・無料ログイン",
     "preinstall": "設置前",
+    "preinstallScheduled": "設置予定",
     "googleMapsCta": "Google Mapsで行く",
     "shareButton": "シェア",
     "typeLabel": "タイプ:",

--- a/apps/web/i18n/strings.ko.json
+++ b/apps/web/i18n/strings.ko.json
@@ -78,6 +78,7 @@
     "firstPhotoUploadCta": "첫 사진 올리기",
     "firstPhotoUploadNote": "pokefuta.com에서 업로드 · 무료 로그인",
     "preinstall": "설치 예정",
+    "preinstallScheduled": "설치 예정",
     "googleMapsCta": "Google Maps에서 보기",
     "shareButton": "공유",
     "typeLabel": "타입:",

--- a/apps/web/i18n/strings.ko.json
+++ b/apps/web/i18n/strings.ko.json
@@ -77,6 +77,7 @@
     "photoViewCta": "사진 보기",
     "firstPhotoUploadCta": "첫 사진 올리기",
     "firstPhotoUploadNote": "pokefuta.com에서 업로드 · 무료 로그인",
+    "preinstall": "설치 예정",
     "googleMapsCta": "Google Maps에서 보기",
     "shareButton": "공유",
     "typeLabel": "타입:",

--- a/apps/web/i18n/strings.zh-CN.json
+++ b/apps/web/i18n/strings.zh-CN.json
@@ -77,6 +77,7 @@
     "photoViewCta": "查看照片",
     "firstPhotoUploadCta": "上传第一张照片",
     "firstPhotoUploadNote": "在 pokefuta.com 上传 · 免费登录",
+    "preinstall": "即将设置",
     "googleMapsCta": "在 Google Maps 查看",
     "shareButton": "分享",
     "typeLabel": "属性：",

--- a/apps/web/i18n/strings.zh-CN.json
+++ b/apps/web/i18n/strings.zh-CN.json
@@ -78,6 +78,7 @@
     "firstPhotoUploadCta": "上传第一张照片",
     "firstPhotoUploadNote": "在 pokefuta.com 上传 · 免费登录",
     "preinstall": "即将设置",
+    "preinstallScheduled": "预计设置",
     "googleMapsCta": "在 Google Maps 查看",
     "shareButton": "分享",
     "typeLabel": "属性：",

--- a/apps/web/i18n/strings.zh-TW.json
+++ b/apps/web/i18n/strings.zh-TW.json
@@ -78,6 +78,7 @@
     "firstPhotoUploadCta": "上傳第一張照片",
     "firstPhotoUploadNote": "在 pokefuta.com 上傳 · 免費登入",
     "preinstall": "即將設置",
+    "preinstallScheduled": "預計設置",
     "googleMapsCta": "在 Google Maps 查看",
     "shareButton": "分享",
     "typeLabel": "屬性：",

--- a/apps/web/i18n/strings.zh-TW.json
+++ b/apps/web/i18n/strings.zh-TW.json
@@ -77,6 +77,7 @@
     "photoViewCta": "查看照片",
     "firstPhotoUploadCta": "上傳第一張照片",
     "firstPhotoUploadNote": "在 pokefuta.com 上傳 · 免費登入",
+    "preinstall": "即將設置",
     "googleMapsCta": "在 Google Maps 查看",
     "shareButton": "分享",
     "typeLabel": "屬性：",

--- a/apps/web/map.html
+++ b/apps/web/map.html
@@ -1134,8 +1134,13 @@
         displayName ? `<span class="travel-popup-photo-author">${escapeHtml(displayName)}</span>` : ''
       ].filter(Boolean).join('');
       const titles = Array.isArray(d.titles) ? d.titles : [];
-      const titleBadgesHtml = titles.length
+      const isPreinstall = d.installed === false;
+      const preinstallBadgeHtml = isPreinstall
+        ? '<span class="travel-popup-badge travel-popup-badge--pre">🚧 設置前</span>'
+        : '';
+      const titleBadgesHtml = (titles.length || isPreinstall)
         ? '<div class="travel-popup-badges">'
+          + preinstallBadgeHtml
           + titles.slice(0, 1).map(t => '<span class="travel-popup-badge">'
             + escapeHtml((t.emoji ? t.emoji + ' ' : '') + t.label)
             + '</span>').join('')
@@ -1160,6 +1165,13 @@
             <span>全国でまだ写真0枚</span>
           </div>
         </div>
+      ` : isPreinstall ? `
+        <div class="popup-photo travel-popup-photo popup-photo--preinstall" aria-label="設置前">
+          <div class="popup-photo__missing popup-photo__preinstall">
+            <b>🚧 設置前</b>
+            <span>${d.installation_note ? escapeHtml(d.installation_note) : '設置予定'}</span>
+          </div>
+        </div>
       ` : `
         <div class="popup-photo travel-popup-photo popup-photo--missing" aria-label="写真募集中">
           <div class="popup-photo__missing">
@@ -1180,6 +1192,8 @@
       const primaryAction = hasPhoto
         ? `<a href="${manholeDetailUrl}" class="travel-popup-action travel-popup-action--primary"
               onclick="if(window.trackEvent){window.trackEvent('popup_click_detail',{${eventParams}});}">詳細を見る</a>`
+        : isPreinstall
+        ? ''
         : `<a href="${escapeHtml(uploadUrl)}" target="_blank" rel="noopener noreferrer" class="travel-popup-action travel-popup-action--primary travel-popup-action--upload"
               onclick="if(window.trackEvent){window.trackEvent('popup_click_upload',{${eventParams}});}">最初の写真を投稿<span class="travel-popup-action-sub">pokefuta.comで受付・無料ログイン</span></a>`;
       const mapsUrl = Number.isFinite(Number(d.lat)) && Number.isFinite(Number(d.lng))

--- a/apps/web/map.template.html
+++ b/apps/web/map.template.html
@@ -1129,7 +1129,7 @@
         <div class="popup-photo travel-popup-photo popup-photo--preinstall" aria-label="${escapeHtml(I.preinstall)}">
           <div class="popup-photo__missing popup-photo__preinstall">
             <b>🚧 ${escapeHtml(I.preinstall)}</b>
-            <span>${d.installation_note ? escapeHtml(d.installation_note) : escapeHtml(I.preinstall)}</span>
+            <span>${d.installation_note ? escapeHtml(d.installation_note) : escapeHtml(I.preinstallScheduled)}</span>
           </div>
         </div>
       ` : `

--- a/apps/web/map.template.html
+++ b/apps/web/map.template.html
@@ -1094,8 +1094,13 @@
         displayName ? `<span class="travel-popup-photo-author">${escapeHtml(displayName)}</span>` : ''
       ].filter(Boolean).join('');
       const titles = Array.isArray(d.titles) ? d.titles : [];
-      const titleBadgesHtml = titles.length
+      const isPreinstall = d.installed === false;
+      const preinstallBadgeHtml = isPreinstall
+        ? '<span class="travel-popup-badge travel-popup-badge--pre">🚧 ' + escapeHtml(I.preinstall) + '</span>'
+        : '';
+      const titleBadgesHtml = (titles.length || isPreinstall)
         ? '<div class="travel-popup-badges">'
+          + preinstallBadgeHtml
           + titles.slice(0, 1).map(t => '<span class="travel-popup-badge">'
             + escapeHtml((t.emoji ? t.emoji + ' ' : '') + t.label)
             + '</span>').join('')
@@ -1120,6 +1125,13 @@
             <span>${I.photoMissing}</span>
           </div>
         </div>
+      ` : isPreinstall ? `
+        <div class="popup-photo travel-popup-photo popup-photo--preinstall" aria-label="${escapeHtml(I.preinstall)}">
+          <div class="popup-photo__missing popup-photo__preinstall">
+            <b>🚧 ${escapeHtml(I.preinstall)}</b>
+            <span>${d.installation_note ? escapeHtml(d.installation_note) : escapeHtml(I.preinstall)}</span>
+          </div>
+        </div>
       ` : `
         <div class="popup-photo travel-popup-photo popup-photo--missing" aria-label="${I.photoWanted}">
           <div class="popup-photo__missing">
@@ -1140,6 +1152,8 @@
       const primaryAction = hasPhoto
         ? `<a href="${manholeDetailUrl}" class="travel-popup-action travel-popup-action--primary"
               onclick="if(window.trackEvent){window.trackEvent('popup_click_detail',{${eventParams}});}">${UI_TEXT.detailPageCta}</a>`
+        : isPreinstall
+        ? ''
         : `<a href="${escapeHtml(uploadUrl)}" target="_blank" rel="noopener noreferrer" class="travel-popup-action travel-popup-action--primary travel-popup-action--upload"
               onclick="if(window.trackEvent){window.trackEvent('popup_click_upload',{${eventParams}});}">${I.firstPhotoUploadCta}<span class="travel-popup-action-sub">${I.firstPhotoUploadNote}</span></a>`;
       const mapsUrl = Number.isFinite(Number(d.lat)) && Number.isFinite(Number(d.lng))


### PR DESCRIPTION
## 背景
`local.pokemon.jp/manhole/desc/{id}/` の詳細HTMLは設置済み・未設置で同型で、物理設置状況を判別できなかった（デザイン登録時点で公開されるため）。実際に岡谷など長野の新規ロットは緯度経度は正しいがまだ現地未設置だった。

## 判別ソース
公式検索API **`/manhole/search/?mode=json`** の `installation_date` フィールドを取り込む。
- 判定: **`installed = "設置予定" not in installation_date`**（空=設置済み）
- 「予定」単体だと `移設済み（…順次移設予定）` を誤判定するため「設置予定」で判定
- 日付はパースせず公式表記を正とする（設置後に公式が空にすれば日次再生成で自動的に installed=true に反転）
- `update_pokefuta.py` が全レコードに `installed`(bool) / `installation_note`(str) を付与

## フロント表示（除外せず「🚧 設置前」バッジ）
| サーフェス | 対応 |
|---|---|
| 詳細ページ | バッジ + 写真投稿CTA→設置予定案内に差し替え（投稿ボタン抑止） |
| 都道府県ページ | manhole-card にバッジ（カウント/ランキングは非改変） |
| マップ popup | バッジ + 投稿CTA→設置予定案内（map.html=JA / map.template.html=I.preinstall で5言語） |

判定は `installed` が**明示 false** のときのみ（フィールド欠如=設置済み扱い。Python `is False` / JS `=== false`）。

## テスト
- 新規: `test_generate_manhole_pages_preinstall.py`(4)、`test_update_pokefuta.py` の設置状況判定(7)、`test_generate_prefecture_pages.py` にバッジ表示/回帰ガード(2)
- `build_i18n.py` を実行し4言語マップに設置前ブランチ＋訳語注入を確認
- 岡谷(481)を実ndjsonに注入して実パイプラインでレンダリング確認→revert済み

## リリース注意（2段階）
マージ時点では表示ロジックのみ反映（現ndjsonに `installed` 無し＝安全側で無変化）。実際の「🚧 設置前」表示は次の `update-pokefuta.yml` 実行が `installed:false` を含むndjsonを生成し、そのデータPRがmainにマージ→再デプロイされた後。

🤖 Generated with [Claude Code](https://claude.com/claude-code)