### PR TITLE
feat: デザインマンホール投稿のリンクを個別ページに変更

### DIFF
--- a/apps/scraper/import_design_manholes.py
+++ b/apps/scraper/import_design_manholes.py
@@ -273,7 +273,7 @@ def build_public_records(
             "lat": submission["latitude"],
             "lng": submission["longitude"],
             "photo_url": submission["photo_url"],
-            "source_url": SITE_URL,
+            "source_url": f"{SITE_URL}/{source_id}",
             "canonical_ref": canonical_ref,
             "nearby_refs": nearby,
             "review_status": review_status,

--- a/apps/scraper/import_design_manholes.py
+++ b/apps/scraper/import_design_manholes.py
@@ -273,7 +273,7 @@ def build_public_records(
             "lat": submission["latitude"],
             "lng": submission["longitude"],
             "photo_url": submission["photo_url"],
-            "source_url": f"{SITE_URL}/{source_id}",
+            "source_url": f"{SITE_URL}/{urllib.parse.quote(str(source_id), safe='')}",
             "canonical_ref": canonical_ref,
             "nearby_refs": nearby,
             "review_status": review_status,

--- a/apps/scraper/test_import_design_manholes.py
+++ b/apps/scraper/test_import_design_manholes.py
@@ -95,6 +95,20 @@ class ImportDesignManholesTests(unittest.TestCase):
         self.assertEqual(records[0]["nearby_refs"][0]["ref"], "gundam:5")
         self.assertNotIn("submitter_name", records[0])
 
+    def test_source_url_links_to_individual_submission_page(self):
+        records = importer.build_public_records(
+            [self.submission],
+            {},
+            {},
+            {},
+            "2026-07-14T00:00:00Z",
+        )
+
+        self.assertEqual(
+            records[0]["source_url"],
+            "https://pokefuta.com/design-manholes/submission-1",
+        )
+
     def test_manual_override_links_canonical_record(self):
         records = importer.build_public_records(
             [self.submission],

--- a/apps/web/design_manhole.html
+++ b/apps/web/design_manhole.html
@@ -383,7 +383,10 @@
           img.alt = d.title || 'デザインマンホール';
           img.loading = 'lazy';
           img.decoding = 'async';
-          return img;
+          const link = document.createElement('a');
+          link.href = `https://pokefuta.com/design-manholes/${encodeURIComponent(d.id)}`;
+          link.appendChild(img);
+          return link;
         }));
         document.getElementById('lp-gallery').hidden = false;
       } catch (e) { /* CORS等で取得できない環境ではギャラリーを出さない */ }

--- a/apps/web/gmanhole_map.html
+++ b/apps/web/gmanhole_map.html
@@ -878,7 +878,7 @@
         photoUrl,
         photoLink: sourceUrl,
         detailUrl: sourceUrl,
-        detailLabel: '投稿一覧を見る'
+        detailLabel: 'この投稿を見る'
       });
     }
 


### PR DESCRIPTION
## 目的

pokefuta.com 側に投稿個別ページ `/design-manholes/[id]`（SSR + OGP + 構造化データ）を追加した（nishiokya/pokefuta#190）のに合わせ、data.pokefuta.com からのリンクを一覧固定 → 投稿別ディープリンクに変更する。gmanhole_map の閲覧者が気になった投稿に直接飛べるようになり、共有・SEO面でも個別ページに被リンクが集まる。

## 変更内容

- `apps/scraper/import_design_manholes.py`: `source_url` を `https://pokefuta.com/design-manholes/{source_id}` に変更（+ テスト追加）
- `apps/web/gmanhole_map.html`: みんなの投稿ポップアップのリンクラベルを「投稿一覧を見る」→「この投稿を見る」（リンク先は `source_url` を使っているため自動追随）
- `apps/web/design_manhole.html`: ギャラリー画像を投稿個別ページへのリンクに

## 備考

- 既存9件の `docs/design_manholes.ndjson` は日次ワークフロー（update-design-manholes.yml）の再取込PRで新URLに更新される
- **マージは pokefuta#190 のデプロイ後を推奨**（先にマージしても一覧ページへ301等はなく404にはならない: 個別ページ未デプロイの間だけリンク先が404になる）

## 検証

- `python3 -m unittest apps.scraper.test_import_design_manholes` — 11件パス（source_url の個別URL化を固定するテストを追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)