### PR TITLE
feat: site-stats の鮮度を日次で監視するワークフローを追加

### DIFF
--- a/.github/workflows/check-site-stats.yml
+++ b/.github/workflows/check-site-stats.yml
@@ -1,0 +1,27 @@
+name: Check Site Stats Freshness
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Run after the 05:30 JST snapshot bake and its Pages deployment.
+    - cron: '0 22 * * *' # 07:00 JST
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Run unit tests
+        run: python3 -m unittest apps.scraper.test_check_site_stats_freshness
+
+      - name: Compare production stats with upstream snapshot
+        run: python3 apps/scraper/check_site_stats_freshness.py

--- a/apps/scraper/check_site_stats_freshness.py
+++ b/apps/scraper/check_site_stats_freshness.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Fail when pokefuta.com serves stale site statistics."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from urllib.request import Request, urlopen
+
+UPSTREAM_URL = "https://data.pokefuta.com/api/site-stats.json"
+SITE_URL = "https://pokefuta.com/api/site-stats"
+TIMEOUT = 30
+STAT_KEYS = (
+    "manholes",
+    "manholes_with_photos",
+    "posts",
+    "public_posts",
+    "private_posts",
+)
+
+
+def fetch_json(url: str) -> tuple[dict[str, Any], dict[str, str]]:
+    request = Request(url, headers={"User-Agent": "pokefuta-stats-monitor/1.0"})
+    with urlopen(request, timeout=TIMEOUT) as response:  # noqa: S310
+        payload = json.load(response)
+        headers = {key.lower(): value for key, value in response.headers.items()}
+    if not isinstance(payload, dict):
+        raise ValueError(f"{url} did not return a JSON object")
+    return payload, headers
+
+
+def parse_timestamp(value: Any) -> datetime:
+    if not isinstance(value, str):
+        raise ValueError("generated_at is missing")
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise ValueError("generated_at must include a timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def validate(
+    upstream: dict[str, Any],
+    site: dict[str, Any],
+    site_headers: dict[str, str],
+    *,
+    now: datetime,
+    max_age: timedelta,
+) -> list[str]:
+    errors: list[str] = []
+    try:
+        generated_at = parse_timestamp(site.get("generated_at"))
+        if now - generated_at > max_age:
+            errors.append(
+                f"site generated_at is stale: {generated_at.isoformat()} "
+                f"(maximum age: {max_age})"
+            )
+    except (TypeError, ValueError) as exc:
+        errors.append(str(exc))
+
+    for key in STAT_KEYS:
+        if upstream.get(key) != site.get(key):
+            errors.append(
+                f"{key} differs: upstream={upstream.get(key)!r}, site={site.get(key)!r}"
+            )
+
+    if site_headers.get("x-nextjs-cache", "").upper() == "HIT":
+        errors.append("x-nextjs-cache: HIT indicates that the route was statically cached")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--upstream-url", default=UPSTREAM_URL)
+    parser.add_argument("--site-url", default=SITE_URL)
+    parser.add_argument("--max-age-hours", type=float, default=30)
+    # 総待ち時間はワークフローの timeout-minutes 内に収めること（現状 3回 × 240秒 = 8分）
+    parser.add_argument("--attempts", type=int, default=3)
+    parser.add_argument("--retry-seconds", type=int, default=240)
+    args = parser.parse_args()
+
+    for attempt in range(1, args.attempts + 1):
+        try:
+            upstream, _ = fetch_json(args.upstream_url)
+            site, site_headers = fetch_json(args.site_url)
+            errors = validate(
+                upstream,
+                site,
+                site_headers,
+                now=datetime.now(timezone.utc),
+                max_age=timedelta(hours=args.max_age_hours),
+            )
+        except Exception as exc:  # Network and malformed responses must fail the monitor.
+            errors = [f"request failed: {exc}"]
+
+        if not errors:
+            print("Site statistics are fresh and match the upstream snapshot.")
+            return 0
+        print(f"Attempt {attempt}/{args.attempts}: {'; '.join(errors)}", file=sys.stderr)
+        if attempt < args.attempts:
+            time.sleep(args.retry_seconds)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/scraper/test_check_site_stats_freshness.py
+++ b/apps/scraper/test_check_site_stats_freshness.py
@@ -1,0 +1,46 @@
+import unittest
+from datetime import datetime, timedelta, timezone
+
+from apps.scraper.check_site_stats_freshness import validate
+
+
+NOW = datetime(2026, 7, 18, 0, 0, tzinfo=timezone.utc)
+STATS = {
+    "generated_at": "2026-07-17T21:00:00+00:00",
+    "manholes": 482,
+    "manholes_with_photos": 250,
+    "posts": 370,
+    "public_posts": 338,
+    "private_posts": 32,
+}
+
+
+class ValidateTest(unittest.TestCase):
+    def test_accepts_fresh_matching_stats(self):
+        self.assertEqual(
+            validate(STATS, STATS, {}, now=NOW, max_age=timedelta(hours=30)), []
+        )
+
+    def test_rejects_stale_stats(self):
+        site = {**STATS, "generated_at": "2026-07-15T00:00:00+00:00"}
+        errors = validate(STATS, site, {}, now=NOW, max_age=timedelta(hours=30))
+        self.assertTrue(any("stale" in error for error in errors))
+
+    def test_rejects_different_counts(self):
+        site = {**STATS, "posts": 280}
+        errors = validate(STATS, site, {}, now=NOW, max_age=timedelta(hours=30))
+        self.assertIn("posts differs: upstream=370, site=280", errors)
+
+    def test_rejects_static_nextjs_cache(self):
+        errors = validate(
+            STATS,
+            STATS,
+            {"x-nextjs-cache": "HIT"},
+            now=NOW,
+            max_age=timedelta(hours=30),
+        )
+        self.assertTrue(any("statically cached" in error for error in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景

PR #188 で `/api/site-stats` が Amplify のビルド時値に凍結され、古い統計を返す問題を修正した。同じ事故が再発しても誰も気づけないため、日次の監視を追加する。

## 内容

- `apps/scraper/check_site_stats_freshness.py` — `data.pokefuta.com/api/site-stats.json`（正）と `pokefuta.com/api/site-stats`（本番応答）を突き合わせる
  - 統計値5項目の不一致を検出
  - `generated_at` が 30時間より古ければ失敗
  - `x-nextjs-cache: HIT` を静的キャッシュの兆候として検出
- `.github/workflows/check-site-stats.yml` — 07:00 JST（05:30 JST のスナップショット生成＋Pagesデプロイの後）に実行
- ユニットテストをワークフロー内でも実行

## リトライ設計

デプロイ直後の伝播待ちを考慮し 240秒間隔で最大3回（合計8分）。`timeout-minutes: 20` に収まる。

## 動作確認

- `python3 -m unittest apps.scraper.test_check_site_stats_freshness` → 4件 OK
- 本番に対して実行 → `Site statistics are fresh and match the upstream snapshot.`（exit 0）

🤖 Generated with [Claude Code](https://claude.com/claude-code)