### PR TITLE
feat: トップのヒーローに称号バッジと写真枚数を表示（top-feed拡張）

### DIFF
--- a/apps/scraper/generate_top_feed.py
+++ b/apps/scraper/generate_top_feed.py
@@ -160,7 +160,8 @@ def build_top_feed(
             "comment": sanitize_comment(photo.get("comment")),
             "created_at": created_jst.isoformat() if created_jst else "",
         }
-        # ペイロード規律: 値があるときだけキーを足す（null は焼き込まない）
+        # badge / photo_count は任意フィールド: 値があるときだけキーを足す
+        # （既存フィールドと違い null を焼き込まず、クライアントは in 判定で読む）
         badge = hero_badge(record)
         if badge:
             entry["badge"] = badge

--- a/apps/scraper/generate_top_feed.py
+++ b/apps/scraper/generate_top_feed.py
@@ -105,14 +105,17 @@ def hero_badge(record: dict) -> dict | None:
 
 
 def photo_count_for(photo: dict) -> int:
-    """その地点の既知の写真枚数（ヒーロー1枚 + gallery の追加分）。
+    """その地点の既知の写真枚数。
 
-    gallery は import 側で5件にキャップされているため、6 は「6枚以上」を意味する
-    （クライアント側は 6 のとき '📷6+' と表示する）。
+    gallery は代表写真（ヒーロー）自身を先頭に含む public 写真のリスト
+    （export_latest_manhole_photos.py の select_gallery_photos は全写真から選ぶ）で、
+    export 側で5件にキャップされている。5 は「5枚以上」を意味する
+    （クライアント側は 5 のとき '📷5+' と表示する）。
     """
     gallery = photo.get("gallery")
-    extra = len(gallery) if isinstance(gallery, list) else 0
-    return 1 + extra
+    if isinstance(gallery, list) and gallery:
+        return len(gallery)
+    return 1
 
 
 def build_top_feed(

--- a/apps/scraper/generate_top_feed.py
+++ b/apps/scraper/generate_top_feed.py
@@ -19,6 +19,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
+from export_latest_manhole_photos import DEFAULT_GALLERY_LIMIT  # noqa: E402
 from photo_caption import to_jst_date  # noqa: E402
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -108,9 +109,9 @@ def photo_count_for(photo: dict) -> int:
     """その地点の既知の写真枚数。
 
     gallery は代表写真（ヒーロー）自身を先頭に含む public 写真のリスト
