### PR TITLE
Link all photo contributors to public stamp books

### DIFF
--- a/apps/scraper/generate_manhole_pages.py
+++ b/apps/scraper/generate_manhole_pages.py
@@ -26,6 +26,7 @@ from photo_caption import (  # noqa: E402
     CAPTION_ELLIPSIS_CSS,
     format_display_name,
     format_photo_date,
+    poster_profile_url,
 )
 
 try:
@@ -490,21 +491,6 @@ def _attr_json(data: dict) -> str:
     a proper object literal.
     """
     return escape(json.dumps(data, ensure_ascii=False), {'"': '&quot;'})
-
-
-# apps/web/index.html の PUBLIC_USER_ID_RE と同じガード。
-# UUID 形式でない値は snapshot の異常データとみなしリンク化しない。
-PUBLIC_USER_ID_RE = re.compile(
-    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.I
-)
-
-
-def poster_profile_url(public_user_id) -> str:
-    """有効な公開ユーザーIDなら pokefuta.com の公開スタンプ帳URLを、無効なら空文字を返す。"""
-    pid = str(public_user_id or "").strip()
-    if not PUBLIC_USER_ID_RE.match(pid):
-        return ""
-    return f"https://pokefuta.com/users/{quote(pid)}/visits"
 
 
 def _js_json(value) -> str:

--- a/apps/scraper/generate_pokemon_index_page.py
+++ b/apps/scraper/generate_pokemon_index_page.py
@@ -34,6 +34,7 @@ from photo_caption import (  # noqa: E402
     caption_meta,
     format_display_name,
     format_photo_date,
+    poster_profile_url,
 )
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")
@@ -711,6 +712,7 @@ def _build_latest_photo_cards(
             # 「7月16日 / Jul 16」のロケール表記に統一（トップページと同じ見せ方）
             "date": format_photo_date(photo.get("created_at"), lang),
             "poster": format_display_name(photo.get("display_name")),
+            "poster_profile_url": poster_profile_url(photo.get("public_user_id")),
         })
         seen_ids.add(mid)
         if len(cards) >= limit:
@@ -968,17 +970,32 @@ def generate_html(
         for fact in fact_cards
     )
 
-    latest_photos_html = "".join(
-        f'<a class="photo-card" href="{escape(photo["href"])}">'
-        f'<img src="{escape(photo["image_url"])}" '
-        f'alt="{escape(photo["title"])} {escape(photo["location"])}" '
-        f'loading="lazy" decoding="async" width="480" height="360">'
-        f'<span class="photo-card-copy"><strong>{escape(photo["title"])}</strong>'
-        # 「場所 · 投稿者 · 7月16日」に統一（summary / トップページと同じ見せ方）
-        f'<small>{caption_meta(escape(photo["location"]), escape(photo["poster"]), escape(enhancement["photo_date"].format(date=photo["date"])) if photo["date"] else "")}'
-        f'</small></span></a>'
-        for photo in latest_photos
-    )
+    latest_photo_cards = []
+    for photo in latest_photos:
+        poster_html = escape(photo["poster"])
+        if photo["poster"] and photo["poster_profile_url"]:
+            poster_html = (
+                f'<a class="poster-link" href="{escape(photo["poster_profile_url"])}" '
+                f'target="_blank" rel="noopener noreferrer" '
+                f'aria-label="{escape(photo["poster"])}さんの公開スタンプ帳を開く">'
+                f'{escape(photo["poster"])}</a>'
+            )
+        meta = caption_meta(
+            escape(photo["location"]),
+            poster_html,
+            escape(enhancement["photo_date"].format(date=photo["date"]))
+            if photo["date"] else "",
+        )
+        latest_photo_cards.append(
+            f'<article class="photo-card">'
+            f'<a class="photo-card-main" href="{escape(photo["href"])}">'
+            f'<img src="{escape(photo["image_url"])}" '
+            f'alt="{escape(photo["title"])} {escape(photo["location"])}" '
+            f'loading="lazy" decoding="async" width="480" height="360">'
+            f'<span class="photo-card-copy"><strong>{escape(photo["title"])}</strong></span>'
+            f'</a><small class="photo-card-meta">{meta}</small></article>'
+        )
+    latest_photos_html = "".join(latest_photo_cards)
     latest_section_html = ""
     if latest_photos_html:
         latest_section_html = (
@@ -1241,13 +1258,14 @@ def generate_html(
       border-radius: 14px;
       background: #fffaf0;
       color: #332f2a;
-      text-decoration: none;
     }}
+    .photo-card-main {{ display: block; color: inherit; text-decoration: none; }}
     .photo-card img {{ display: block; width: 100%; aspect-ratio: 4 / 3; object-fit: cover; }}
-    .photo-card-copy {{ display: flex; flex-direction: column; padding: 9px 10px 10px; }}
+    .photo-card-copy {{ display: flex; flex-direction: column; padding: 9px 10px 4px; }}
     .photo-card-copy strong {{ font-size: 14px; }}
     /* 長い投稿者名でもカード幅を崩さない（トップページのヒーローと同じ手法） */
-    .photo-card-copy small {{ color: #756c61; {CAPTION_ELLIPSIS_CSS} }}
+    .photo-card-meta {{ display: block; padding: 0 10px 10px; color: #756c61; {CAPTION_ELLIPSIS_CSS} }}
+    .photo-card-meta .poster-link {{ color: #176f68; font-weight: 800; text-decoration: underline; text-underline-offset: 2px; }}
     .faq-list {{ display: grid; gap: 8px; }}
     .faq-list details {{ border: 1px solid #ded3bd; border-radius: 12px; background: #fffaf0; padding: 12px 14px; }}
     .faq-list summary {{ cursor: pointer; font-weight: 800; color: #332f2a; }}

--- a/apps/scraper/generate_pokemon_index_page.py
+++ b/apps/scraper/generate_pokemon_index_page.py
@@ -976,8 +976,7 @@ def generate_html(
         if photo["poster"] and photo["poster_profile_url"]:
             poster_html = (
                 f'<a class="poster-link" href="{escape(photo["poster_profile_url"])}" '
-                f'target="_blank" rel="noopener noreferrer" '
-                f'aria-label="{escape(photo["poster"])}さんの公開スタンプ帳を開く">'
+                f'target="_blank" rel="noopener noreferrer">'
                 f'{escape(photo["poster"])}</a>'
             )
         meta = caption_meta(

--- a/apps/scraper/generate_prefecture_pages.py
+++ b/apps/scraper/generate_prefecture_pages.py
@@ -12,6 +12,13 @@ from urllib.parse import quote, urlparse
 from xml.sax.saxutils import escape
 
 try:
+    from apps.scraper.photo_caption import poster_profile_url
+except ModuleNotFoundError as exc:
+    if exc.name != "apps":
+        raise
+    from photo_caption import poster_profile_url
+
+try:
     from apps.scraper.prefectures import (
         PREFECTURES,
         PREFECTURE_ORDER,
@@ -435,7 +442,18 @@ def _photo_section(
         city = str(record.get("city", "") or "所在地不明")
         pokemons = "・".join(_clean_pokemons(record)) or "ポケモン"
         poster = str(photo.get("display_name", "") or "").strip()
-        poster_html = f"<small>{escape(poster)}さんの投稿</small>" if poster else ""
+        profile_url = poster_profile_url(photo.get("public_user_id"))
+        poster_html = ""
+        if poster:
+            if profile_url:
+                poster_html = (
+                    f'<small class="photo-card-poster"><a href="{_escape_attr(profile_url)}" '
+                    f'target="_blank" rel="noopener noreferrer" '
+                    f'aria-label="{_escape_attr(poster)}さんの公開スタンプ帳を開く">'
+                    f'{escape(poster)}さんの投稿</a></small>'
+                )
+            else:
+                poster_html = f'<small class="photo-card-poster">{escape(poster)}さんの投稿</small>'
         gallery_cards.append(
             f'<article class="photo-card">'
             f'<a class="photo-card-image" href="/manholes/{quote(mid)}/" '
@@ -445,7 +463,7 @@ def _photo_section(
             f'alt="{_escape_attr(prefecture)}{_escape_attr(city)}のポケふた投稿写真" '
             f'loading="lazy" decoding="async" width="640" height="480">'
             f'<span><strong>{escape(city)}</strong><small>{escape(pokemons)}</small>'
-            f'{poster_html}</span></a>'
+            f'</span></a>{poster_html}'
             f'<a class="photo-card-upload" href="{_escape_attr(_upload_url(mid, slug))}" '
             f'data-track="prefecture_photo_upload_start" data-position="{position}" '
             f'data-destination="upload" data-content-id="{_escape_attr(mid)}" '
@@ -957,6 +975,8 @@ def build_page(
     }}
     .photo-card-image > span {{ display: grid; padding: 9px 10px; }}
     .photo-card-image small {{ overflow: hidden; color: #75685c; font-size: .72rem; text-overflow: ellipsis; white-space: nowrap; }}
+    .photo-card-poster {{ display: block; padding: 0 10px 9px; overflow: hidden; color: #75685c; font-size: .72rem; text-overflow: ellipsis; white-space: nowrap; }}
+    .photo-card-poster a {{ color: #176f68; font-weight: 800; text-decoration: underline; text-underline-offset: 2px; }}
     .photo-card-upload {{
       display: grid; place-items: center; min-height: 44px; padding: 6px 9px;
       border-top: 1px solid #ece4d7; color: #176f68; font-size: .75rem;

--- a/apps/scraper/generate_prefecture_pages.py
+++ b/apps/scraper/generate_prefecture_pages.py
@@ -443,6 +443,8 @@ def _photo_section(
         pokemons = "・".join(_clean_pokemons(record)) or "ポケモン"
         poster = str(photo.get("display_name", "") or "").strip()
         profile_url = poster_profile_url(photo.get("public_user_id"))
+        if profile_url:
+            profile_url = f"{profile_url}?{_campaign_params(slug)}"
         poster_html = ""
         if poster:
             if profile_url:

--- a/apps/scraper/generate_summary_pages.py
+++ b/apps/scraper/generate_summary_pages.py
@@ -26,6 +26,7 @@ from photo_caption import (  # noqa: E402
     caption_meta,
     format_display_name,
     format_photo_date,
+    poster_profile_url,
 )
 
 try:
@@ -1006,8 +1007,15 @@ _CSS = """\
       display: flex;
       flex-direction: column;
       gap: 5px;
