### PR TITLE
feat: 今日のポケふたのキュレーションを4→7セットに増やす（週次ローテーション化）

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -361,6 +361,45 @@
           { id: 149, imgAlt: '奈良県斑鳩町のガーディ・マダツボミのポケふた', badge: '🌲 世界遺産', bg: 'linear-gradient(140deg,#C89870,#A06840)', title: 'ガーディ・マダツボミ', place: '奈良県 斑鳩町 →', href: 'map.html?manhole=149' },
           { id: 301, imgAlt: '石川県金沢市のミロカロスのポケふた', badge: '🏛 美術館', bg: 'linear-gradient(140deg,#D0B8E0,#A890C0)', title: 'ミロカロス', place: '石川県 金沢市 →', href: 'map.html?manhole=301' }
         ]
+      },
+      {
+        id: 67, imgAlt: '北海道稚内市の日本最北のポケふた（アローラキュウコン・アローラロコン）',
+        bgStyle: 'linear-gradient(140deg,#9DB6C7,#6E8CA0)',
+        badge: '🧭 日本最北', mediaLabel: '北海道 稚内市',
+        title: '日本のいちばん北で待つポケふた',
+        place: '北海道 稚内市 ／ アローラキュウコン・アローラロコン',
+        footerText: '北海道のポケふたをもっと見る', footerCta: '地図で見る →',
+        href: 'map.html?manhole=67',
+        small: [
+          { id: 156, imgAlt: '東京都小笠原村のミュウのポケふた', badge: '🏝 離島', bg: 'linear-gradient(140deg,#5AB4E0,#2E8BB0)', title: 'ミュウ', place: '東京都 小笠原村 →', href: 'map.html?manhole=156' },
+          { id: 411, imgAlt: '茨城県つくば市のレックウザのポケふた', badge: '🌟 全国2枚', bg: 'linear-gradient(140deg,#7EA0C0,#4E7090)', title: 'レックウザ', place: '茨城県 つくば市 →', href: 'map.html?manhole=411' }
+        ]
+      },
+      {
+        id: 154, imgAlt: '東京都小笠原村のリザードンのポケふた',
+        bgStyle: 'linear-gradient(140deg,#5AB4E0,#2E8BB0)',
+        badge: '🏝 離島×世界遺産', mediaLabel: '東京都 小笠原村',
+        title: '船でしか行けない島のポケふた',
+        place: '東京都 小笠原村 ／ リザードン',
+        footerText: '東京のポケふたをもっと見る', footerCta: '地図で見る →',
+        href: 'map.html?manhole=154',
+        small: [
+          { id: 159, imgAlt: '京都府京都市のホウオウのポケふた', badge: '⭐ ここだけ', bg: 'linear-gradient(140deg,#E8C070,#C09040)', title: 'ホウオウ', place: '京都府 京都市 →', href: 'map.html?manhole=159' },
+          { id: 54, imgAlt: '宮城県仙台市のジラーチ・ラプラスのポケふた', badge: '⭐ ここだけ', bg: 'linear-gradient(140deg,#B0C8E0,#7898C0)', title: 'ジラーチ・ラプラス', place: '宮城県 仙台市 →', href: 'map.html?manhole=54' }
+        ]
+      },
+      {
+        id: 346, imgAlt: '和歌山県那智勝浦町のセレビィのポケふた',
+        bgStyle: 'linear-gradient(140deg,#4AA880,#2A7860)',
+        badge: '⭐ 全国でここだけ', mediaLabel: '和歌山県 那智勝浦町',
+        title: '熊野の森にひそむ幻のポケふた',
+        place: '和歌山県 那智勝浦町 ／ セレビィ',
+        footerText: '和歌山のポケふたをもっと見る', footerCta: '地図で見る →',
+        href: 'map.html?manhole=346',
+        small: [
+          { id: 343, imgAlt: '和歌山県高野町のウーラオスのポケふた', badge: '⭐ ここだけ', bg: 'linear-gradient(140deg,#A8C0A0,#6E8C68)', title: 'ウーラオス', place: '和歌山県 高野町 →', href: 'map.html?manhole=343' },
+          { id: 9, imgAlt: '鹿児島県指宿市のニンフィアのポケふた', badge: '🌟 全国2枚', bg: 'linear-gradient(140deg,#F0C0D0,#C890A8)', title: 'ニンフィア', place: '鹿児島県 指宿市 →', href: 'map.html?manhole=9' }
+        ]
       }
     ];
 

