### PR TITLE
Unify GA4 tracking across generated pages

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -78,6 +78,7 @@ jobs:
           python3 apps/scraper/generate_prefecture_trivia.py --check
           echo "[dist] Test prefecture landing page generation"
           python3 -m unittest \
+            apps.scraper.test_analytics_contract \
             apps.scraper.test_generate_prefecture_pages.PrefecturePageDeployContractTest \
             apps.scraper.test_web_prefecture_links
           echo "[dist] Test character manhole landing page generation"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,8 @@ pokefuta.ndjsonはapps/scraperで更新している
 latest-manhole-photos.json と docs/api/*.json は import-manhole-photos.yml が Supabase から日次一括生成（画像DL込み。pokefuta.com アプリの /api/manholes・/api/site-stats は docs/api を読む。手動で回すときだけ `/import-photos` スキル）
 都道府県ページは `docs/latest-manhole-photos.json` を生成時に読み、写真掲載率・投稿写真・写真募集状態を47都道府県共通テンプレートへ静的に埋め込む
 都道府県ページから pokefuta.com への導線は `from=data` と `utm_source=data.pokefuta.com&utm_medium=referral&utm_campaign=prefecture_page&utm_content=<prefecture slug>` を付ける。GA4の `content_id`・`photo_state`・`surface` はカスタムディメンションとして登録して分析する
+GA4 は `apps/web/assets/analytics.js` から初期化し、`data.pokefuta.com` だけで送信する。各HTMLや生成スクリプトに gtag ローダーを直書きしない
+イベント発生箇所は `surface` で表し、GA4の流入元予約語 `source` をカスタムイベント引数に使わない
 
 ## ディレクトリ構成
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,8 +3,8 @@ dataset/prefecture_events.json は手動更新（都道府県ページに出す�
 pokefuta.ndjsonはapps/scraperで更新している
 latest-manhole-photos.json と docs/api/*.json は import-manhole-photos.yml が Supabase から日次一括生成（画像DL込み。pokefuta.com アプリの /api/manholes・/api/site-stats は docs/api を読む。手動で回すときだけ `/import-photos` スキル）
 都道府県ページは `docs/latest-manhole-photos.json` を生成時に読み、写真掲載率・投稿写真・写真募集状態を47都道府県共通テンプレートへ静的に埋め込む
-都道府県ページから pokefuta.com への導線は `from=data` と `utm_source=data.pokefuta.com&utm_medium=referral&utm_campaign=prefecture_page&utm_content=<prefecture slug>` を付ける。GA4の `content_id`・`photo_state`・`surface` はカスタムディメンションとして登録して分析する
-GA4 は `apps/web/assets/analytics.js` から初期化し、`data.pokefuta.com` だけで送信する。各HTMLや生成スクリプトに gtag ローダーを直書きしない
+都道府県ページから pokefuta.com への導線は `from=data` のみ付ける。同一GA4プロパティ内の内部UTMは使わず、クロスドメインリンカーと着地側の `source_app=tracker` / `p_data_referral` で分析する。GA4の `content_id`・`photo_state`・`surface` はカスタムディメンションとして登録して分析する
+GA4 は `apps/web/assets/analytics.js` から初期化し、`data.pokefuta.com` だけで送信する。各HTMLや生成スクリプトに gtag ローダーや独自の `trackEvent` を直書きしない
 イベント発生箇所は `surface` で表し、GA4の流入元予約語 `source` をカスタムイベント引数に使わない
 
 ## ディレクトリ構成

--- a/apps/scraper/generate_character_manhole_page.py
+++ b/apps/scraper/generate_character_manhole_page.py
@@ -694,16 +694,13 @@ def generate_html(
   <style>{PAGE_STYLE}</style>
   <link rel="icon" href="./assets/pokefuta_icon_32.png" type="image/png" />
   <!-- Google Analytics -->
-  <script src="/assets/analytics.js"></script>
+  <script src="/assets/analytics.js?v=20260805a"></script>
   <script>
     window.PokefutaAnalytics.init({{
       'page_path': '/character_manholes',
       site_type: 'map',
       page_type: 'lp_character_manholes',
     }});
-    window.trackEvent = function(action, params = {{}}) {{
-      gtag('event', action, params);
-    }};
   </script>
   <!-- End GA -->
 </head>

--- a/apps/scraper/generate_character_manhole_page.py
+++ b/apps/scraper/generate_character_manhole_page.py
@@ -694,13 +694,9 @@ def generate_html(
   <style>{PAGE_STYLE}</style>
   <link rel="icon" href="./assets/pokefuta_icon_32.png" type="image/png" />
   <!-- Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-K18NR4GZG2"></script>
+  <script src="/assets/analytics.js"></script>
   <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){{dataLayer.push(arguments);}}
-    gtag('js', new Date());
-    gtag('config', 'G-K18NR4GZG2', {{
-      'anonymize_ip': true,
+    window.PokefutaAnalytics.init({{
       'page_path': '/character_manholes',
       site_type: 'map',
       page_type: 'lp_character_manholes',

--- a/apps/scraper/generate_manhole_pages.py
+++ b/apps/scraper/generate_manhole_pages.py
@@ -1231,7 +1231,7 @@ def generate_html(
   </script>
 
   <!-- Google Analytics -->
-  <script src="/assets/analytics.js"></script>
+  <script src="/assets/analytics.js?v=20260805a"></script>
   <script>
     window.PokefutaAnalytics.init({{
       'page_path': '/manholes/' + {manhole_id_js} + '/',
@@ -1246,10 +1246,6 @@ def generate_html(
       pokemon_count: {len(pokemons)},
       has_photo: {has_photo_js}
     }});
-
-    function trackEvent(action, params) {{
-      gtag('event', action, params);
-    }}
 
     function shareManhole() {{
       var _sp = {{

--- a/apps/scraper/generate_manhole_pages.py
+++ b/apps/scraper/generate_manhole_pages.py
@@ -38,7 +38,6 @@ except ModuleNotFoundError as exc:
 
 # Constants
 BASE_URL = "https://data.pokefuta.com/"
-GA_MEASUREMENT_ID = "G-K18NR4GZG2"
 
 SECONDARY_TAG_LABELS: dict[str, tuple[str, str]] = {
     'tourism':          ('🗺', '観光スポット'),
@@ -620,8 +619,8 @@ def generate_html(
     # Source-differentiated params for Google Maps — same event name but
     # distinguishable in GA4 by where the tap came from.
     _base = {"manhole_id": manhole_id, "prefecture": prefecture, "city": city}
-    gmaps_onclick_hero  = _attr_json({**_base, "source": "hero"})
-    gmaps_onclick_links = _attr_json({**_base, "source": "links"})
+    gmaps_onclick_hero  = _attr_json({**_base, "surface": "hero"})
+    gmaps_onclick_links = _attr_json({**_base, "surface": "links"})
 
     # Build Pokemon info with metadata
     pokemon_info_html = ""
@@ -708,7 +707,7 @@ def generate_html(
         if display_name:
             _profile_url = poster_profile_url(photo.get("public_user_id"))
             if _profile_url:
-                _poster_onclick = _attr_json({"manhole_id": manhole_id, "source": "hero"})
+                _poster_onclick = _attr_json({"manhole_id": manhole_id, "surface": "hero"})
                 credit_parts.append(
                     f"<a class='poster-link' href='{_profile_url}'"
                     f" target='_blank' rel='noopener noreferrer'"
@@ -753,7 +752,7 @@ def generate_html(
                     g_label += f" · {escape(g_date)}"
                 _g_profile_url = poster_profile_url(g.get("public_user_id"))
                 if _g_profile_url:
-                    _g_poster_onclick = _attr_json({"manhole_id": manhole_id, "source": "gallery"})
+                    _g_poster_onclick = _attr_json({"manhole_id": manhole_id, "surface": "gallery"})
                     credit_span = (
                         f"<a class='gallery-credit poster-link' href='{_g_profile_url}'"
                         f" target='_blank' rel='noopener noreferrer'"
@@ -972,7 +971,7 @@ def generate_html(
         f"{_icon('icon-link-share', 'link-card-icon')}<span>共有</span></button>"
     )
     # ポケふた写真館（pokefuta.com）の同ふたページ。ギャラリー未表示のふたでも写真館へ飛べるよう常設
-    _photo_studio_onclick = _attr_json({"manhole_id": manhole_id, "source": "links_photo_studio"})
+    _photo_studio_onclick = _attr_json({"manhole_id": manhole_id, "surface": "links_photo_studio"})
     link_cards.append(
         f"<a class='link-card link-card--internal' href='https://pokefuta.com/manhole/{quote(manhole_id, safe='')}'"
         f" target='_blank' rel='noopener noreferrer'"
@@ -992,7 +991,7 @@ def generate_html(
             f"<a class='link-card link-card--internal' href=\"{escape(pref_url)}\">"
             f"{_icon('icon-detail-same-pref', 'link-card-icon')}<span>同じ都道府県</span></a>"
         )
-    _map_onclick = _attr_json({"manhole_id": manhole_id, "source": "links_map"})
+    _map_onclick = _attr_json({"manhole_id": manhole_id, "surface": "links_map"})
     link_cards.append(
         f"<a class='link-card link-card--internal' href=\"{escape(BASE_URL)}\""
         f" onclick=\"trackEvent('click_map_internal', {_map_onclick})\">"
@@ -1052,7 +1051,7 @@ def generate_html(
                 f"{status_html}"
                 f"</li>"
             )
-        _design_more_onclick = _attr_json({"manhole_id": manhole_id, "source": "design_section"})
+        _design_more_onclick = _attr_json({"manhole_id": manhole_id, "surface": "design_section"})
         design_html = (
             f"<section id='design-manholes' class='design-section section-card'>"
             f"<h2>🎨 近くのデザインマンホール</h2>"
@@ -1151,7 +1150,7 @@ def generate_html(
     )
 
     # Back button HTML
-    _back_onclick = _attr_json({"manhole_id": manhole_id, "source": "back_btn"})
+    _back_onclick = _attr_json({"manhole_id": manhole_id, "surface": "back_btn"})
     back_btn_html = (
         f"<a href=\"{escape(map_url)}\" class=\"back-btn\""
         f" onclick=\"trackEvent('click_map_internal', {_back_onclick})\">"
@@ -1232,12 +1231,9 @@ def generate_html(
   </script>
 
   <!-- Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id={GA_MEASUREMENT_ID}"></script>
+  <script src="/assets/analytics.js"></script>
   <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){{dataLayer.push(arguments);}}
-    gtag('js', new Date());
-    gtag('config', '{GA_MEASUREMENT_ID}', {{
+    window.PokefutaAnalytics.init({{
       'page_path': '/manholes/' + {manhole_id_js} + '/',
       site_type: 'map',
       page_type: 'map_manhole',

--- a/apps/scraper/generate_pokemon_index_page.py
+++ b/apps/scraper/generate_pokemon_index_page.py
@@ -1106,7 +1106,7 @@ def generate_html(
   </script>
 
   <!-- Google Analytics -->
-  <script src="/assets/analytics.js"></script>
+  <script src="/assets/analytics.js?v=20260805a"></script>
   <script>
     window.PokefutaAnalytics.init({{'page_path': '/{url_prefix}pokemon/', site_type: 'map', page_type: 'pokemon_index'}});
     gtag('event', 'view_pokemon_index', {{'pokemon_count': {total_count}, 'lang': '{lang}'}});

--- a/apps/scraper/generate_pokemon_index_page.py
+++ b/apps/scraper/generate_pokemon_index_page.py
@@ -21,7 +21,6 @@ sys.path.insert(0, str(Path(__file__).parent))
 from generate_pokemon_pages import (
     BASE_URL,
     DEFAULT_OGP_IMAGE,
-    GA_MEASUREMENT_ID,
     LANG_CONFIGS,
     _get_display_name,
     build_pokemon_index,
@@ -1107,12 +1106,9 @@ def generate_html(
   </script>
 
   <!-- Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id={GA_MEASUREMENT_ID}"></script>
+  <script src="/assets/analytics.js"></script>
   <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){{dataLayer.push(arguments);}}
-    gtag('js', new Date());
-    gtag('config', '{GA_MEASUREMENT_ID}', {{'page_path': '/{url_prefix}pokemon/', site_type: 'map', page_type: 'pokemon_index'}});
+    window.PokefutaAnalytics.init({{'page_path': '/{url_prefix}pokemon/', site_type: 'map', page_type: 'pokemon_index'}});
     gtag('event', 'view_pokemon_index', {{'pokemon_count': {total_count}, 'lang': '{lang}'}});
   </script>
 

--- a/apps/scraper/generate_pokemon_pages.py
+++ b/apps/scraper/generate_pokemon_pages.py
@@ -815,7 +815,7 @@ def generate_html(
   </script>
 
   <!-- Google Analytics -->
-  <script src="/assets/analytics.js"></script>
+  <script src="/assets/analytics.js?v=20260805a"></script>
   <script>
     window.PokefutaAnalytics.init({{
       'page_path': '/{url_prefix}pokemon/' + {slug_js} + '/',
@@ -827,9 +827,6 @@ def generate_html(
       manhole_count: {count},
       lang: '{lang}'
     }});
-    function trackEvent(action, params) {{
-      gtag('event', action, params);
-    }}
   </script>
 
   <style>

--- a/apps/scraper/generate_pokemon_pages.py
+++ b/apps/scraper/generate_pokemon_pages.py
@@ -24,7 +24,6 @@ logging.basicConfig(level=logging.INFO, format="%(message)s")
 logger = logging.getLogger(__name__)
 
 BASE_URL = "https://data.pokefuta.com/"
-GA_MEASUREMENT_ID = "G-K18NR4GZG2"
 DEFAULT_OGP_IMAGE = f"{BASE_URL}assets/ogp/pokefuta_map_ogp.png"
 
 # Short contextual descriptions explaining regional connections.
@@ -816,12 +815,9 @@ def generate_html(
   </script>
 
   <!-- Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id={GA_MEASUREMENT_ID}"></script>
+  <script src="/assets/analytics.js"></script>
   <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){{dataLayer.push(arguments);}}
-    gtag('js', new Date());
-    gtag('config', '{GA_MEASUREMENT_ID}', {{
+    window.PokefutaAnalytics.init({{
       'page_path': '/{url_prefix}pokemon/' + {slug_js} + '/',
       site_type: 'map',
       page_type: 'pokemon_lp',

--- a/apps/scraper/generate_prefecture_pages.py
+++ b/apps/scraper/generate_prefecture_pages.py
@@ -349,10 +349,7 @@ def _pokemon_cards(records: list[dict], pokemon_slugs: dict[str, str]) -> str:
 
 
 def _campaign_params(slug: str) -> str:
-    return (
-        "from=data&utm_source=data.pokefuta.com&utm_medium=referral"
-        f"&utm_campaign=prefecture_page&utm_content={quote(slug)}"
-    )
+    return "from=data"
 
 
 def _upload_url(manhole_id: str, slug: str) -> str:
@@ -1200,7 +1197,7 @@ def build_page(
     </section>
     <footer><a href="/summary/">全国のポケふた一覧へ戻る</a></footer>
   </main>
-  <script src="/assets/analytics.js"></script>
+  <script src="/assets/analytics.js?v=20260805a"></script>
   <script>
     window.PokefutaAnalytics.init({{
       'page_path': '/prefectures/' + {_json_for_script(slug)} + '/',

--- a/apps/scraper/generate_prefecture_pages.py
+++ b/apps/scraper/generate_prefecture_pages.py
@@ -1200,12 +1200,9 @@ def build_page(
     </section>
     <footer><a href="/summary/">全国のポケふた一覧へ戻る</a></footer>
   </main>
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-K18NR4GZG2"></script>
+  <script src="/assets/analytics.js"></script>
   <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag() {{ dataLayer.push(arguments); }}
-    gtag('js', new Date());
-    gtag('config', 'G-K18NR4GZG2', {{
+    window.PokefutaAnalytics.init({{
       'page_path': '/prefectures/' + {_json_for_script(slug)} + '/',
       site_type: 'map',
       page_type: 'prefecture',

--- a/apps/scraper/generate_summary_pages.py
+++ b/apps/scraper/generate_summary_pages.py
@@ -2936,7 +2936,7 @@ def _build_fact_sections(s: dict, stats: dict, tr) -> tuple[str, str]:
 
 def _build_tracking_script(s: dict) -> str:
     return """\
-  <script src="/assets/analytics.js"></script>
+  <script src="/assets/analytics.js?v=20260805a"></script>
   <script>
     window.PokefutaAnalytics.init({
       'page_path': window.location.pathname,

--- a/apps/scraper/generate_summary_pages.py
+++ b/apps/scraper/generate_summary_pages.py
@@ -2936,13 +2936,9 @@ def _build_fact_sections(s: dict, stats: dict, tr) -> tuple[str, str]:
 
 def _build_tracking_script(s: dict) -> str:
     return """\
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-K18NR4GZG2"></script>
+  <script src="/assets/analytics.js"></script>
   <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-K18NR4GZG2', {
-      'anonymize_ip': true,
+    window.PokefutaAnalytics.init({
       'page_path': window.location.pathname,
       site_type: 'map',
       page_type: 'summary',

--- a/apps/scraper/test_analytics_contract.py
+++ b/apps/scraper/test_analytics_contract.py
@@ -1,0 +1,49 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class AnalyticsContractTest(unittest.TestCase):
+    def test_shared_loader_is_production_only(self):
+        analytics = (ROOT / "web/assets/analytics.js").read_text(encoding="utf-8")
+
+        self.assertIn("PRODUCTION_HOSTS = ['data.pokefuta.com']", analytics)
+        self.assertIn("window.location.hostname.toLowerCase()", analytics)
+        self.assertIn("domains: ['data.pokefuta.com', 'pokefuta.com']", analytics)
+
+    def test_ga_sources_use_shared_loader(self):
+        sources = [
+            ROOT / "web/index.template.html",
+            ROOT / "web/map.template.html",
+            ROOT / "web/index.html",
+            ROOT / "web/map.html",
+            ROOT / "web/gmanhole_map.html",
+            ROOT / "web/design_manhole.html",
+            ROOT / "web/nearby_manholes.html",
+            ROOT / "scraper/generate_character_manhole_page.py",
+            ROOT / "scraper/generate_summary_pages.py",
+            ROOT / "scraper/generate_prefecture_pages.py",
+            ROOT / "scraper/generate_pokemon_index_page.py",
+            ROOT / "scraper/generate_pokemon_pages.py",
+            ROOT / "scraper/generate_manhole_pages.py",
+        ]
+
+        for source in sources:
+            with self.subTest(source=source.name):
+                text = source.read_text(encoding="utf-8")
+                self.assertIn("analytics.js", text)
+                self.assertIn("PokefutaAnalytics.init", text)
+                self.assertNotIn("googletagmanager.com/gtag", text)
+
+    def test_event_location_uses_surface_not_reserved_source(self):
+        generator = (ROOT / "scraper/generate_manhole_pages.py").read_text(encoding="utf-8")
+        map_template = (ROOT / "web/map.template.html").read_text(encoding="utf-8")
+
+        self.assertNotRegex(generator, r'\{[^\n]*["\']source["\']\s*:')
+        self.assertIn("surface: 'top_feature_section'", map_template)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/scraper/test_analytics_contract.py
+++ b/apps/scraper/test_analytics_contract.py
@@ -1,3 +1,4 @@
+import re
 import unittest
 from pathlib import Path
 
@@ -14,21 +15,13 @@ class AnalyticsContractTest(unittest.TestCase):
         self.assertIn("domains: ['data.pokefuta.com', 'pokefuta.com']", analytics)
 
     def test_ga_sources_use_shared_loader(self):
-        sources = [
-            ROOT / "web/index.template.html",
-            ROOT / "web/map.template.html",
-            ROOT / "web/index.html",
-            ROOT / "web/map.html",
-            ROOT / "web/gmanhole_map.html",
-            ROOT / "web/design_manhole.html",
-            ROOT / "web/nearby_manholes.html",
-            ROOT / "scraper/generate_character_manhole_page.py",
-            ROOT / "scraper/generate_summary_pages.py",
-            ROOT / "scraper/generate_prefecture_pages.py",
-            ROOT / "scraper/generate_pokemon_index_page.py",
-            ROOT / "scraper/generate_pokemon_pages.py",
-            ROOT / "scraper/generate_manhole_pages.py",
-        ]
+        candidates = list((ROOT / "web").glob("*.html"))
+        candidates += list((ROOT / "scraper").glob("generate_*.py"))
+        sources = []
+        for source in candidates:
+            text = source.read_text(encoding="utf-8")
+            if "gtag(" in text or "PokefutaAnalytics.init" in text:
+                sources.append(source)
 
         for source in sources:
             with self.subTest(source=source.name):
@@ -38,11 +31,23 @@ class AnalyticsContractTest(unittest.TestCase):
                 self.assertNotIn("googletagmanager.com/gtag", text)
 
     def test_event_location_uses_surface_not_reserved_source(self):
-        generator = (ROOT / "scraper/generate_manhole_pages.py").read_text(encoding="utf-8")
-        map_template = (ROOT / "web/map.template.html").read_text(encoding="utf-8")
+        candidates = list((ROOT / "web").glob("*.html"))
+        candidates += list((ROOT / "scraper").glob("generate_*.py"))
+        reserved_source = re.compile(
+            r"(?:trackEvent|_attr_json)\s*\([^)]{0,800}?[\"']source[\"']\s*:",
+            re.DOTALL,
+        )
 
-        self.assertNotRegex(generator, r'\{[^\n]*["\']source["\']\s*:')
-        self.assertIn("surface: 'top_feature_section'", map_template)
+        for source in candidates:
+            with self.subTest(source=source.name):
+                text = source.read_text(encoding="utf-8")
+                self.assertIsNone(reserved_source.search(text))
+
+    def test_internal_app_links_do_not_use_utm(self):
+        generator = (ROOT / "scraper/generate_prefecture_pages.py").read_text(encoding="utf-8")
+
+        self.assertIn('return "from=data"', generator)
+        self.assertNotIn("utm_source=data.pokefuta.com", generator)
 
 
 if __name__ == "__main__":

--- a/apps/scraper/test_generate_manhole_pages_poster_links.py
+++ b/apps/scraper/test_generate_manhole_pages_poster_links.py
@@ -75,7 +75,7 @@ class HeroCreditLinkTests(unittest.TestCase):
         self.assertIn(f"<a class='poster-link' href='{PROFILE_URL}'", html)
         self.assertIn("📷 いろはす</a>", html)
         self.assertIn("click_poster_profile", html)
-        self.assertIn("&quot;source&quot;: &quot;hero&quot;", html)
+        self.assertIn("&quot;surface&quot;: &quot;hero&quot;", html)
 
     def test_hero_credit_plain_text_without_public_user_id(self):
         html = _generate(_photo(public_user_id=None))
@@ -103,7 +103,7 @@ class GalleryCreditLinkTests(unittest.TestCase):
         html = _generate(_photo(gallery_local=gallery_local))
         self.assertIn(f"<a class='gallery-credit poster-link' href='{PROFILE_URL}'", html)
         self.assertIn("📷 たこ · 5月1日</a>", html)
-        self.assertIn("&quot;source&quot;: &quot;gallery&quot;", html)
+        self.assertIn("&quot;surface&quot;: &quot;gallery&quot;", html)
 
     def test_gallery_credit_plain_text_without_public_user_id(self):
         gallery_local = [

--- a/apps/scraper/test_generate_prefecture_pages.py
+++ b/apps/scraper/test_generate_prefecture_pages.py
@@ -64,7 +64,7 @@ class GeneratePrefecturePagesTest(unittest.TestCase):
             html,
         )
         self.assertIn("https://pokefuta.com/visits?from=data", html)
-        self.assertIn("utm_campaign=prefecture_page", html)
+        self.assertNotIn("utm_", html)
         self.assertIn("prefecture_visit_cta_click", html)
         self.assertIn("prefecture_photo_candidate_click", html)
         self.assertIn("prefecture_photo_upload_start", html)
@@ -251,9 +251,7 @@ class GeneratePrefecturePagesTest(unittest.TestCase):
         self.assertIn("旅人さんの投稿", html)
         self.assertIn(
             'href="https://pokefuta.com/users/'
-            '6096691c-eeda-4e73-8401-a11274868ede/visits?from=data&amp;'
-            'utm_source=data.pokefuta.com&amp;utm_medium=referral&amp;'
-            'utm_campaign=prefecture_page&amp;utm_content=hokkaido"',
+            '6096691c-eeda-4e73-8401-a11274868ede/visits?from=data"',
             html,
         )
         self.assertIn('class="photo-card-poster"', html)

--- a/apps/web/assets/analytics.js
+++ b/apps/web/assets/analytics.js
@@ -37,9 +37,13 @@
       initialized = true;
     }
 
-    window.gtag('set', context);
-    window.gtag('config', MEASUREMENT_ID, Object.assign({ anonymize_ip: true }, config));
+    window.gtag('config', MEASUREMENT_ID, config);
     return true;
+  }
+
+  function setContext(params) {
+    context = Object.assign({}, context, params || {});
+    delete context.send_page_view;
   }
 
   function trackEvent(name, params) {
@@ -50,6 +54,7 @@
   window.PokefutaAnalytics = {
     enabled: enabled,
     init: init,
+    setContext: setContext,
     trackEvent: trackEvent
   };
   window.trackEvent = trackEvent;

--- a/apps/web/assets/analytics.js
+++ b/apps/web/assets/analytics.js
@@ -1,0 +1,56 @@
+(function () {
+  'use strict';
+
+  var MEASUREMENT_ID = 'G-K18NR4GZG2';
+  var PRODUCTION_HOSTS = ['data.pokefuta.com'];
+  var enabled = PRODUCTION_HOSTS.indexOf(window.location.hostname.toLowerCase()) !== -1;
+  var initialized = false;
+  var context = { site_type: 'map' };
+
+  window.dataLayer = window.dataLayer || [];
+  window.gtag = window.gtag || function () {
+    if (enabled) window.dataLayer.push(arguments);
+  };
+
+  function loadGtag() {
+    if (document.querySelector('script[data-pokefuta-ga4]')) return;
+    var script = document.createElement('script');
+    script.async = true;
+    script.src = 'https://www.googletagmanager.com/gtag/js?id=' + encodeURIComponent(MEASUREMENT_ID);
+    script.dataset.pokefutaGa4 = 'true';
+    document.head.appendChild(script);
+  }
+
+  function init(params) {
+    var config = Object.assign({ site_type: 'map' }, params || {});
+    context = Object.assign({}, config);
+    delete context.send_page_view;
+    if (!enabled) return false;
+
+    loadGtag();
+    if (!initialized) {
+      window.gtag('js', new Date());
+      window.gtag('set', 'linker', {
+        domains: ['data.pokefuta.com', 'pokefuta.com'],
+        accept_incoming: true
+      });
+      initialized = true;
+    }
+
+    window.gtag('set', context);
+    window.gtag('config', MEASUREMENT_ID, Object.assign({ anonymize_ip: true }, config));
+    return true;
+  }
+
+  function trackEvent(name, params) {
+    if (!enabled) return;
+    window.gtag('event', name, Object.assign({}, context, params || {}));
+  }
+
+  window.PokefutaAnalytics = {
+    enabled: enabled,
+    init: init,
+    trackEvent: trackEvent
+  };
+  window.trackEvent = trackEvent;
+})();

--- a/apps/web/design_manhole.html
+++ b/apps/web/design_manhole.html
@@ -201,13 +201,9 @@
   </style>
   <link rel="icon" href="./assets/pokefuta_icon_32.png" type="image/png" />
   <!-- Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-K18NR4GZG2"></script>
+  <script src="./assets/analytics.js"></script>
   <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-K18NR4GZG2', {
-      'anonymize_ip': true,
+    window.PokefutaAnalytics.init({
       'page_path': '/design_manhole',
       site_type: 'map',
       page_type: 'lp_design_manhole',

--- a/apps/web/design_manhole.html
+++ b/apps/web/design_manhole.html
@@ -201,16 +201,13 @@
   </style>
   <link rel="icon" href="./assets/pokefuta_icon_32.png" type="image/png" />
   <!-- Google Analytics -->
-  <script src="./assets/analytics.js"></script>
+  <script src="./assets/analytics.js?v=20260805a"></script>
   <script>
     window.PokefutaAnalytics.init({
       'page_path': '/design_manhole',
       site_type: 'map',
       page_type: 'lp_design_manhole',
     });
-    window.trackEvent = function(action, params = {}) {
-      gtag('event', action, params);
-    };
   </script>
   <!-- End GA -->
 </head>

--- a/apps/web/gmanhole_map.html
+++ b/apps/web/gmanhole_map.html
@@ -127,7 +127,7 @@
   </style>
   <link rel="icon" href="./assets/pokefuta_icon_32.png" type="image/png" />
   <!-- Google Analytics -->
-  <script src="./assets/analytics.js"></script>
+  <script src="./assets/analytics.js?v=20260805a"></script>
   <script>
     // Dynamic page_path for Gundam manhole map
     // Inline code-to-name mapping to avoid duplication (full map defined globally below)
@@ -155,10 +155,6 @@
       ...gmanholeGA4Params,
     });
 
-    // Event tracking helper function
-    window.trackEvent = function(action, params = {}) {
-      gtag('event', action, params);
-    };
   </script>
   <!-- End GA -->
   <script>

--- a/apps/web/gmanhole_map.html
+++ b/apps/web/gmanhole_map.html
@@ -127,12 +127,8 @@
   </style>
   <link rel="icon" href="./assets/pokefuta_icon_32.png" type="image/png" />
   <!-- Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-K18NR4GZG2"></script>
+  <script src="./assets/analytics.js"></script>
   <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
     // Dynamic page_path for Gundam manhole map
     // Inline code-to-name mapping to avoid duplication (full map defined globally below)
     const CODE_TO_PREF = {'01':'北海道','02':'青森県','03':'岩手県','04':'宮城県','05':'秋田県','06':'山形県','07':'福島県','08':'茨城県','09':'栃木県','10':'群馬県','11':'埼玉県','12':'千葉県','13':'東京都','14':'神奈川県','15':'新潟県','16':'富山県','17':'石川県','18':'福井県','19':'山梨県','20':'長野県','21':'岐阜県','22':'静岡県','23':'愛知県','24':'三重県','25':'滋賀県','26':'京都府','27':'大阪府','28':'兵庫県','29':'奈良県','30':'和歌山県','31':'鳥取県','32':'島根県','33':'岡山県','34':'広島県','35':'山口県','36':'徳島県','37':'香川県','38':'愛媛県','39':'高知県','40':'福岡県','41':'佐賀県','42':'長崎県','43':'熊本県','44':'大分県','45':'宮崎県','46':'鹿児島県','47':'沖縄県'};
@@ -154,8 +150,7 @@
       gmanholeGA4Params.work = workParam;
     }
 
-    gtag('config', 'G-K18NR4GZG2', {
-      'anonymize_ip': true,
+    window.PokefutaAnalytics.init({
       'page_path': pagePath,
       ...gmanholeGA4Params,
     });

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -66,13 +66,9 @@
     })();
   </script>
   <!-- Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-K18NR4GZG2"></script>
+  <script src="./assets/analytics.js"></script>
   <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-K18NR4GZG2', {
-      anonymize_ip: true,
+    window.PokefutaAnalytics.init({
       page_path: '/top',
       site_type: 'map',
       page_type: 'top_page',

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -66,20 +66,13 @@
     })();
   </script>
   <!-- Google Analytics -->
-  <script src="./assets/analytics.js"></script>
+  <script src="./assets/analytics.js?v=20260805a"></script>
   <script>
     window.PokefutaAnalytics.init({
       page_path: '/top',
       site_type: 'map',
       page_type: 'top_page',
     });
-    window.trackEvent = function(action, params) {
-      gtag('event', action, Object.assign(
-        {},
-        params || {},
-        { site_type: 'map', page_type: 'top_page' }
-      ));
-    };
   </script>
   <!-- End GA -->
   <link rel="stylesheet" href="./assets/theme.css" />

--- a/apps/web/index.template.html
+++ b/apps/web/index.template.html
@@ -69,13 +69,9 @@
     })();
   </script>
   <!-- Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-K18NR4GZG2"></script>
+  <script src="%%BASE_PATH%%assets/analytics.js"></script>
   <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-K18NR4GZG2', {
-      anonymize_ip: true,
+    window.PokefutaAnalytics.init({
       page_path: '/top',
       site_type: 'map',
       page_type: 'top_page',

--- a/apps/web/index.template.html
+++ b/apps/web/index.template.html
@@ -69,20 +69,13 @@
     })();
   </script>
   <!-- Google Analytics -->
-  <script src="%%BASE_PATH%%assets/analytics.js"></script>
+  <script src="%%BASE_PATH%%assets/analytics.js?v=20260805a"></script>
   <script>
     window.PokefutaAnalytics.init({
       page_path: '/top',
       site_type: 'map',
       page_type: 'top_page',
     });
-    window.trackEvent = function(action, params) {
-      gtag('event', action, Object.assign(
-        {},
-        params || {},
-        { site_type: 'map', page_type: 'top_page' }
-      ));
-    };
   </script>
   <!-- End GA -->
   <link rel="stylesheet" href="%%BASE_PATH%%assets/theme.css" />

--- a/apps/web/map.html
+++ b/apps/web/map.html
@@ -299,12 +299,8 @@
   <link rel="stylesheet" href="./assets/pokefuta-map.css?v=20260614-hero-toggle" />
   <link rel="icon" href="./assets/pokefuta-marker.svg" type="image/svg+xml" />
   <!-- Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-K18NR4GZG2"></script>
+  <script src="./assets/analytics.js"></script>
   <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
     // Dynamic page_path based on URL parameters
     const params = new URLSearchParams(window.location.search);
     const manholeParam = params.get('manhole');
@@ -329,8 +325,7 @@
       };
     }
 
-    gtag('config', 'G-K18NR4GZG2', {
-      anonymize_ip: true,
+    window.PokefutaAnalytics.init({
       page_path: pagePath,
       ...mapGA4Params,
     });
@@ -2142,7 +2137,7 @@
                 feature: tag,
                 feature_label: TAG_META[tag]?.label || tag,
                 result_count: parseInt(btn.dataset.count, 10),
-                source: 'top_feature_section'
+                surface: 'top_feature_section'
               });
             }
           });

--- a/apps/web/map.html
+++ b/apps/web/map.html
@@ -299,7 +299,7 @@
   <link rel="stylesheet" href="./assets/pokefuta-map.css?v=20260614-hero-toggle" />
   <link rel="icon" href="./assets/pokefuta-marker.svg" type="image/svg+xml" />
   <!-- Google Analytics -->
-  <script src="./assets/analytics.js"></script>
+  <script src="./assets/analytics.js?v=20260805a"></script>
   <script>
     // Dynamic page_path based on URL parameters
     const params = new URLSearchParams(window.location.search);
@@ -333,10 +333,6 @@
     // Current page_type for dynamic event params (updated on SPA navigation)
     window.currentGA4PageType = mapGA4Params.page_type || 'map_top';
 
-    // Event tracking helper function
-    window.trackEvent = function(action, params = {}) {
-      gtag('event', action, params);
-    };
   </script>
   <!-- End GA -->
 </head>
@@ -702,6 +698,11 @@
         window.applyPrefecturePageMeta(prefecture);
         // Send page_view for SPA navigation (skip initial page load)
         window.currentGA4PageType = 'map_prefecture';
+        window.PokefutaAnalytics.setContext({
+          page_path: `/prefectures/${window.PREFECTURE_SLUG_MAP[prefecture] || encodeURIComponent(prefecture)}/`,
+          page_type: 'map_prefecture',
+          prefecture: window.PREFECTURE_SLUG_MAP[prefecture] || prefecture,
+        });
         if (window.gtag && !isInitialPageLoad) {
           gtag('event', 'page_view', {
             page_path: `/prefectures/${window.PREFECTURE_SLUG_MAP[prefecture] || encodeURIComponent(prefecture)}/`,
@@ -715,6 +716,7 @@
         window.history.replaceState({}, '', window.buildCanonicalPath(''));
         window.applyPrefecturePageMeta('');
         window.currentGA4PageType = 'map_top';
+        window.PokefutaAnalytics.setContext({ page_path: '/map', page_type: 'map_top', prefecture: '' });
         // Send page_view for SPA navigation back to top (skip initial page load)
         if (window.gtag && !isInitialPageLoad) {
           gtag('event', 'page_view', {
@@ -1610,6 +1612,11 @@
       window.history.replaceState({ manhole: data.id }, '', window.buildManholeCanonicalPath(data.id));
       // Send page_view for manhole detail (always: covers both initial ?manhole= load and SPA navigation)
       window.currentGA4PageType = 'map_manhole';
+      window.PokefutaAnalytics.setContext({
+        page_path: `/manholes/${encodeURIComponent(data.id)}/`,
+        page_type: 'map_manhole',
+        prefecture: window.PREFECTURE_SLUG_MAP[data.prefecture] || data.prefecture || '',
+      });
       if (window.gtag) {
         gtag('event', 'page_view', {
           'page_path': `/manholes/${encodeURIComponent(data.id)}/`,

--- a/apps/web/map.template.html
+++ b/apps/web/map.template.html
@@ -305,12 +305,8 @@
   <link rel="stylesheet" href="%%BASE_PATH%%assets/pokefuta-map.css?v=20260614-hero-toggle" />
   <link rel="icon" href="%%BASE_PATH%%assets/pokefuta-marker.svg" type="image/svg+xml" />
   <!-- Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-K18NR4GZG2"></script>
+  <script src="%%BASE_PATH%%assets/analytics.js"></script>
   <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
     // Dynamic page_path based on URL parameters
     const params = new URLSearchParams(window.location.search);
     const manholeParam = params.get('manhole');
@@ -335,8 +331,7 @@
       };
     }
 
-    gtag('config', 'G-K18NR4GZG2', {
-      anonymize_ip: true,
+    window.PokefutaAnalytics.init({
       page_path: pagePath,
       ...mapGA4Params,
     });
@@ -2110,7 +2105,7 @@
                 feature: tag,
                 feature_label: TAG_META[tag]?.label || tag,
                 result_count: parseInt(btn.dataset.count, 10),
-                source: 'top_feature_section'
+                surface: 'top_feature_section'
               });
             }
           });

--- a/apps/web/map.template.html
+++ b/apps/web/map.template.html
@@ -305,7 +305,7 @@
   <link rel="stylesheet" href="%%BASE_PATH%%assets/pokefuta-map.css?v=20260614-hero-toggle" />
   <link rel="icon" href="%%BASE_PATH%%assets/pokefuta-marker.svg" type="image/svg+xml" />
   <!-- Google Analytics -->
-  <script src="%%BASE_PATH%%assets/analytics.js"></script>
+  <script src="%%BASE_PATH%%assets/analytics.js?v=20260805a"></script>
   <script>
     // Dynamic page_path based on URL parameters
     const params = new URLSearchParams(window.location.search);
@@ -339,10 +339,6 @@
     // Current page_type for dynamic event params (updated on SPA navigation)
     window.currentGA4PageType = mapGA4Params.page_type || 'map_top';
 
-    // Event tracking helper function
-    window.trackEvent = function(action, params = {}) {
-      gtag('event', action, params);
-    };
   </script>
   <!-- End GA -->
 </head>
@@ -714,6 +710,11 @@
         window.applyPrefecturePageMeta(prefecture);
         // Send page_view for SPA navigation (skip initial page load)
         window.currentGA4PageType = 'map_prefecture';
+        window.PokefutaAnalytics.setContext({
+          page_path: `/prefectures/${window.PREFECTURE_SLUG_MAP[prefecture] || encodeURIComponent(prefecture)}/`,
+          page_type: 'map_prefecture',
+          prefecture: window.PREFECTURE_SLUG_MAP[prefecture] || prefecture,
+        });
         if (window.gtag && !isInitialPageLoad) {
           gtag('event', 'page_view', {
             page_path: `/prefectures/${window.PREFECTURE_SLUG_MAP[prefecture] || encodeURIComponent(prefecture)}/`,
@@ -727,6 +728,7 @@
         window.history.replaceState({}, '', window.buildCanonicalPath(''));
         window.applyPrefecturePageMeta('');
         window.currentGA4PageType = 'map_top';
+        window.PokefutaAnalytics.setContext({ page_path: '/map', page_type: 'map_top', prefecture: '' });
         // Send page_view for SPA navigation back to top (skip initial page load)
         if (window.gtag && !isInitialPageLoad) {
           gtag('event', 'page_view', {
@@ -1574,6 +1576,11 @@
       window.history.replaceState({ manhole: data.id }, '', window.buildManholeCanonicalPath(data.id));
       // Send page_view for manhole detail (always: covers both initial ?manhole= load and SPA navigation)
       window.currentGA4PageType = 'map_manhole';
+      window.PokefutaAnalytics.setContext({
+        page_path: `/manholes/${encodeURIComponent(data.id)}/`,
+        page_type: 'map_manhole',
+        prefecture: window.PREFECTURE_SLUG_MAP[data.prefecture] || data.prefecture || '',
+      });
       if (window.gtag) {
         gtag('event', 'page_view', {
           'page_path': `/manholes/${encodeURIComponent(data.id)}/`,

--- a/apps/web/nearby_manholes.html
+++ b/apps/web/nearby_manholes.html
@@ -508,7 +508,7 @@
   </script>
 
 <!-- Google Analytics -->
-<script src="./assets/analytics.js"></script>
+<script src="./assets/analytics.js?v=20260805a"></script>
 <script>
   window.PokefutaAnalytics.init({
     'page_path': '/nearby',
@@ -516,10 +516,6 @@
     page_type: 'map_nearby',
   });
 
-  // Event tracking helper function
-  window.trackEvent = function(action, params = {}) {
-    gtag('event', action, params);
-  };
 </script>
 </body>
 </html>

--- a/apps/web/nearby_manholes.html
+++ b/apps/web/nearby_manholes.html
@@ -507,15 +507,10 @@
     });
   </script>
 
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-K18NR4GZG2"></script>
+<!-- Google Analytics -->
+<script src="./assets/analytics.js"></script>
 <script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-K18NR4GZG2', {
-    'anonymize_ip': true,
+  window.PokefutaAnalytics.init({
     'page_path': '/nearby',
     site_type: 'map',
     page_type: 'map_nearby',

--- a/tools/make_template.py
+++ b/tools/make_template.py
@@ -237,6 +237,12 @@ t = t.replace(OLD_JSONLD_KEYWORDS, NEW_JSONLD_KEYWORDS, 1)
 # ──────────────────────────────────────────
 
 # CSS links in <head>
+t = re.sub(
+    r'  <script src="\./assets/analytics\.js([^\"]*)"></script>',
+    r'  <script src="%%BASE_PATH%%assets/analytics.js\1"></script>',
+    t,
+    count=1
+)
 t = t.replace(
     '  <link rel="stylesheet" href="./assets/theme.css" />',
     '  <link rel="stylesheet" href="%%BASE_PATH%%assets/theme.css" />', 1


### PR DESCRIPTION
## Summary
- Centralize GA4 initialization and event dispatch in `apps/web/assets/analytics.js`.
- Load analytics only on `data.pokefuta.com`, excluding localhost, K11, and preview hosts.
- Configure cross-domain linking with `pokefuta.com`.
- Update static pages, templates, and page generators to use the shared loader.
- Rename event location parameter `source` to `surface` to avoid traffic-source attribution pollution.
- Remove internal UTM parameters from app links and retain only `from=data`.
- Add cache-busted shared loader references, template generation coverage, and analytics contract tests in CI.

## Why
GA initialization was duplicated across many generated pages, making host filtering and cross-domain behavior inconsistent. Event parameters such as `source: hero`, `source: back_btn`, and `source: top_feature_section` were interpreted as acquisition sources in GA4.

The cross-domain linker is now the source of truth for sessions. `from=data` is a product-journey marker consumed by pokefuta.com as `source_app=tracker` and `p_data_referral`, not an acquisition UTM.

## Impact
SEO traffic attribution remains intact, data-to-app journeys are measured without overwriting their original acquisition source, and local development traffic no longer enters production GA4.

## Validation
- 116 relevant unit tests passed
- Modified Python generators compile successfully
- Hostname smoke test: localhost loads 0 GA scripts; `data.pokefuta.com` loads 1
- Shared event context smoke test passed
- Repository-wide check confirms no per-page `trackEvent` implementation or internal UTM runtime remains

## Existing test-suite notes
The full 248-test discovery still contains four unrelated `DiscoveryHubTests` failures from stale top-page fixtures and one missing local `bs4` dependency. The GA-related tests pass.