-      text-decoration: none;
       color: inherit;
+    }
+
+    .photo-card-main {
+      display: flex;
+      flex-direction: column;
+      gap: 5px;
+      color: inherit;
+      text-decoration: none;
     }
 
     .photo-card img {
@@ -1261,6 +1269,14 @@ _CSS = """\
     .summary-hero h1 span {
       display: inline;
       white-space: nowrap;
+    }
+
+    .photo-card-meta .poster-link {
+      color: #176f68;
+      font-weight: 800;
+      text-decoration: underline;
+      text-decoration-thickness: 1px;
+      text-underline-offset: 2px;
     }
 
     .summary-hero .summary-hero-subtitle {
@@ -3522,18 +3538,29 @@ def _build_latest_photos_section(
         # 「場所 · 投稿者 · 7月16日」に統一（トップページのヒーローと同じ見せ方）
         date = format_photo_date(photo.get("created_at"), "ja")
         poster = format_display_name(photo.get("display_name"))
+        profile_url = poster_profile_url(photo.get("public_user_id"))
+        poster_html = escape(poster)
+        if poster and profile_url:
+            poster_html = (
+                f'<a class="poster-link" href="{escape(profile_url)}" '
+                f'target="_blank" rel="noopener noreferrer" '
+                f'aria-label="{escape(poster)}さんの公開スタンプ帳を開く">'
+                f'{escape(poster)}</a>'
+            )
         # caption_meta にはエスケープ済みの部品のみ渡す（date も一貫させる）
-        meta = caption_meta(escape(location), escape(poster), escape(date))
+        meta = caption_meta(escape(location), poster_html, escape(date))
         manhole_href = f"/manholes/{mid}/"
         display_title = pokemons or title
         if not url:
             continue
         cards.append(
-            f'<a class="photo-card" href="{escape(manhole_href)}">'
+            f'<article class="photo-card">'
+            f'<a class="photo-card-main" href="{escape(manhole_href)}">'
             f'<img src="{escape(url)}" alt="{escape(display_title)}" loading="lazy" decoding="async">'
             f'<span class="photo-card-title">{escape(display_title)}</span>'
-            f'<span class="photo-card-meta">{meta}</span>'
             f'</a>'
+            f'<span class="photo-card-meta">{meta}</span>'
+            f'</article>'
         )
 
     if not cards:

--- a/apps/scraper/photo_caption.py
+++ b/apps/scraper/photo_caption.py
@@ -13,11 +13,17 @@
 
 from __future__ import annotations
 
+import re
 from datetime import date, datetime
+from urllib.parse import quote
 from zoneinfo import ZoneInfo
 
 JST = ZoneInfo("Asia/Tokyo")
 DISPLAY_NAME_MAX_LEN = 20
+PUBLIC_USER_ID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.I,
+)
 
 # Intl 依存の locale 揺れを避け、決定的に整形するための固定月名（en 用）
 _EN_MONTHS = (
@@ -89,6 +95,14 @@ def format_display_name(name: object, max_len: int = DISPLAY_NAME_MAX_LEN) -> st
     if len(collapsed) > max_len:
         return collapsed[: max_len - 1].rstrip() + "…"
     return collapsed
+
+
+def poster_profile_url(public_user_id: object) -> str:
+    """有効な公開ユーザーIDを公開スタンプ帳URLへ変換する。"""
+    pid = str(public_user_id or "").strip()
+    if not PUBLIC_USER_ID_RE.fullmatch(pid):
+        return ""
+    return f"https://pokefuta.com/users/{quote(pid)}/visits"
 
 
 def caption_meta(*parts: object, sep: str = " · ") -> str:

--- a/apps/scraper/test_generate_manhole_pages_poster_links.py
+++ b/apps/scraper/test_generate_manhole_pages_poster_links.py
@@ -102,7 +102,7 @@ class GalleryCreditLinkTests(unittest.TestCase):
         ]
         html = _generate(_photo(gallery_local=gallery_local))
         self.assertIn(f"<a class='gallery-credit poster-link' href='{PROFILE_URL}'", html)
-        self.assertIn("📷 たこ</a>", html)
+        self.assertIn("📷 たこ · 5月1日</a>", html)
         self.assertIn("&quot;source&quot;: &quot;gallery&quot;", html)
 
     def test_gallery_credit_plain_text_without_public_user_id(self):
@@ -114,7 +114,7 @@ class GalleryCreditLinkTests(unittest.TestCase):
             },
         ]
         html = _generate(_photo(gallery_local=gallery_local))
-        self.assertIn("<span class='gallery-credit'>📷 たこ</span>", html)
+        self.assertIn("<span class='gallery-credit'>📷 たこ · 5月1日</span>", html)
         self.assertNotIn("gallery-credit poster-link", html)
 
 

--- a/apps/scraper/test_generate_pokemon_index_page.py
+++ b/apps/scraper/test_generate_pokemon_index_page.py
@@ -82,6 +82,7 @@ class LatestPhotoCardsTest(unittest.TestCase):
             html,
         )
         self.assertIn('class="poster-link"', html)
+        self.assertNotIn("さんの公開スタンプ帳を開く", html)
 
     def test_pokemon_index_does_not_render_hero_summary_panel(self):
         pokemon_index = {

--- a/apps/scraper/test_generate_pokemon_index_page.py
+++ b/apps/scraper/test_generate_pokemon_index_page.py
@@ -37,6 +37,7 @@ class LatestPhotoCardsTest(unittest.TestCase):
                     "url": "https://example.com/slowpoke.jpg",
                     "created_at": "2026-06-13T00:00:00Z",
                     "display_name": "とても長い名前の投稿者さんイーブイ推し団長",
+                    "public_user_id": "6096691c-eeda-4e73-8401-a11274868ede",
                 },
             },
         }
@@ -59,6 +60,28 @@ class LatestPhotoCardsTest(unittest.TestCase):
         # 日付はロケール表記（UTC 00:00 → JST 同日）、投稿者名は 20 文字で省略
         self.assertEqual(cards[0]["date"], "Jun 13")
         self.assertEqual(cards[0]["poster"], "とても長い名前の投稿者さんイーブイ推し…")
+        self.assertEqual(
+            cards[0]["poster_profile_url"],
+            "https://pokefuta.com/users/6096691c-eeda-4e73-8401-a11274868ede/visits",
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            html = generate_html(
+                pokemon_index,
+                "en",
+                LANG_CONFIGS["en"],
+                LP_INDEX_STRINGS["en"],
+                lambda pref: "Kagawa",
+                photos_data,
+                Path(tmpdir),
+            )
+        self.assertIn('<article class="photo-card">', html)
+        self.assertIn(
+            'href="https://pokefuta.com/users/'
+            '6096691c-eeda-4e73-8401-a11274868ede/visits"',
+            html,
+        )
+        self.assertIn('class="poster-link"', html)
 
     def test_pokemon_index_does_not_render_hero_summary_panel(self):
         pokemon_index = {

--- a/apps/scraper/test_generate_prefecture_pages.py
+++ b/apps/scraper/test_generate_prefecture_pages.py
@@ -232,6 +232,7 @@ class GeneratePrefecturePagesTest(unittest.TestCase):
                 "url": "https://images.pokefuta.com/photos/9001.jpg",
                 "created_at": "2026-07-20T00:00:00Z",
                 "display_name": "旅人",
+                "public_user_id": "6096691c-eeda-4e73-8401-a11274868ede",
             }
         }
         with tempfile.TemporaryDirectory() as directory:
@@ -248,6 +249,12 @@ class GeneratePrefecturePagesTest(unittest.TestCase):
         self.assertIn('aria-valuenow="50"', html)
         self.assertIn('loading="lazy" decoding="async" width="640" height="480"', html)
         self.assertIn("旅人さんの投稿", html)
+        self.assertIn(
+            'href="https://pokefuta.com/users/'
+            '6096691c-eeda-4e73-8401-a11274868ede/visits"',
+            html,
+        )
+        self.assertIn('class="photo-card-poster"', html)
         self.assertIn("写真未掲載のポケふたは1地点", html)
         self.assertIn("最初の写真を投稿", html)
         self.assertIn("manhole_id=9002&amp;from=data", html)

--- a/apps/scraper/test_generate_prefecture_pages.py
+++ b/apps/scraper/test_generate_prefecture_pages.py
@@ -251,7 +251,9 @@ class GeneratePrefecturePagesTest(unittest.TestCase):
         self.assertIn("旅人さんの投稿", html)
         self.assertIn(
             'href="https://pokefuta.com/users/'
-            '6096691c-eeda-4e73-8401-a11274868ede/visits"',
+            '6096691c-eeda-4e73-8401-a11274868ede/visits?from=data&amp;'
+            'utm_source=data.pokefuta.com&amp;utm_medium=referral&amp;'
+            'utm_campaign=prefecture_page&amp;utm_content=hokkaido"',
             html,
         )
         self.assertIn('class="photo-card-poster"', html)

--- a/apps/scraper/test_generate_summary_pages.py
+++ b/apps/scraper/test_generate_summary_pages.py
@@ -37,11 +37,17 @@ class LatestPhotosSectionTests(unittest.TestCase):
             "url": "https://example.com/220.jpeg",
             "created_at": "2026-07-15T15:30:00+00:00",  # JST では 7/16
             "display_name": "テスト太郎",
+            "public_user_id": "6096691c-eeda-4e73-8401-a11274868ede",
         })
         self.assertIn(
-            '<span class="photo-card-meta">北海道斜里町 · テスト太郎 · 7月16日</span>',
+            '<span class="photo-card-meta">北海道斜里町 · '
+            '<a class="poster-link" href="https://pokefuta.com/users/'
+            '6096691c-eeda-4e73-8401-a11274868ede/visits"',
             html,
         )
+        self.assertIn('>テスト太郎</a> · 7月16日</span>', html)
+        self.assertIn('<article class="photo-card">', html)
+        self.assertIn('<a class="photo-card-main" href="/manholes/220/">', html)
 
     def test_meta_without_poster_keeps_location_and_date(self):
         html = self._build({

--- a/apps/scraper/test_photo_caption.py
+++ b/apps/scraper/test_photo_caption.py
@@ -91,6 +91,21 @@ class FormatDisplayNameTests(unittest.TestCase):
         self.assertEqual(pc.format_display_name(123), "")
 
 
+class PosterProfileUrlTests(unittest.TestCase):
+    VALID_UUID = "6096691c-eeda-4e73-8401-a11274868ede"
+
+    def test_valid_uuid_maps_to_public_stamp_book(self):
+        self.assertEqual(
+            pc.poster_profile_url(self.VALID_UUID),
+            f"https://pokefuta.com/users/{self.VALID_UUID}/visits",
+        )
+
+    def test_invalid_values_are_not_linked(self):
+        for value in (None, "", "not-a-uuid", "../evil", 123):
+            with self.subTest(value=value):
+                self.assertEqual(pc.poster_profile_url(value), "")
+
+
 class CaptionMetaTests(unittest.TestCase):
     def test_joins_with_middle_dot(self):
         self.assertEqual(

--- a/apps/scraper/test_web_prefecture_links.py
+++ b/apps/scraper/test_web_prefecture_links.py
@@ -26,6 +26,18 @@ class WebPrefectureLinksTest(unittest.TestCase):
         self.assertIn("%%BASE_PATH%%prefectures/${encodeURIComponent(slug)}/", source)
         self.assertIn("anchor.textContent = UI_TEXT.prefectureSite;", source)
 
+    def test_map_photo_authors_link_to_public_stamp_books(self) -> None:
+        for filename in ("map.html", "map.template.html"):
+            with self.subTest(filename=filename):
+                source = (ROOT / "apps/web" / filename).read_text(encoding="utf-8")
+                self.assertIn("function getPosterProfileUrl(publicUserId)", source)
+                self.assertIn("photoMeta?.public_user_id", source)
+                self.assertIn(
+                    "https://pokefuta.com/users/${encodeURIComponent(id)}/visits",
+                    source,
+                )
+                self.assertIn('<a class="travel-popup-photo-author"', source)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/apps/scraper/test_web_prefecture_links.py
+++ b/apps/scraper/test_web_prefecture_links.py
@@ -37,6 +37,10 @@ class WebPrefectureLinksTest(unittest.TestCase):
                     source,
                 )
                 self.assertIn('<a class="travel-popup-photo-author"', source)
+                self.assertNotIn(
+                    'aria-label="${escapeHtml(displayName)}さんの公開スタンプ帳を開く"',
+                    source,
+                )
 
 
 if __name__ == "__main__":

--- a/apps/web/assets/pokefuta-map.css
+++ b/apps/web/assets/pokefuta-map.css
@@ -1123,6 +1123,14 @@ body.pokefuta-map-page {
 .pokefuta-map-page .travel-popup-photo-author {
   background: rgba(36, 31, 26, .82);
   color: #fffaf0;
+  text-decoration: none;
+}
+
+.pokefuta-map-page a.travel-popup-photo-author:hover,
+.pokefuta-map-page a.travel-popup-photo-author:focus-visible {
+  background: #176f68;
+  outline: 2px solid #fffaf0;
+  outline-offset: 2px;
 }
 
 .pokefuta-map-page .travel-popup-body {

--- a/apps/web/map.html
+++ b/apps/web/map.html
@@ -1141,7 +1141,7 @@
       const photoMetaItems = [
         photoDate ? `<span class="travel-popup-photo-date">撮影日 ${escapeHtml(photoDate)}</span>` : '',
         displayName ? (posterProfileUrl
-          ? `<a class="travel-popup-photo-author" href="${escapeHtml(posterProfileUrl)}" target="_blank" rel="noopener noreferrer" aria-label="${escapeHtml(displayName)}さんの公開スタンプ帳を開く">${escapeHtml(displayName)}</a>`
+          ? `<a class="travel-popup-photo-author" href="${escapeHtml(posterProfileUrl)}" target="_blank" rel="noopener noreferrer">${escapeHtml(displayName)}</a>`
           : `<span class="travel-popup-photo-author">${escapeHtml(displayName)}</span>`)
           : ''
       ].filter(Boolean).join('');

--- a/apps/web/map.html
+++ b/apps/web/map.html
@@ -860,6 +860,14 @@
       return meta || null;
     }
 
+    function getPosterProfileUrl(publicUserId) {
+      const id = String(publicUserId || '').trim();
+      const validId = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+      return validId.test(id)
+        ? `https://pokefuta.com/users/${encodeURIComponent(id)}/visits`
+        : '';
+    }
+
     function getPhotoTakenDate(id) {
       const meta = getLatestPhotoMeta(id);
       return formatPhotoDate(meta?.shot_at || meta?.created_at);
@@ -1129,9 +1137,13 @@
       const hasPhoto = Boolean(photoMeta?.url || photoMeta?.original_url || photoMeta?.storage_key);
       const photoDate = getPhotoTakenDate(d.id);
       const displayName = String(photoMeta?.display_name || '').trim();
+      const posterProfileUrl = getPosterProfileUrl(photoMeta?.public_user_id);
       const photoMetaItems = [
         photoDate ? `<span class="travel-popup-photo-date">撮影日 ${escapeHtml(photoDate)}</span>` : '',
-        displayName ? `<span class="travel-popup-photo-author">${escapeHtml(displayName)}</span>` : ''
+        displayName ? (posterProfileUrl
+          ? `<a class="travel-popup-photo-author" href="${escapeHtml(posterProfileUrl)}" target="_blank" rel="noopener noreferrer" aria-label="${escapeHtml(displayName)}さんの公開スタンプ帳を開く">${escapeHtml(displayName)}</a>`
+          : `<span class="travel-popup-photo-author">${escapeHtml(displayName)}</span>`)
+          : ''
       ].filter(Boolean).join('');
       const titles = Array.isArray(d.titles) ? d.titles : [];
       const isPreinstall = d.installed === false;

--- a/apps/web/map.template.html
+++ b/apps/web/map.template.html
@@ -1101,7 +1101,7 @@
       const photoMetaItems = [
         photoDate ? `<span class="travel-popup-photo-date">${I.photoDatePrefix}${escapeHtml(photoDate)}</span>` : '',
         displayName ? (posterProfileUrl
-          ? `<a class="travel-popup-photo-author" href="${escapeHtml(posterProfileUrl)}" target="_blank" rel="noopener noreferrer" aria-label="${escapeHtml(displayName)}さんの公開スタンプ帳を開く">${escapeHtml(displayName)}</a>`
+          ? `<a class="travel-popup-photo-author" href="${escapeHtml(posterProfileUrl)}" target="_blank" rel="noopener noreferrer">${escapeHtml(displayName)}</a>`
           : `<span class="travel-popup-photo-author">${escapeHtml(displayName)}</span>`)
           : ''
       ].filter(Boolean).join('');

--- a/apps/web/map.template.html
+++ b/apps/web/map.template.html
@@ -818,6 +818,14 @@
       return meta || null;
     }
 
+    function getPosterProfileUrl(publicUserId) {
+      const id = String(publicUserId || '').trim();
+      const validId = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+      return validId.test(id)
+        ? `https://pokefuta.com/users/${encodeURIComponent(id)}/visits`
+        : '';
+    }
+
     function getPhotoTakenDate(id) {
       const meta = getLatestPhotoMeta(id);
       return formatPhotoDate(meta?.shot_at || meta?.created_at);
@@ -1089,9 +1097,13 @@
       const hasPhoto = Boolean(photoMeta?.url || photoMeta?.original_url || photoMeta?.storage_key);
       const photoDate = getPhotoTakenDate(d.id);
       const displayName = String(photoMeta?.display_name || '').trim();
+      const posterProfileUrl = getPosterProfileUrl(photoMeta?.public_user_id);
       const photoMetaItems = [
         photoDate ? `<span class="travel-popup-photo-date">${I.photoDatePrefix}${escapeHtml(photoDate)}</span>` : '',
-        displayName ? `<span class="travel-popup-photo-author">${escapeHtml(displayName)}</span>` : ''
+        displayName ? (posterProfileUrl
+          ? `<a class="travel-popup-photo-author" href="${escapeHtml(posterProfileUrl)}" target="_blank" rel="noopener noreferrer" aria-label="${escapeHtml(displayName)}さんの公開スタンプ帳を開く">${escapeHtml(displayName)}</a>`
+          : `<span class="travel-popup-photo-author">${escapeHtml(displayName)}</span>`)
+          : ''
       ].filter(Boolean).join('');
       const titles = Array.isArray(d.titles) ? d.titles : [];
       const isPreinstall = d.installed === false;


### PR DESCRIPTION
## Summary
- Link photo contributor display names from map popups, prefecture galleries, the summary page, and the Pokemon index.
- Reuse one UUID-validated public stamp-book URL helper across generated pages.
- Keep manhole cards valid by separating contributor links from detail-page links.

## Verification
- 60 focused unit tests passed.
- Generated summary, Pokemon index, and all 47 prefecture pages successfully.
- Verified 6 summary links, 6 Pokemon-index links, and 101 prefecture-page links in generated HTML.
- Verified all 585 display-name records have valid public_user_id values.
- Loginless browser smoke check: 6 contributor links, 0 nested anchors, and no horizontal overflow on the local summary page.

## Route note
- The live public page is /users/{public_user_id}/visits; /users/{public_user_id} currently returns 404.