--- a/apps/web/index.template.html
+++ b/apps/web/index.template.html
@@ -360,6 +360,45 @@
           { id: 149, imgAlt: '奈良県斑鳩町のガーディ・マダツボミのポケふた', badge: '🌲 世界遺産', bg: 'linear-gradient(140deg,#C89870,#A06840)', title: 'ガーディ・マダツボミ', place: '奈良県 斑鳩町 →', href: BASE_PATH + 'map.html?manhole=149' },
           { id: 301, imgAlt: '石川県金沢市のミロカロスのポケふた', badge: '🏛 美術館', bg: 'linear-gradient(140deg,#D0B8E0,#A890C0)', title: 'ミロカロス', place: '石川県 金沢市 →', href: BASE_PATH + 'map.html?manhole=301' }
         ]
+      },
+      {
+        id: 67, imgAlt: '北海道稚内市の日本最北のポケふた（アローラキュウコン・アローラロコン）',
+        bgStyle: 'linear-gradient(140deg,#9DB6C7,#6E8CA0)',
+        badge: '🧭 日本最北', mediaLabel: '北海道 稚内市',
+        title: '日本のいちばん北で待つポケふた',
+        place: '北海道 稚内市 ／ アローラキュウコン・アローラロコン',
+        footerText: '北海道のポケふたをもっと見る', footerCta: '地図で見る →',
+        href: BASE_PATH + 'map.html?manhole=67',
+        small: [
+          { id: 156, imgAlt: '東京都小笠原村のミュウのポケふた', badge: '🏝 離島', bg: 'linear-gradient(140deg,#5AB4E0,#2E8BB0)', title: 'ミュウ', place: '東京都 小笠原村 →', href: BASE_PATH + 'map.html?manhole=156' },
+          { id: 411, imgAlt: '茨城県つくば市のレックウザのポケふた', badge: '🌟 全国2枚', bg: 'linear-gradient(140deg,#7EA0C0,#4E7090)', title: 'レックウザ', place: '茨城県 つくば市 →', href: BASE_PATH + 'map.html?manhole=411' }
+        ]
+      },
+      {
+        id: 154, imgAlt: '東京都小笠原村のリザードンのポケふた',
+        bgStyle: 'linear-gradient(140deg,#5AB4E0,#2E8BB0)',
+        badge: '🏝 離島×世界遺産', mediaLabel: '東京都 小笠原村',
+        title: '船でしか行けない島のポケふた',
+        place: '東京都 小笠原村 ／ リザードン',
+        footerText: '東京のポケふたをもっと見る', footerCta: '地図で見る →',
+        href: BASE_PATH + 'map.html?manhole=154',
+        small: [
+          { id: 159, imgAlt: '京都府京都市のホウオウのポケふた', badge: '⭐ ここだけ', bg: 'linear-gradient(140deg,#E8C070,#C09040)', title: 'ホウオウ', place: '京都府 京都市 →', href: BASE_PATH + 'map.html?manhole=159' },
+          { id: 54, imgAlt: '宮城県仙台市のジラーチ・ラプラスのポケふた', badge: '⭐ ここだけ', bg: 'linear-gradient(140deg,#B0C8E0,#7898C0)', title: 'ジラーチ・ラプラス', place: '宮城県 仙台市 →', href: BASE_PATH + 'map.html?manhole=54' }
+        ]
+      },
+      {
+        id: 346, imgAlt: '和歌山県那智勝浦町のセレビィのポケふた',
+        bgStyle: 'linear-gradient(140deg,#4AA880,#2A7860)',
+        badge: '⭐ 全国でここだけ', mediaLabel: '和歌山県 那智勝浦町',
+        title: '熊野の森にひそむ幻のポケふた',
+        place: '和歌山県 那智勝浦町 ／ セレビィ',
+        footerText: '和歌山のポケふたをもっと見る', footerCta: '地図で見る →',
+        href: BASE_PATH + 'map.html?manhole=346',
+        small: [
+          { id: 343, imgAlt: '和歌山県高野町のウーラオスのポケふた', badge: '⭐ ここだけ', bg: 'linear-gradient(140deg,#A8C0A0,#6E8C68)', title: 'ウーラオス', place: '和歌山県 高野町 →', href: BASE_PATH + 'map.html?manhole=343' },
+          { id: 9, imgAlt: '鹿児島県指宿市のニンフィアのポケふた', badge: '🌟 全国2枚', bg: 'linear-gradient(140deg,#F0C0D0,#C890A8)', title: 'ニンフィア', place: '鹿児島県 指宿市 →', href: BASE_PATH + 'map.html?manhole=9' }
+        ]
       }
     ];
 


