### PR TITLE
fix: トップのヒーロー写真の日付をロケール表記にし、長い投稿者名での崩れを防ぐ

### DIFF
--- a/apps/web/assets/top-page.css
+++ b/apps/web/assets/top-page.css
@@ -397,6 +397,10 @@ a { color: inherit; text-decoration: none; }
 .hero-footer-text {
   font-size: 12px;
   color: var(--top-text-muted);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .hero-footer-name-link {
@@ -416,6 +420,7 @@ a { color: inherit; text-decoration: none; }
   font-size: 12.5px;
   font-weight: 700;
   color: var(--top-purple);
+  flex-shrink: 0; /* 左の投稿者名が長くても CTA は潰さない（名前側を ellipsis する） */
 }
 
 /* Small hero cards */

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -424,18 +424,28 @@
 
     var PUBLIC_USER_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+    function formatFeedDate(value) {
+      if (!value) return '';
+      var date = new Date(value + 'T00:00:00+09:00');
+      if (isNaN(date.getTime())) return value;
+      return new Intl.DateTimeFormat(document.documentElement.lang || 'ja', {
+        month: 'short', day: 'numeric', timeZone: 'Asia/Tokyo'
+      }).format(date);
+    }
+
     function communityHero(photos) {
       function names(p) { return (p.pokemons || []).slice(0, 2).join('・'); }
       function place(p) { return (p.title || '').replace('/', ' '); }
       var f = photos[0];
-      var footerText = '📷 ' + (f.display_name ? TF_STRINGS.by.replace('{name}', f.display_name) + ' · ' : '') + (f.created_at || '');
+      var displayDate = formatFeedDate(f.created_at);
+      var footerText = '📷 ' + (f.display_name ? TF_STRINGS.by.replace('{name}', f.display_name) + ' · ' : '') + displayDate;
       var footerName = null;
       if (f.display_name && f.public_user_id && PUBLIC_USER_ID_RE.test(f.public_user_id)) {
         var byParts = TF_STRINGS.by.split('{name}');
         footerName = {
           prefix: '📷 ' + byParts[0],
           name: f.display_name,
-          suffix: byParts[1] + ' · ' + (f.created_at || ''),
+          suffix: byParts[1] + ' · ' + displayDate,
           publicUserId: f.public_user_id
         };
       }

--- a/apps/web/index.template.html
+++ b/apps/web/index.template.html
@@ -423,18 +423,28 @@
 
     var PUBLIC_USER_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+    function formatFeedDate(value) {
+      if (!value) return '';
+      var date = new Date(value + 'T00:00:00+09:00');
+      if (isNaN(date.getTime())) return value;
+      return new Intl.DateTimeFormat(document.documentElement.lang || 'ja', {
+        month: 'short', day: 'numeric', timeZone: 'Asia/Tokyo'
+      }).format(date);
+    }
+
     function communityHero(photos) {
       function names(p) { return (p.pokemons || []).slice(0, 2).join('・'); }
       function place(p) { return (p.title || '').replace('/', ' '); }
       var f = photos[0];
-      var footerText = '📷 ' + (f.display_name ? TF_STRINGS.by.replace('{name}', f.display_name) + ' · ' : '') + (f.created_at || '');
+      var displayDate = formatFeedDate(f.created_at);
+      var footerText = '📷 ' + (f.display_name ? TF_STRINGS.by.replace('{name}', f.display_name) + ' · ' : '') + displayDate;
       var footerName = null;
       if (f.display_name && f.public_user_id && PUBLIC_USER_ID_RE.test(f.public_user_id)) {
         var byParts = TF_STRINGS.by.split('{name}');
         footerName = {
           prefix: '📷 ' + byParts[0],
           name: f.display_name,
-          suffix: byParts[1] + ' · ' + (f.created_at || ''),
+          suffix: byParts[1] + ' · ' + displayDate,
           publicUserId: f.public_user_id
         };
       }


### PR DESCRIPTION
## 内容

トップページのヒーロー写真フッター（`📷 ○○ さんの投稿 · 日付`）まわりの表示修正。

### 1. 日付が生の ISO 表記だった

`2026-07-16` とそのまま出ていたので `Intl.DateTimeFormat` で整形する。

| lang | before | after |
|---|---|---|
| ja | `2026-07-16` | `7月16日` |
| en | `2026-07-16` | `Jul 16` |
| ko | `2026-07-16` | `7월 16일` |
| zh-TW | `2026-07-16` | `7月16日` |

`created_at` は UTC 日付を切り出した値なので `timeZone: 'Asia/Tokyo'` を明示し、閲覧者のタイムゾーンによって日付が前後しないようにしている。空文字・不正値はそのままフォールバック。

### 2. 長い投稿者名でフッターが崩れる

`.hero-featured-footer` は `justify-content: space-between` の flex で、投稿者名が長いと CTA（`ランキング →`）が押し潰される。名前側を `ellipsis` で省略し、CTA に `flex-shrink: 0` を付けて固定した。

## 動作確認

- `python3 tools/build_i18n.py` → 未置換マーカーなし（4言語ビルド OK）
- `formatFeedDate` を4ロケールで実行し上表の出力を確認
- `python3 -m unittest apps.scraper.test_generate_top_feed` → 10件 OK

## 補足（本PRの対象外）

- `test_generate_summary_pages` / `test_web_prefecture_links` に4件の失敗がありますが、**main 時点で既に失敗している既存の不具合**です（`index.html` / `index.template.html` の双方に `label: 'ガンダムマンホール'` が存在しないというアサーション）。本PRとは無関係のため触っていません。
- `tools/make_template.py` は現状**壊れています**。実行すると `%%PAGE_TITLE%%` 等のプレースホルダを日本語リテラルに置換してしまい i18n が壊れるため、`index.template.html` は手で更新しました。別途対応が必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)