### PR TITLE
fix: キャラマンホール収集の再生成を冪等にする

### DIFF
--- a/apps/scraper/collect_character_manholes.py
+++ b/apps/scraper/collect_character_manholes.py
@@ -418,6 +418,74 @@ def collect_work(spec: Dict[str, Any], muni: Dict[str, Dict[str, str]], no_geoco
     return records
 
 
+# 再生成のたびに書き換わってよいのはこの2つだけ。差分判定からは除外する。
+TIMESTAMP_FIELDS = ("first_seen", "last_updated")
+
+# 逆ジオコード由来のフィールド。--no-geocode やGSIの一時失敗で空になりうるため、
+# 空で返ってきたときは前回値を残す (空で上書きするとdocs側のaddressが消える)。
+GEOCODED_FIELDS = ("prefecture", "city", "address")
+
+
+def load_existing_records(path: str) -> Dict[str, Dict[str, Any]]:
+    """前回出力を id -> レコード で読む。初回生成時は空を返す。"""
+    if not os.path.exists(path):
+        return {}
+    existing: Dict[str, Dict[str, Any]] = {}
+    with open(path, encoding="utf-8") as f:
+        for line_number, line in enumerate(f, start=1):
+            if not line.strip():
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError as e:
+                raise ValueError(f"{path}:{line_number}: invalid JSON: {e}") from e
+            existing[record["id"]] = record
+    return existing
+
+
+def merge_with_existing(
+    records: List[Dict[str, Any]],
+    existing: Dict[str, Dict[str, Any]],
+    no_geocode: bool = False,
+) -> List[Dict[str, Any]]:
+    """前回出力を踏まえてタイムスタンプと欠損フィールドを解決する。
+
+    これが無いと再生成のたびに全レコードが差分になり、本当に変わった行が
+    埋もれる。中身が変わっていない再実行は差分ゼロになるのが正しい。
+
+    no_geocode 実行では GEOCODED_FIELDS を一切信用せず前回値を優先する。
+    逆ジオを省くと空になるだけでなく、より悪い値が入るため:
+      - collect_static は住所をランドマーク連結で捏造する
+        ('静岡市 葵区追手町' -> '静岡市葵区静岡市歴史博物館')
+      - KML の city_hint は誤っていることがある (佐賀の '鹿島市' -> '鹿嶋市')
+    """
+    merged: List[Dict[str, Any]] = []
+    for rec in records:
+        prev = existing.get(rec["id"])
+        if prev is None:
+            merged.append(rec)
+            continue
+
+        for key in GEOCODED_FIELDS:
+            if no_geocode and prev.get(key):
+                rec[key] = prev[key]
+            elif not rec.get(key) and prev.get(key):
+                rec[key] = prev[key]
+
+        # 初回検出時刻は維持する
+        if prev.get("first_seen"):
+            rec["first_seen"] = prev["first_seen"]
+
+        unchanged = {k: v for k, v in rec.items() if k not in TIMESTAMP_FIELDS} == {
+            k: v for k, v in prev.items() if k not in TIMESTAMP_FIELDS
+        }
+        if unchanged and prev.get("last_updated"):
+            rec["last_updated"] = prev["last_updated"]
+
+        merged.append(rec)
+    return merged
+
+
 def atomic_write_ndjson(path: str, records: List[Dict[str, Any]]) -> None:
     d = os.path.dirname(os.path.abspath(path)) or "."
     os.makedirs(d, exist_ok=True)
@@ -451,6 +519,9 @@ def main() -> None:
         all_records.extend(collect_work(spec, muni, args.no_geocode))
     for record in all_records:
         apply_marker_style(record)
+    all_records = merge_with_existing(
+        all_records, load_existing_records(args.out), args.no_geocode
+    )
 
     atomic_write_ndjson(args.out, all_records)
     print(f"Wrote {len(all_records)} records to {args.out}", file=sys.stderr)

--- a/apps/scraper/test_collect_character_manholes.py
+++ b/apps/scraper/test_collect_character_manholes.py
@@ -59,6 +59,101 @@ class CharacterManholeCollectorTests(unittest.TestCase):
         self.assertTrue(all(record.get("marker_label") for record in records))
         self.assertTrue(all(record.get("marker_color") for record in records))
 
+    def test_first_seen_survives_regeneration(self):
+        """再生成で first_seen が書き換わると全レコードが差分になる。"""
+        existing = {"zls-1": {"id": "zls-1", "address": "佐賀県佐賀市唐人二丁目",
+                              "first_seen": "2026-07-05T06:05:21Z",
+                              "last_updated": "2026-07-05T06:05:21Z"}}
+        fresh = [{"id": "zls-1", "address": "佐賀県佐賀市唐人二丁目",
+                  "first_seen": "2026-07-20T00:00:00Z",
+                  "last_updated": "2026-07-20T00:00:00Z"}]
+
+        merged = collector.merge_with_existing(fresh, existing)
+
+        self.assertEqual(merged[0]["first_seen"], "2026-07-05T06:05:21Z")
+
+    def test_unchanged_record_keeps_last_updated(self):
+        """中身が変わっていない再実行は差分ゼロであるべき。"""
+        existing = {"zls-1": {"id": "zls-1", "city": "佐賀市",
+                              "first_seen": "2026-07-05T06:05:21Z",
+                              "last_updated": "2026-07-05T06:05:21Z"}}
+        fresh = [{"id": "zls-1", "city": "佐賀市",
+                  "first_seen": "2026-07-20T00:00:00Z",
+                  "last_updated": "2026-07-20T00:00:00Z"}]
+
+        merged = collector.merge_with_existing(fresh, existing)
+
+        self.assertEqual(merged[0], existing["zls-1"])
+
+    def test_changed_record_bumps_last_updated(self):
+        existing = {"zls-1": {"id": "zls-1", "city": "佐賀市",
+                              "first_seen": "2026-07-05T06:05:21Z",
+                              "last_updated": "2026-07-05T06:05:21Z"}}
+        fresh = [{"id": "zls-1", "city": "鹿嶋市",
+                  "first_seen": "2026-07-20T00:00:00Z",
+                  "last_updated": "2026-07-20T00:00:00Z"}]
+
+        merged = collector.merge_with_existing(fresh, existing)
+
+        self.assertEqual(merged[0]["city"], "鹿嶋市")
+        self.assertEqual(merged[0]["last_updated"], "2026-07-20T00:00:00Z")
+        self.assertEqual(merged[0]["first_seen"], "2026-07-05T06:05:21Z")
+
+    def test_no_geocode_does_not_blank_existing_address(self):
+        """--no-geocode 時に address が空で返っても既存値を消さない。"""
+        existing = {"zls-1": {"id": "zls-1", "prefecture": "佐賀県", "city": "佐賀市",
+                              "address": "佐賀県佐賀市唐人二丁目",
+                              "first_seen": "2026-07-05T06:05:21Z",
+                              "last_updated": "2026-07-05T06:05:21Z"}}
+        fresh = [{"id": "zls-1", "prefecture": "佐賀県", "city": "", "address": "",
+                  "first_seen": "2026-07-20T00:00:00Z",
+                  "last_updated": "2026-07-20T00:00:00Z"}]
+
+        merged = collector.merge_with_existing(fresh, existing)
+
+        self.assertEqual(merged[0]["address"], "佐賀県佐賀市唐人二丁目")
+        self.assertEqual(merged[0]["city"], "佐賀市")
+        self.assertEqual(merged[0]["last_updated"], "2026-07-05T06:05:21Z")
+
+    def test_no_geocode_does_not_overwrite_with_worse_values(self):
+        """逆ジオ無しの住所/市区町村は捏造・誤りを含むので既存値を優先する。"""
+        existing = {"chibimaruko-1": {"id": "chibimaruko-1", "city": "静岡市葵区",
+                                      "address": "静岡県静岡市　葵区追手町",
+                                      "first_seen": "2026-07-05T06:06:18Z",
+                                      "last_updated": "2026-07-05T06:06:18Z"}}
+        fresh = [{"id": "chibimaruko-1", "city": "静岡市葵区",
+                  "address": "静岡県静岡市葵区静岡市歴史博物館",
+                  "first_seen": "2026-07-20T00:00:00Z",
+                  "last_updated": "2026-07-20T00:00:00Z"}]
+
+        merged = collector.merge_with_existing(fresh, existing, no_geocode=True)
+
+        self.assertEqual(merged[0], existing["chibimaruko-1"])
+
+    def test_geocoded_run_may_update_address(self):
+        """逆ジオを実行した回は住所の更新を通す (no_geocode との非対称性)。"""
+        existing = {"zls-1": {"id": "zls-1", "address": "佐賀県佐賀市唐人二丁目",
+                              "first_seen": "2026-07-05T06:05:21Z",
+                              "last_updated": "2026-07-05T06:05:21Z"}}
+        fresh = [{"id": "zls-1", "address": "佐賀県佐賀市唐人一丁目",
+                  "first_seen": "2026-07-20T00:00:00Z",
+                  "last_updated": "2026-07-20T00:00:00Z"}]
+
+        merged = collector.merge_with_existing(fresh, existing, no_geocode=False)
+
+        self.assertEqual(merged[0]["address"], "佐賀県佐賀市唐人一丁目")
+        self.assertEqual(merged[0]["last_updated"], "2026-07-20T00:00:00Z")
+
+    def test_new_record_is_passed_through(self):
+        merged = collector.merge_with_existing(
+            [{"id": "imas-20th-machida-loco", "address": "東京都町田市原町田6丁目",
+              "first_seen": "2026-07-20T00:00:00Z",
+              "last_updated": "2026-07-20T00:00:00Z"}],
+            {},
+        )
+
+        self.assertEqual(merged[0]["first_seen"], "2026-07-20T00:00:00Z")
+
     def test_public_map_reads_marker_style_from_records(self):
         source = (ROOT / "apps/web/gmanhole_map.html").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## 背景

#363 の作業中に発見した既存バグの修正です。`collect_character_manholes.py` はフル再生成のたびに全レコードを書き換えていました。

実データで確認した被害:

- **`first_seen` を毎回 `now()` で再生成する** — 全123件のタイムスタンプが差分になり、本当に変わった行がレビューで埋もれる
- **`--no-geocode` で回すと KML 由来100件の `address` が空文字で上書きされる**

このコレクタは CLAUDE.md の家系B（レビュー待ち）で人の目が入りますが、100行の差分に紛れると見落としやすく、実際 #363 の作業中に私が一度踏みました。

## さらに見つかったこと

`--no-geocode` は空にするだけでなく、**より悪い値を書き込んでいました**。当初は「空なら前回値を残す」だけの修正にしていたのですが、再生成の差分を確認して気づきました:

| レコード | 逆ジオ有り（正） | `--no-geocode`（誤） |
|---|---|---|
| chibimaruko-1 | 静岡県静岡市　葵区追手町 | 静岡県静岡市葵区**静岡市歴史博物館** |
| zls-11 | 佐賀市 | **鹿嶋市**（茨城県の市名） |

- `collect_static` が住所をランドマーク連結で捏造している
- KML の `city_hint` が誤っている（地図作成者側の表記ゆれ）

どちらも非空なので「空なら残す」では防げませんでした。

## 変更

`merge_with_existing()` を追加し、前回出力とマージしてから書き出すようにしました。

- `first_seen` は初回検出値を維持
- `last_updated` は中身が実際に変わったときだけ更新（no-op 実行が差分ゼロになる）
- 逆ジオ由来フィールド（`prefecture` / `city` / `address`）は、空で返ったとき前回値を残す。`--no-geocode` 実行では上記の理由から**常に**前回値を優先する

`--no-geocode` と通常実行で挙動を非対称にしています。逆ジオを実際に走らせた回は住所の更新を通すので、本来の改善は従来どおり反映されます。

## 検証

- `--no-geocode` でフル再生成 → **差分ゼロ**（以前は100件破壊）
- 逆ジオ有りでフル再生成 → **差分ゼロ**（現行データが正であることの確認にもなっている）
- `python3 -m unittest apps.scraper.test_collect_character_manholes` — 12 tests OK（新規7件）

## 対象外

`collect_static` の住所捏造そのものは直していません。今回の変更で既存レコードを壊せなくなりましたが、**新規レコードには依然として捏造住所が入ります**。別途対応が必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)