### PR TITLE
fix: 静的ソースの代替住所でランドマーク名を連結しない

### DIFF
--- a/apps/scraper/collect_character_manholes.py
+++ b/apps/scraper/collect_character_manholes.py
@@ -321,7 +321,10 @@ def collect_static(spec: Dict[str, Any], muni: Dict[str, Dict[str, str]], no_geo
         lat = float(place["lat"])
         lng = float(place["lng"])
         city = place.get("city", "")
-        address = f"{spec.get('prefecture', '')}{city}{place.get('landmark', '')}"
+        # 逆ジオが使えないときの代替は都道府県+市区町村まで。ランドマーク名を
+        # 連結すると住所でないものが address に入る
+        # ('静岡県静岡市葵区静岡市歴史博物館')。目印は landmark 側に持たせる。
+        address = f"{spec.get('prefecture', '')}{city}"
         if not no_geocode:
             g = gsi_reverse(lat, lng, muni)
             if g["address"]:

--- a/apps/scraper/test_collect_character_manholes.py
+++ b/apps/scraper/test_collect_character_manholes.py
@@ -154,6 +154,24 @@ class CharacterManholeCollectorTests(unittest.TestCase):
 
         self.assertEqual(merged[0]["first_seen"], "2026-07-20T00:00:00Z")
 
+    def test_static_fallback_address_is_not_fabricated(self):
+        """逆ジオ無しの代替住所にランドマーク名を混ぜない。"""
+        records = collector.collect_static(
+            {
+                "work": "テスト作品",
+                "slug": "test",
+                "prefecture": "静岡県",
+                "source_url": "https://example.com/",
+                "places": [{"character": "まる子", "landmark": "静岡市歴史博物館",
+                            "city": "静岡市葵区", "lat": 34.97664, "lng": 138.38500}],
+            },
+            muni={},
+            no_geocode=True,
+        )
+
+        self.assertEqual(records[0]["address"], "静岡県静岡市葵区")
+        self.assertEqual(records[0]["landmark"], "静岡市歴史博物館")
+
     def test_public_map_reads_marker_style_from_records(self):
         source = (ROOT / "apps/web/gmanhole_map.html").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## 背景

#366 の残課題です。あちらで既存レコードは保護しましたが、**新規レコードには捏造住所が入る状態が残っていました**。

`collect_static` は逆ジオコードが使えないとき、`address` を「都道府県 + 市区町村 + ランドマーク」で組み立てています。結果として住所でない文字列が `address` に入ります:

```
静岡県静岡市葵区静岡市歴史博物館   ← 捏造
静岡県静岡市　葵区追手町           ← 逆ジオが返す正しい値
```

施設名を住所欄に連結しているだけで、番地の情報は元々どこにもありません。

## 変更

代替値を**都道府県 + 市区町村まで**に留めました。粗いですが真である住所になります。目印は元から `landmark` フィールドが持っているので、情報は失われません。

```diff
-address = f"{spec.get('prefecture', '')}{city}{place.get('landmark', '')}"
+address = f"{spec.get('prefecture', '')}{city}"
```

逆ジオを実行した回は従来どおり結果で上書きするので、通常運用の出力は変わりません。

## 影響範囲

地図側は `d.address || d.city` のように空・粗い住所を織り込み済みのため、表示への影響はありません。

- `apps/web/gmanhole_map.html:902` — `d.landmark || d.address || ''`
- `apps/web/gmanhole_map.html:919` — `d.address || d.city || ''`

## 検証

- `--no-geocode` でフル再生成 → **既存123件は差分ゼロ**（#366 のマージ保護が効いているため既存の住所は変わらない）
- `python3 -m unittest apps.scraper.test_collect_character_manholes` — 13 tests OK（新規1件）

これで #363 の作業中に見つけた問題は片付きます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)