### PR TITLE
feat: 詳細ページから投稿者の公開スタンプ帳と写真館へのリンクを追加

### DIFF
--- a/apps/scraper/generate_manhole_pages.py
+++ b/apps/scraper/generate_manhole_pages.py
@@ -327,6 +327,21 @@ def _attr_json(data: dict) -> str:
     return escape(json.dumps(data, ensure_ascii=False), {'"': '&quot;'})
 
 
+# apps/web/index.html の PUBLIC_USER_ID_RE と同じガード。
+# UUID 形式でない値は snapshot の異常データとみなしリンク化しない。
+PUBLIC_USER_ID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.I
+)
+
+
+def poster_profile_url(public_user_id) -> str:
+    """有効な公開ユーザーIDなら pokefuta.com の公開スタンプ帳URLを、無効なら空文字を返す。"""
+    pid = str(public_user_id or "").strip()
+    if not PUBLIC_USER_ID_RE.match(pid):
+        return ""
+    return f"https://pokefuta.com/users/{quote(pid)}/visits"
+
+
 def _js_json(value) -> str:
     """Serialize value as JSON safe for embedding inside an inline <script> block.
 
@@ -543,7 +558,17 @@ def generate_html(
 
         credit_parts = []
         if display_name:
-            credit_parts.append(f"📷 {escape(display_name)}")
+            _profile_url = poster_profile_url(photo.get("public_user_id"))
+            if _profile_url:
+                _poster_onclick = _attr_json({"manhole_id": manhole_id, "source": "hero"})
+                credit_parts.append(
+                    f"<a class='poster-link' href='{_profile_url}'"
+                    f" target='_blank' rel='noopener noreferrer'"
+                    f" onclick=\"trackEvent('click_poster_profile', {_poster_onclick})\">"
+                    f"📷 {escape(display_name)}</a>"
+                )
+            else:
+                credit_parts.append(f"📷 {escape(display_name)}")
         if shot_date:
             credit_parts.append(shot_date)
         if credit_parts:
@@ -572,9 +597,20 @@ def generate_html(
         thumbs = ""
         for g in gallery_items:
             g_credit = str(g.get("display_name") or "")[:20]
-            credit_span = (
-                f"<span class='gallery-credit'>📷 {escape(g_credit)}</span>" if g_credit else ""
-            )
+            if g_credit:
+                _g_profile_url = poster_profile_url(g.get("public_user_id"))
+                if _g_profile_url:
+                    _g_poster_onclick = _attr_json({"manhole_id": manhole_id, "source": "gallery"})
+                    credit_span = (
+                        f"<a class='gallery-credit poster-link' href='{_g_profile_url}'"
+                        f" target='_blank' rel='noopener noreferrer'"
+                        f" onclick=\"trackEvent('click_poster_profile', {_g_poster_onclick})\">"
+                        f"📷 {escape(g_credit)}</a>"
+                    )
+                else:
+                    credit_span = f"<span class='gallery-credit'>📷 {escape(g_credit)}</span>"
+            else:
+                credit_span = ""
             thumbs += (
                 f"<figure class='gallery-item'>"
                 f"<img src=\"{escape(g['url'])}\" alt=\"{escape(h1)}の写真\" loading=\"lazy\">"
@@ -773,6 +809,14 @@ def generate_html(
     link_cards.append(
         f"<button type='button' class='link-card link-card--share' onclick='shareManhole()'>"
         f"{_icon('icon-link-share', 'link-card-icon')}<span>共有</span></button>"
+    )
+    # ポケふた写真館（pokefuta.com）の同ふたページ。ギャラリー未表示のふたでも写真館へ飛べるよう常設
+    _photo_studio_onclick = _attr_json({"manhole_id": manhole_id, "source": "links_photo_studio"})
+    link_cards.append(
+        f"<a class='link-card link-card--internal' href='https://pokefuta.com/manhole/{quote(manhole_id)}'"
+        f" target='_blank' rel='noopener noreferrer'"
+        f" onclick=\"trackEvent('click_photo_studio', {_photo_studio_onclick})\">"
+        f"{_icon('icon-link-photo', 'link-card-icon')}<span>ポケふた写真館</span></a>"
     )
     # Navigation: Official / Prefecture / Same Pref / National Map
     if has_official_url:
@@ -1593,6 +1637,12 @@ def generate_html(
       align-items: center;
     }}
 
+    a.poster-link {{
+      color: #fff;
+      text-decoration: underline;
+      text-underline-offset: 2px;
+    }}
+
     .photo-comment {{
       position: absolute;
       bottom: 0;
@@ -1888,6 +1938,7 @@ def generate_all_pages(
                     "url": f"{BASE_URL}manhole/image/{manhole_id}_{slug}.jpeg",
                     "display_name": item.get("display_name"),
                     "shot_at": item.get("shot_at"),
+                    "public_user_id": item.get("public_user_id"),
                 })
 
         photo: Optional[dict] = (

--- a/apps/scraper/generate_manhole_pages.py
+++ b/apps/scraper/generate_manhole_pages.py
@@ -813,7 +813,7 @@ def generate_html(
     # ポケふた写真館（pokefuta.com）の同ふたページ。ギャラリー未表示のふたでも写真館へ飛べるよう常設
     _photo_studio_onclick = _attr_json({"manhole_id": manhole_id, "source": "links_photo_studio"})
     link_cards.append(
-        f"<a class='link-card link-card--internal' href='https://pokefuta.com/manhole/{quote(manhole_id)}'"
+        f"<a class='link-card link-card--internal' href='https://pokefuta.com/manhole/{quote(manhole_id, safe='')}'"
         f" target='_blank' rel='noopener noreferrer'"
         f" onclick=\"trackEvent('click_photo_studio', {_photo_studio_onclick})\">"
         f"{_icon('icon-link-photo', 'link-card-icon')}<span>ポケふた写真館</span></a>"

--- a/apps/scraper/test_generate_manhole_pages_poster_links.py
+++ b/apps/scraper/test_generate_manhole_pages_poster_links.py
@@ -1,0 +1,132 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).with_name("generate_manhole_pages.py")
+SPEC = importlib.util.spec_from_file_location("generate_manhole_pages", MODULE_PATH)
+pages = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(pages)
+
+VALID_UUID = "6096691c-eeda-4e73-8401-a11274868ede"
+PROFILE_URL = f"https://pokefuta.com/users/{VALID_UUID}/visits"
+
+
+def _manhole() -> dict:
+    return {
+        "id": "1",
+        "prefecture": "鹿児島県",
+        "city": "指宿",
+        "address": "鹿児島県指宿市湊1丁目1-1",
+        "lat": 31.237194,
+        "lng": 130.642861,
+        "pokemons": ["イーブイ"],
+        "titles": [],
+        "tags": [],
+    }
+
+
+def _photo(public_user_id=None, gallery_local: list[dict] | None = None) -> dict:
+    local_url = f"{pages.BASE_URL}manhole/image/1_latest.jpeg"
+    return {
+        "photo_id": "rep11111-0000",
+        "url": local_url,
+        "original_url": local_url,
+        "display_name": "いろはす",
+        "public_user_id": public_user_id,
+        "shot_at": "2026-06-07T00:00:00+00:00",
+        "comment": None,
+        "gallery_local": gallery_local or [],
+    }
+
+
+def _generate(photo: dict | None) -> str:
+    return pages.generate_html(
+        manhole=_manhole(),
+        photo=photo,
+        pokemon_meta={},
+        nearby=[],
+        same_pref=[],
+        pref_total=0,
+        same_pokemon=[],
+        id_to_image_url={},
+    )
+
+
+class PosterProfileUrlTests(unittest.TestCase):
+    def test_valid_uuid(self):
+        self.assertEqual(pages.poster_profile_url(VALID_UUID), PROFILE_URL)
+
+    def test_uppercase_and_whitespace(self):
+        self.assertEqual(
+            pages.poster_profile_url(f" {VALID_UUID.upper()} "),
+            f"https://pokefuta.com/users/{VALID_UUID.upper()}/visits",
+        )
+
+    def test_invalid_values_return_empty(self):
+        for value in (None, "", "not-a-uuid", "../evil", "x' onmouseover='alert(1)", 123):
+            with self.subTest(value=value):
+                self.assertEqual(pages.poster_profile_url(value), "")
+
+
+class HeroCreditLinkTests(unittest.TestCase):
+    def test_hero_credit_linked_with_valid_public_user_id(self):
+        html = _generate(_photo(public_user_id=VALID_UUID))
+        self.assertIn(f"<a class='poster-link' href='{PROFILE_URL}'", html)
+        self.assertIn("📷 いろはす</a>", html)
+        self.assertIn("click_poster_profile", html)
+        self.assertIn("&quot;source&quot;: &quot;hero&quot;", html)
+
+    def test_hero_credit_plain_text_without_public_user_id(self):
+        html = _generate(_photo(public_user_id=None))
+        self.assertIn("<span>📷 いろはす</span>", html)
+        self.assertNotIn("poster-link", html.replace("a.poster-link", ""))  # CSS 定義は除外
+        self.assertNotIn("click_poster_profile", html)
+
+    def test_hero_credit_plain_text_with_invalid_public_user_id(self):
+        html = _generate(_photo(public_user_id="../evil"))
+        self.assertIn("<span>📷 いろはす</span>", html)
+        self.assertNotIn("click_poster_profile", html)
+        self.assertNotIn("/users/", html)
+
+
+class GalleryCreditLinkTests(unittest.TestCase):
+    def test_gallery_credit_linked_with_valid_public_user_id(self):
+        gallery_local = [
+            {
+                "url": f"{pages.BASE_URL}manhole/image/1_abcd1234.jpeg",
+                "display_name": "たこ",
+                "shot_at": "2026-05-01T00:00:00+00:00",
+                "public_user_id": VALID_UUID,
+            },
+        ]
+        html = _generate(_photo(gallery_local=gallery_local))
+        self.assertIn(f"<a class='gallery-credit poster-link' href='{PROFILE_URL}'", html)
+        self.assertIn("📷 たこ</a>", html)
+        self.assertIn("&quot;source&quot;: &quot;gallery&quot;", html)
+
+    def test_gallery_credit_plain_text_without_public_user_id(self):
+        gallery_local = [
+            {
+                "url": f"{pages.BASE_URL}manhole/image/1_abcd1234.jpeg",
+                "display_name": "たこ",
+                "shot_at": "2026-05-01T00:00:00+00:00",
+            },
+        ]
+        html = _generate(_photo(gallery_local=gallery_local))
+        self.assertIn("<span class='gallery-credit'>📷 たこ</span>", html)
+        self.assertNotIn("gallery-credit poster-link", html)
+
+
+class PhotoStudioLinkCardTests(unittest.TestCase):
+    def test_photo_studio_card_always_rendered(self):
+        for photo in (None, _photo(public_user_id=VALID_UUID)):
+            with self.subTest(has_photo=photo is not None):
+                html = _generate(photo)
+                self.assertIn("ポケふた写真館", html)
+                self.assertIn("href='https://pokefuta.com/manhole/1'", html)
+                self.assertIn("click_photo_studio", html)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/MANHOLE_DETAIL_SPEC.md
+++ b/docs/MANHOLE_DETAIL_SPEC.md
@@ -52,6 +52,8 @@ data.pokefuta.com（tracker）と pokefuta.com のマンホール詳細ページ
     "manhole_id": 1,
     "photo_id": "...",        // 代表（最新）— 従来どおり
     "url": "...",
+    "display_name": "...",     // 代表写真の撮影者名
+    "public_user_id": "...",   // 代表写真の投稿者の公開UUID（gallery 各エントリにも同名キーあり）
     "...": "...",
     "gallery": [
       { "photo_id": "...", "url": "...", "storage_key": "...", "shot_at": "...", "created_at": "...", "display_name": "...", "public_user_id": "..." }

--- a/docs/MANHOLE_DETAIL_SPEC.md
+++ b/docs/MANHOLE_DETAIL_SPEC.md
@@ -54,13 +54,14 @@ data.pokefuta.com（tracker）と pokefuta.com のマンホール詳細ページ
     "url": "...",
     "...": "...",
     "gallery": [
-      { "photo_id": "...", "url": "...", "storage_key": "...", "shot_at": "...", "created_at": "...", "display_name": "..." }
+      { "photo_id": "...", "url": "...", "storage_key": "...", "shot_at": "...", "created_at": "...", "display_name": "...", "public_user_id": "..." }
     ]
   }
 }
 ```
 
 - 対象は `is_public = true` の写真のみ。撮影者名のキーは既存の代表写真と同じ `display_name`（app_user の display_name を引く）。
+- 代表・`gallery` の各エントリに `public_user_id`（app_user.id の公開UUID）を含める。投稿者の公開スタンプ帳 `pokefuta.com/users/{public_user_id}/visits` へのリンク生成に使う。
 
 ### 取り込み拡張（tracker repo: `apps/tools/import_latest_manhole_photos.py`）
 
@@ -73,6 +74,8 @@ data.pokefuta.com（tracker）と pokefuta.com のマンホール詳細ページ
 - `gallery` が2枚以上のときのみセクション3を描画。代表をヒーロー、残りをサムネイルグリッド。
 - 末尾に「すべての写真を見る → pokefuta.com/manhole/{id}」リンク。
 - `gallery` 未定義・1枚以下は現行と同じ見た目（後方互換）。
+- 撮影者クレジット（ヒーロー・ギャラリー共通）: `public_user_id` が有効なUUIDのとき `📷 表示名` を `pokefuta.com/users/{public_user_id}/visits` へのリンク（`.poster-link`）にする。無効・欠落時は従来どおりテキスト表示。
+- セクション10（リンク）に「ポケふた写真館」カードを常設し `pokefuta.com/manhole/{id}` へ飛ばす（ギャラリー非表示のふたにも写真館導線を確保）。
 
 ## 実装ステップ
 


### PR DESCRIPTION
## 概要

data.pokefuta.com のマンホール詳細ページから、投稿者の公開スタンプ帳（pokefuta.com/users/{public_user_id}/visits）とポケふた写真館本体への導線を増やす。

## 変更内容

### apps/scraper/generate_manhole_pages.py
- **ヒーロー写真の撮影者クレジット**: `📷 表示名` を投稿者の公開スタンプ帳へのリンクに（別タブ・`click_poster_profile` イベント計測付き）
- **みんなの写真ギャラリー**: 各サムネのクレジットも同様にリンク化。`gallery_local` に `public_user_id` を通すよう修正（従来はこのフィールドを捨てていた）
- **リンクセクションに「ポケふた写真館」カードを常設**: ギャラリーが表示されないふたでも `pokefuta.com/manhole/{id}` へ飛べる（既存 `icon-link-photo` を流用）
- **UUID ガード**: `apps/web/index.html` のホームフィードと同じ `PUBLIC_USER_ID_RE` を `poster_profile_url()` として移植。UUID 形式でない値はリンク化せず従来どおりテキスト表示

### docs/MANHOLE_DETAIL_SPEC.md
- gallery エントリのフィールド一覧に `public_user_id` を追記（記載漏れの解消）
- クレジットリンクと写真館カードの仕様を明文化

## データ前提

- `docs/latest-manhole-photos.json`（import-manhole-photos.yml が日次生成）は代表・gallery の両方に `public_user_id` を含む拡張済み。DB・エクスポート側の変更は不要
- `dist/latest-manhole-photos.json` は旧形式のままだが dist は gitignore 済みで、pages-deploy.yml が docs/ からコピーするため次回デプロイで自動更新

## 検証

- ローカルで `generate_manhole_pages.py` 実行: 482 ページ生成成功
- 写真あり 222 ページ全件でヒーロークレジットがリンク化、ギャラリー持ち 68 ページでサムネクレジットもリンク化
- 全 poster-link の href が UUID 形式の `/users/…/visits` のみであることを grep で確認（エスケープ崩れ・インジェクションなし）
- `poster_profile_url()` 単体テスト: None / 空 / 非UUID / パストラバーサル / 属性インジェクション文字列 → すべて空文字（リンク化されない）
- `py_compile` OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)