### PR DESCRIPTION
## 概要

トップの「今日、どのポケふたに会いに行く？」のフォールバック用キュレーション `HEROES` を **4セット → 7セット** に増やします。

`dayIndex = Math.floor(Date.now() / 86400000) % HEROES.length` なので、4セットだと4日周期で一巡していました。7にすることで**曜日と対応した週次ローテーション**になります（表示自体は毎日変わるため「毎日更新」ラベルとも整合）。

なお本番では top-feed.json のコミュニティ投稿写真が読み込まれるとヒーローは上書きされるため、このセットは**投稿が無い/読み込めないときのフォールバック**です。

## 追加した3セット

いずれも `pokefuta.ndjson` の `titles` で priority が高い希少称号を持つ蓋から選定し、`dataset/manhole/image/` にミラーがあることを確認済みです。

| セット | featured | small 1 | small 2 |
|---|---|---|---|
| 🧭 日本最北 | #67 稚内（日本最北のポケふた / priority 100） | #156 小笠原ミュウ（離島 / 95） | #411 つくばレックウザ（全国2枚 / 70） |
| 🏝 離島×世界遺産 | #154 小笠原リザードン（離島 / 95） | #159 京都ホウオウ（ここだけ / 90） | #54 仙台ジラーチ・ラプラス（ここだけ / 90） |
| ⭐ 全国でここだけ | #346 那智勝浦セレビィ（ここだけ / 90） | #343 高野ウーラオス（ここだけ / 90） | #9 指宿ニンフィア（全国2枚 / 70） |

文言・`bgStyle` は既存セットの書式とグラデーションパレットに合わせています。

## i18n について

`HEROES` の文言は**全言語で日本語直書き**という既存の状態をそのまま踏襲しています（新規の i18n ギャップを作ってはいません）。`index.template.html` 側は既存セットと同様に `href` のみ `BASE_PATH +` 付きです。

## 検証

- `index.html` / `index.template.html` ともに **7セット**、`BASE_PATH` の有無以外は HEROES 配列が**完全一致**することを diff で確認
- `node --check` で両ファイルのインライン JS 構文 OK
- `python3 tools/build_i18n.py`: WARN 0
- HEROES が参照する全21枚の画像ミラーが `dataset/manhole/image/` に存在することを確認
- **7セット全部をブラウザで実表示確認**（dayIndex を 0〜6 に固定し top-feed の上書きだけを止めた検証ページで、ヘッドレス Edge にてスクリーンショット取得）。画像・バッジ・タイトル・小カード2枚がすべて正しく描画されることを目視

🤖 Generated with [Claude Code](https://claude.com/claude-code)
