### PR TITLE
ヘッダーのログインを pokefuta と同じ紫の枠線ボタンにする

### DIFF
--- a/apps/web/assets/site-header.css
+++ b/apps/web/assets/site-header.css
@@ -83,6 +83,25 @@ body.has-site-header {
   text-underline-offset: 4px;
 }
 
+/* ログイン系リンクは pokefuta アプリのヘッダーと同じ紫の枠線ボタンにする */
+.site-header__auth-link--desktop,
+.site-header__auth-link--mobile {
+  padding: 7px 16px;
+  border: 1px solid #7b63a8;
+  border-radius: 8px;
+  color: #7b63a8;
+  font-weight: 700;
+}
+
+.site-header__auth-link--desktop:hover,
+.site-header__auth-link--desktop:focus-visible,
+.site-header__auth-link--mobile:hover,
+.site-header__auth-link--mobile:focus-visible {
+  background: rgba(123, 99, 168, .1);
+  color: #7b63a8;
+  text-decoration: none;
+}
+
 .site-header__auth-link--mobile {
   display: none;
 }
@@ -130,6 +149,13 @@ body.has-site-header {
 
   .site-header__auth-link--mobile {
     display: block;
+    padding: 6px 12px;
+    border: 1px solid #7b63a8;
+    border-radius: 8px;
+    background: transparent;
+    color: #7b63a8;
+    font-size: 12px;
+    font-weight: 700;
   }
 }
 


### PR DESCRIPTION
## 概要

pokefuta-tracker のヘッダーの「ログイン」を、pokefuta アプリのヘッダーと同じ**紫の枠線ボタン**の見た目に揃えました。CSS のみの変更です。

## 変更内容

`apps/web/assets/site-header.css`

- ログイン系リンク（`.site-header__auth-link--desktop` / `--mobile`）に pokefuta と同じスタイルを適用
  - 枠線 `1px solid #7b63a8` / 角丸 `8px` / 文字色 `#7b63a8` / `font-weight: 700`
  - ホバー時 `background: rgba(123,99,168,.1)`（pokefuta の `hover:bg-[#7B63A8]/10` 相当）
- モバイルは他ナビの薄紫チップ背景に上書きされないよう、メディアクエリ内でも枠線ボタンを再指定（`padding: 6px 12px` / `font-size: 12px` / 背景透過）

## スコープ外（今回はやらないこと）

- 「新規登録」ボタンの追加、ログイン時のプロフィール pill 化（＝ボタンの見た目のみ合わせる方針）
- `session-badge.js` の挙動（ログイン後に表示名／スタンプ帳へ差し替え）は**変更なし**
- テンプレート `inject_site_header.py` は変更不要

## テスト

- `python3 -m unittest apps.scraper.test_inject_site_header` → 7 件 OK
- `node apps/web/assets/session-badge.test.js` → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)