-    （export_latest_manhole_photos.py の select_gallery_photos は全写真から選ぶ）で、
-    export 側で5件にキャップされている。5 は「5枚以上」を意味する
-    （クライアント側は 5 のとき '📷5+' と表示する）。
+    （export_latest_manhole_photos.py の select_gallery_photos は全写真から選ぶ）。
+    export 側で gallery_limit 件にキャップされるため、この値は実際の枚数の
+    下限でしかない（上限到達かどうかは at_cap を参照）。
     """
     gallery = photo.get("gallery")
     if isinstance(gallery, list) and gallery:
@@ -124,6 +125,7 @@ def build_top_feed(
     site_stats: dict,
     image_dir: Path = IMAGE_DIR,
     max_photos: int = MAX_PHOTOS,
+    gallery_limit: int = DEFAULT_GALLERY_LIMIT,
 ) -> dict:
     photos = photos_data.get("photos", {}) or {}
     sorted_photos = sorted(
@@ -168,6 +170,10 @@ def build_top_feed(
         photo_count = photo_count_for(photo)
         if photo_count >= 2:
             entry["photo_count"] = photo_count
+            # gallery が export のキャップに達している = 実際はこれ以上ある可能性がある。
+            # キャップ値をクライアントに焼き込ませないためフラグで渡す（'📷5+' の判定用）
+            if photo_count >= gallery_limit:
+                entry["photo_count_at_cap"] = True
         entries.append(entry)
         if len(entries) >= max_photos:
             break

--- a/apps/scraper/generate_top_feed.py
+++ b/apps/scraper/generate_top_feed.py
@@ -30,6 +30,10 @@ IMAGE_DIR = ROOT / "dataset" / "manhole" / "image"
 MAX_PHOTOS = 12
 COMMENT_MAX_LEN = 80
 
+# 称号バッジに採用する最低 priority。「ここだけ」(90) / 離島 (95) / 最北端等 (100) /
+# レア (70) / 市内唯一 (60) は拾い、観光・駅前などの汎用タグ (36 帯) は拾わない
+HERO_BADGE_MIN_PRIORITY = 60
+
 # pokefuta.ndjson の pokemons に混ざる非ポケモン表記（トップページ JS と同じ除外規則）
 _EXCLUDED_POKEMON_PATTERN = "ローカルActs"
 
@@ -73,6 +77,44 @@ def sanitize_comment(text: object) -> str | None:
     return collapsed
 
 
+def hero_badge(record: dict) -> dict | None:
+    """ndjson の titles[0]（priority 降順格納済み）から称号バッジを作る。
+
+    label には hashtag から '#' を落とした短縮形を使う（titles の label は
+    「ガラルダルマッカは全国でここだけ」のように長く、ヒーローのバッジ枠に
+    収まらないため）。希少称号（HERO_BADGE_MIN_PRIORITY 以上）のみ採用。
+    """
+    titles = record.get("titles") or []
+    if not titles or not isinstance(titles[0], dict):
+        return None
+    top = titles[0]
+    priority = top.get("priority")
+    hashtag = top.get("hashtag")
+    if not isinstance(priority, (int, float)) or priority < HERO_BADGE_MIN_PRIORITY:
+        return None
+    if not isinstance(hashtag, str):
+        return None
+    label = hashtag.lstrip("#").strip()
+    if not label:
+        return None
+    return {
+        "emoji": top.get("emoji") or "",
+        "label": label,
+        "priority": int(priority),
+    }
+
+
+def photo_count_for(photo: dict) -> int:
+    """その地点の既知の写真枚数（ヒーロー1枚 + gallery の追加分）。
+
+    gallery は import 側で5件にキャップされているため、6 は「6枚以上」を意味する
+    （クライアント側は 6 のとき '📷6+' と表示する）。
+    """
+    gallery = photo.get("gallery")
+    extra = len(gallery) if isinstance(gallery, list) else 0
+    return 1 + extra
+
+
 def build_top_feed(
     photos_data: dict,
     records_by_id: dict[str, dict],
@@ -104,7 +146,7 @@ def build_top_feed(
         # UTC のまま [:10] すると UTC 15:00 以降の投稿が1日前にずれるため
         # JST に変換してから日付化する（トップの formatFeedDate は JST 日付を前提）
         created_jst = to_jst_date(photo.get("created_at"))
-        entries.append({
+        entry = {
             "id": mid,
             "title": record.get("title", ""),
             "prefecture": record.get("prefecture", ""),
@@ -114,7 +156,15 @@ def build_top_feed(
             "public_user_id": photo.get("public_user_id") or None,
             "comment": sanitize_comment(photo.get("comment")),
             "created_at": created_jst.isoformat() if created_jst else "",
-        })
+        }
+        # ペイロード規律: 値があるときだけキーを足す（null は焼き込まない）
+        badge = hero_badge(record)
+        if badge:
+            entry["badge"] = badge
+        photo_count = photo_count_for(photo)
+        if photo_count >= 2:
+            entry["photo_count"] = photo_count
+        entries.append(entry)
         if len(entries) >= max_photos:
             break
 

--- a/apps/scraper/test_generate_top_feed.py
+++ b/apps/scraper/test_generate_top_feed.py
@@ -54,6 +54,59 @@ class SanitizeCommentTests(unittest.TestCase):
         self.assertTrue(result.endswith("…"))
 
 
+class HeroBadgeTests(unittest.TestCase):
+    def _title(self, **extra):
+        title = {
+            "emoji": "🌟",
+            "hashtag": "#レアポケふた",
+            "key": "rare_pokemon",
+            "label": "レアポケふた（全国2枚）",
+            "priority": 70,
+        }
+        title.update(extra)
+        return title
+
+    def test_high_priority_title_becomes_badge_with_short_label(self):
+        record = _record("1", titles=[self._title()])
+        self.assertEqual(
+            top_feed.hero_badge(record),
+            {"emoji": "🌟", "label": "レアポケふた", "priority": 70},
+        )
+
+    def test_priority_below_threshold_is_rejected(self):
+        record = _record("1", titles=[self._title(priority=59)])
+        self.assertIsNone(top_feed.hero_badge(record))
+
+    def test_generic_tag_priority_is_rejected(self):
+        record = _record(
+            "1",
+            titles=[self._title(hashtag="#観光ポケふた", priority=36)],
+        )
+        self.assertIsNone(top_feed.hero_badge(record))
+
+    def test_missing_hashtag_is_rejected(self):
+        record = _record("1", titles=[self._title(hashtag=None)])
+        self.assertIsNone(top_feed.hero_badge(record))
+
+    def test_missing_titles_is_rejected(self):
+        self.assertIsNone(top_feed.hero_badge(_record("1")))
+        self.assertIsNone(top_feed.hero_badge(_record("1", titles=[])))
+
+    def test_missing_emoji_becomes_empty_string(self):
+        record = _record("1", titles=[self._title(emoji=None)])
+        badge = top_feed.hero_badge(record)
+        self.assertEqual(badge["emoji"], "")
+
+
+class PhotoCountTests(unittest.TestCase):
+    def test_no_gallery_counts_hero_only(self):
+        self.assertEqual(top_feed.photo_count_for({}), 1)
+        self.assertEqual(top_feed.photo_count_for({"gallery": None}), 1)
+
+    def test_gallery_entries_add_to_hero(self):
+        self.assertEqual(top_feed.photo_count_for({"gallery": [{}, {}]}), 3)
+
+
 class BuildTopFeedTests(unittest.TestCase):
     def setUp(self):
         self._tmp = tempfile.TemporaryDirectory()
@@ -163,6 +216,32 @@ class BuildTopFeedTests(unittest.TestCase):
         self.assertEqual(
             entry["public_user_id"], "11111111-2222-3333-4444-555555555555"
         )
+
+    def test_badge_and_photo_count_added_only_when_meaningful(self):
+        photos = {
+            "1": _photo("1", "2026-06-02T00:00:00+00:00", gallery=[{}, {}]),
+            "2": _photo("2", "2026-06-01T00:00:00+00:00"),
+        }
+        records = {
+            "1": _record(
+                "1",
+                titles=[{"emoji": "⭐", "hashtag": "#ここだけ", "priority": 90}],
+            ),
+            "2": _record("2"),
+        }
+        self._touch_image("1")
+        self._touch_image("2")
+        feed = top_feed.build_top_feed(
+            {"photos": photos}, records, {}, image_dir=self.image_dir
+        )
+        rich, plain = feed["photos"]
+        self.assertEqual(
+            rich["badge"], {"emoji": "⭐", "label": "ここだけ", "priority": 90}
+        )
+        self.assertEqual(rich["photo_count"], 3)
+        # 値が無いエントリにはキー自体を足さない（null を焼き込まない）
+        self.assertNotIn("badge", plain)
+        self.assertNotIn("photo_count", plain)
 
     def test_stats_subset_ignores_non_int_values(self):
         site_stats = {

--- a/apps/scraper/test_generate_top_feed.py
+++ b/apps/scraper/test_generate_top_feed.py
@@ -102,9 +102,14 @@ class PhotoCountTests(unittest.TestCase):
     def test_no_gallery_counts_hero_only(self):
         self.assertEqual(top_feed.photo_count_for({}), 1)
         self.assertEqual(top_feed.photo_count_for({"gallery": None}), 1)
+        self.assertEqual(top_feed.photo_count_for({"gallery": []}), 1)
 
-    def test_gallery_entries_add_to_hero(self):
-        self.assertEqual(top_feed.photo_count_for({"gallery": [{}, {}]}), 3)
+    def test_gallery_length_is_the_count(self):
+        # gallery は代表写真自身を先頭に含むため len がそのまま枚数
+        self.assertEqual(top_feed.photo_count_for({"gallery": [{}, {}]}), 2)
+        self.assertEqual(
+            top_feed.photo_count_for({"gallery": [{}] * 5}), 5
+        )
 
 
 class BuildTopFeedTests(unittest.TestCase):
@@ -238,7 +243,7 @@ class BuildTopFeedTests(unittest.TestCase):
         self.assertEqual(
             rich["badge"], {"emoji": "⭐", "label": "ここだけ", "priority": 90}
         )
-        self.assertEqual(rich["photo_count"], 3)
+        self.assertEqual(rich["photo_count"], 2)
         # 値が無いエントリにはキー自体を足さない（null を焼き込まない）
         self.assertNotIn("badge", plain)
         self.assertNotIn("photo_count", plain)

--- a/apps/scraper/test_generate_top_feed.py
+++ b/apps/scraper/test_generate_top_feed.py
@@ -112,6 +112,47 @@ class PhotoCountTests(unittest.TestCase):
         )
 
 
+class PhotoCountCapTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.image_dir = Path(self._tmp.name)
+        (self.image_dir / "1_latest.jpeg").write_bytes(b"")
+
+    def _feed(self, gallery_len: int, gallery_limit: int):
+        photos = {
+            "1": _photo(
+                "1",
+                "2026-06-01T00:00:00+00:00",
+                gallery=[{}] * gallery_len,
+            )
+        }
+        feed = top_feed.build_top_feed(
+            {"photos": photos},
+            {"1": _record("1")},
+            {},
+            image_dir=self.image_dir,
+            gallery_limit=gallery_limit,
+        )
+        return feed["photos"][0]
+
+    def test_at_cap_sets_flag(self):
+        entry = self._feed(gallery_len=5, gallery_limit=5)
+        self.assertEqual(entry["photo_count"], 5)
+        self.assertTrue(entry["photo_count_at_cap"])
+
+    def test_below_cap_omits_flag(self):
+        entry = self._feed(gallery_len=4, gallery_limit=5)
+        self.assertEqual(entry["photo_count"], 4)
+        self.assertNotIn("photo_count_at_cap", entry)
+
+    def test_larger_cap_keeps_mid_counts_uncapped(self):
+        # キャップが増えても 5 枚が「5+」にならない（クライアントは値を持たない）
+        entry = self._feed(gallery_len=5, gallery_limit=10)
+        self.assertEqual(entry["photo_count"], 5)
+        self.assertNotIn("photo_count_at_cap", entry)
+
+
 class BuildTopFeedTests(unittest.TestCase):
     def setUp(self):
         self._tmp = tempfile.TemporaryDirectory()
@@ -244,6 +285,7 @@ class BuildTopFeedTests(unittest.TestCase):
             rich["badge"], {"emoji": "⭐", "label": "ここだけ", "priority": 90}
         )
         self.assertEqual(rich["photo_count"], 2)
+        self.assertNotIn("photo_count_at_cap", rich)
         # 値が無いエントリにはキー自体を足さない（null を焼き込まない）
         self.assertNotIn("badge", plain)
         self.assertNotIn("photo_count", plain)

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -433,6 +433,21 @@
       }).format(date);
     }
 
+    function heroBadge(p) {
+      // 称号バッジ（例「🌟 レアポケふた」）。label は日本語のみのため、
+      // 非 ja ページでは共通の TF_STRINGS.badge にフォールバックする（既知の i18n ギャップ）
+      if (p.badge && p.badge.label && (document.documentElement.lang || 'ja') === 'ja') {
+        return (p.badge.emoji ? p.badge.emoji + ' ' : '') + p.badge.label;
+      }
+      return TF_STRINGS.badge;
+    }
+
+    function heroMediaLabel(p, place) {
+      // photo_count は gallery 5件キャップのため 6 = 「6枚以上」（📷6+ と表示）
+      if (!(p.photo_count >= 2)) return place;
+      return place + ' · 📷' + p.photo_count + (p.photo_count >= 6 ? '+' : '');
+    }
+
     function communityHero(photos) {
       function names(p) { return (p.pokemons || []).slice(0, 2).join('・'); }
       function place(p) { return (p.title || '').replace('/', ' '); }
@@ -453,8 +468,8 @@
         id: f.id, community: true,
         imgAlt: (names(f) || place(f)) + 'のポケふた投稿写真',
         bgStyle: 'linear-gradient(140deg,#7E9DB2,#5E7C8A)',
-        badge: TF_STRINGS.badge,
-        mediaLabel: place(f),
+        badge: heroBadge(f),
+        mediaLabel: heroMediaLabel(f, place(f)),
         title: f.comment || names(f) || place(f),
         place: f.comment && names(f) ? place(f) + ' ／ ' + names(f) : place(f),
         footerText: footerText,
@@ -466,7 +481,7 @@
             id: p.id,
             imgAlt: (names(p) || place(p)) + 'のポケふた投稿写真',
             bg: 'linear-gradient(140deg,#7E9DB2,#5E7C8A)',
-            badge: TF_STRINGS.badge,
+            badge: heroBadge(p),
             title: names(p) || place(p),
             place: place(p) + ' →',
             href: 'map.html?manhole=' + encodeURIComponent(p.id)

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -443,9 +443,9 @@
     }
 
     function heroMediaLabel(p, place) {
-      // photo_count は gallery 5件キャップのため 6 = 「6枚以上」（📷6+ と表示）
+      // photo_count は gallery 5件キャップのため 5 = 「5枚以上」（📷5+ と表示）
       if (!(p.photo_count >= 2)) return place;
-      return place + ' · 📷' + p.photo_count + (p.photo_count >= 6 ? '+' : '');
+      return place + ' · 📷' + p.photo_count + (p.photo_count >= 5 ? '+' : '');
     }
 
     function communityHero(photos) {

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -443,9 +443,10 @@
     }
 
     function heroMediaLabel(p, place) {
-      // photo_count は gallery 5件キャップのため 5 = 「5枚以上」（📷5+ と表示）
+      // photo_count は export の gallery キャップで頭打ちになるため、
+      // 上限到達は生成側の photo_count_at_cap で判定する（キャップ値は焼き込まない）
       if (!(p.photo_count >= 2)) return place;
-      return place + ' · 📷' + p.photo_count + (p.photo_count >= 5 ? '+' : '');
+      return place + ' · 📷' + p.photo_count + (p.photo_count_at_cap ? '+' : '');
     }
 
     function communityHero(photos) {

--- a/apps/web/index.template.html
+++ b/apps/web/index.template.html
@@ -442,9 +442,9 @@
     }
 
     function heroMediaLabel(p, place) {
-      // photo_count は gallery 5件キャップのため 6 = 「6枚以上」（📷6+ と表示）
+      // photo_count は gallery 5件キャップのため 5 = 「5枚以上」（📷5+ と表示）
       if (!(p.photo_count >= 2)) return place;
-      return place + ' · 📷' + p.photo_count + (p.photo_count >= 6 ? '+' : '');
+      return place + ' · 📷' + p.photo_count + (p.photo_count >= 5 ? '+' : '');
     }
 
     function communityHero(photos) {

--- a/apps/web/index.template.html
+++ b/apps/web/index.template.html
@@ -432,6 +432,21 @@
       }).format(date);
     }
 
+    function heroBadge(p) {
+      // 称号バッジ（例「🌟 レアポケふた」）。label は日本語のみのため、
+      // 非 ja ページでは共通の TF_STRINGS.badge にフォールバックする（既知の i18n ギャップ）
+      if (p.badge && p.badge.label && (document.documentElement.lang || 'ja') === 'ja') {
+        return (p.badge.emoji ? p.badge.emoji + ' ' : '') + p.badge.label;
+      }
+      return TF_STRINGS.badge;
+    }
+
+    function heroMediaLabel(p, place) {
+      // photo_count は gallery 5件キャップのため 6 = 「6枚以上」（📷6+ と表示）
+      if (!(p.photo_count >= 2)) return place;
+      return place + ' · 📷' + p.photo_count + (p.photo_count >= 6 ? '+' : '');
+    }
+
     function communityHero(photos) {
       function names(p) { return (p.pokemons || []).slice(0, 2).join('・'); }
       function place(p) { return (p.title || '').replace('/', ' '); }
@@ -452,8 +467,8 @@
         id: f.id, community: true,
         imgAlt: (names(f) || place(f)) + 'のポケふた投稿写真',
         bgStyle: 'linear-gradient(140deg,#7E9DB2,#5E7C8A)',
-        badge: TF_STRINGS.badge,
-        mediaLabel: place(f),
+        badge: heroBadge(f),
+        mediaLabel: heroMediaLabel(f, place(f)),
         title: f.comment || names(f) || place(f),
         place: f.comment && names(f) ? place(f) + ' ／ ' + names(f) : place(f),
         footerText: footerText,
@@ -465,7 +480,7 @@
             id: p.id,
             imgAlt: (names(p) || place(p)) + 'のポケふた投稿写真',
             bg: 'linear-gradient(140deg,#7E9DB2,#5E7C8A)',
-            badge: TF_STRINGS.badge,
+            badge: heroBadge(p),
             title: names(p) || place(p),
             place: place(p) + ' →',
             href: BASE_PATH + 'map.html?manhole=' + encodeURIComponent(p.id)

--- a/apps/web/index.template.html
+++ b/apps/web/index.template.html
@@ -442,9 +442,10 @@
     }
 
     function heroMediaLabel(p, place) {
-      // photo_count は gallery 5件キャップのため 5 = 「5枚以上」（📷5+ と表示）
+      // photo_count は export の gallery キャップで頭打ちになるため、
+      // 上限到達は生成側の photo_count_at_cap で判定する（キャップ値は焼き込まない）
       if (!(p.photo_count >= 2)) return place;
-      return place + ' · 📷' + p.photo_count + (p.photo_count >= 5 ? '+' : '');
+      return place + ' · 📷' + p.photo_count + (p.photo_count_at_cap ? '+' : '');
     }
 
     function communityHero(photos) {


### PR DESCRIPTION
## 概要

「今日、どのポケふたに会いに行く？」（TODAY'S HERO）の表示情報を増強します。

## 変更内容

### top-feed.json スキーマ拡張（generate_top_feed.py）
- `badge`: ndjson の `titles[0]`（priority 降順格納済み）が **priority >= 60** の希少称号のとき `{emoji, label, priority}` を焼き込み。label は hashtag から `#` を落とした短縮形（例「レアポケふた」）。観光・駅前など汎用タグ（priority 36 帯）は拾いません。
- `photo_count`: その地点の既知写真枚数 = `len(gallery)`。**gallery は代表写真自身を先頭に含む**（`select_gallery_photos()` が全写真から選ぶ）ため加算はしません。**>= 2 のときのみ**焼き込み。export 側でキャップされるため実枚数の下限であり、上限到達時のみ `photo_count_at_cap: true` を併せて焼き込む（キャップ値はクライアントに持たせない）。
- badge / photo_count は任意フィールドで、値が無いエントリにはキー自体を足しません（既存フィールドと違い null を焼き込まない）。追加入力ファイルは不要（既存の latest-manhole-photos.json / pokefuta.ndjson から取得）。

### ヒーローUI（index.html / index.template.html 対編集）
- `heroBadge()`: badge があれば「⭐ 激レアポケふた」のような称号バッジに差し替え。**非 ja ページは従来の `TF_STRINGS.badge` にフォールバック**（label が日本語のみのため。既知の i18n ギャップとして踏襲）。
- `heroMediaLabel()`: photo_count >= 2 のとき「福島県 小野町 · 📷2」形式（`photo_count_at_cap` のとき 📷5+）。絵文字+数字で言語中立のため**新規 i18n キーなし**。
- フッター行（#346 のロケール日付・ellipsis 対応）は変更なし。

## 検証
- `python3 -m unittest test_generate_top_feed`: 21件 OK（badge 閾値・hashtag 欠損・photo_count 条件・キー省略のテスト追加）
- `python3 tools/build_i18n.py`: WARN なし
- node --check で両 HTML のインライン JS 構文 OK、heroBadge / heroMediaLabel ブロックの対称性を diff で確認
- ローカル実表示確認（ヘッドレス Edge）: ja ページで「⭐ 激レアポケふた」バッジ +「福島県 小野町 · 📷2」+ フッター「…さんの投稿 · 7月20日」、en ページで「📸 Fan photo」フォールバック +「Jul 20」を確認
- photo_count の二重カウント（codex P1 指摘）は実データ 242/242 件で代表写真が gallery に含まれることを確認のうえ修正済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
