### PR TITLE
docs: スクリプト移管後に残った旧パス参照を修正

### DIFF
--- a/apps/scraper/export_latest_manhole_photos.py
+++ b/apps/scraper/export_latest_manhole_photos.py
@@ -9,7 +9,7 @@ Example:
   export NEXT_PUBLIC_SUPABASE_URL="https://xxxxx.supabase.co"
   export SUPABASE_SERVICE_ROLE_KEY="xxxxx"
   export R2_PUBLIC_BASE_URL="https://images.pokefuta.com"
-  python3 tools/export_latest_manhole_photos.py
+  python3 apps/scraper/export_latest_manhole_photos.py
 """
 
 from __future__ import annotations

--- a/docs/MANHOLE_DETAIL_SPEC.md
+++ b/docs/MANHOLE_DETAIL_SPEC.md
@@ -44,7 +44,7 @@ data.pokefuta.com（tracker）と pokefuta.com のマンホール詳細ページ
 
 現行の `latest-manhole-photos.json` は 1マンホール=最新1枚。以下のとおり拡張する。
 
-### エクスポート拡張（pokefuta repo: `tools/export_latest_manhole_photos.py`）
+### エクスポート拡張（tracker repo: `apps/scraper/export_latest_manhole_photos.py`）
 
 - `photos[manhole_id]` の既存フィールド（代表＝最新1枚）は**そのまま維持**（後方互換）。
 - 各エントリに `gallery` 配列を追加：代表を含む公開写真を新しい順に**最大5枚**。
@@ -84,7 +84,7 @@ data.pokefuta.com（tracker）と pokefuta.com のマンホール詳細ページ
 
 ## 実装ステップ
 
-1. **pokefuta repo**: `tools/export_latest_manhole_photos.py` に `gallery` 追加（後方互換）
+1. **tracker repo**: `apps/scraper/export_latest_manhole_photos.py` に `gallery` 追加（後方互換。2026-07-19 に pokefuta repo から移管済み）
 2. **tracker repo**: `apps/tools/import_latest_manhole_photos.py` のギャラリーDL＋縮小＋掃除
 3. **tracker repo**: `generate_manhole_pages.py` にギャラリーセクション追加
 4. **pokefuta repo**: `ManholePage.tsx` の未ログイン時レイアウトを本仕様のセクション順に再構成（近隣・同ポケモン・県内セクションの新設を含む）


### PR DESCRIPTION
## 概要

PR #352 の移管はバイト同一性を優先したため、移管スクリプト自身の docstring と仕様書に旧パス（pokefuta repo の `tools/`）への参照が残っていた。pokefuta 側の実体は nishiokya/pokefuta#193 で削除済みのため、参照を現在の場所に合わせる。

## 変更内容

- `apps/scraper/export_latest_manhole_photos.py` — docstring の実行例を `apps/scraper/` パスに修正（コード変更なし）
- `docs/MANHOLE_DETAIL_SPEC.md` — ギャラリー拡張（エクスポート側）の実装場所を tracker repo に訂正

## 検証

- `python3 -m unittest apps.scraper.test_export_latest_manhole_photos` → 12件 OK
- `tools/export_latest_manhole_photos` の残存参照 grep → 0件

🤖 Generated with [Claude Code](https://claude.com/claude-code)