### PR TITLE
Prevent unresolved design manholes from publishing

### DIFF
--- a/.github/workflows/update-design-manholes.yml
+++ b/.github/workflows/update-design-manholes.yml
@@ -1,3 +1,4 @@
+# Family B: create or update a PR and wait for human review before publishing.
 name: Daily Design Manhole Dataset Update
 
 on:
@@ -9,12 +10,17 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: daily-design-manhole-dataset-update
+  cancel-in-progress: false
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   update:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -44,7 +50,6 @@ jobs:
           fi
 
       - name: Create pull request
-        if: steps.diff.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
           commit-message: "chore: update design manhole submissions"

--- a/.github/workflows/update-design-manholes.yml
+++ b/.github/workflows/update-design-manholes.yml
@@ -42,6 +42,7 @@ jobs:
           git add \
             apps/scraper/design_manhole_submissions.ndjson \
             dataset/design_manhole_geocode_cache.json \
+            dataset/design_manhole_review_queue.ndjson \
             docs/design_manholes.ndjson
           if git diff --cached --quiet; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
@@ -55,7 +56,7 @@ jobs:
           commit-message: "chore: update design manhole submissions"
           title: "Daily design manhole dataset update"
           body: |
-            Imports published pokefuta.com design-manhole submissions, reverse-geocodes new coordinates, and refreshes the public NDJSON snapshot.
+            Imports published pokefuta.com design-manhole submissions, reverse-geocodes new coordinates, refreshes the public NDJSON snapshot, and preserves non-public candidates in a review queue.
           branch: daily/update-design-manhole-dataset
           labels: |-
             data-update

--- a/apps/scraper/import_design_manholes.py
+++ b/apps/scraper/import_design_manholes.py
@@ -31,6 +31,7 @@ GSI_MUNI_URL = "https://maps.gsi.go.jp/js/muni.js"
 USER_AGENT = "pokefuta-tracker design-manhole importer (+https://github.com/nishiokya/pokefuta-tracker)"
 DEFAULT_LIMIT = 200
 NEARBY_THRESHOLD_METERS = 50.0
+PUBLIC_REVIEW_STATUSES = frozenset({"pending", "matched", "reviewed_distinct"})
 
 
 def utc_now() -> str:
@@ -295,8 +296,19 @@ def build_public_records(
 
 
 def select_public_records(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Exclude nearby submissions until a human resolves their canonical match."""
-    return [record for record in records if record.get("review_status") != "needs_review"]
+    """Publish only records in explicitly allowed states."""
+    return [
+        record
+        for record in records
+        if record.get("status") == "active"
+        and record.get("review_status") in PUBLIC_REVIEW_STATUSES
+    ]
+
+
+def select_review_records(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Keep every non-public record available for human review."""
+    public_ids = {record.get("source_id") for record in select_public_records(records)}
+    return [record for record in records if record.get("source_id") not in public_ids]
 
 
 def validate_snapshot_size(
@@ -329,6 +341,11 @@ def main() -> None:
         "--output", type=Path, default=root / "docs/design_manholes.ndjson"
     )
     parser.add_argument(
+        "--review-output",
+        type=Path,
+        default=root / "dataset/design_manhole_review_queue.ndjson",
+    )
+    parser.add_argument(
         "--geocode-cache",
         type=Path,
         default=root / "dataset/design_manhole_geocode_cache.json",
@@ -357,25 +374,28 @@ def main() -> None:
         "pokefuta": load_ndjson(root / "docs/pokefuta.ndjson"),
     }
     imported_at = utc_now()
-    previous_public = load_ndjson(args.output)
+    previous_records = load_ndjson(args.output) + load_ndjson(args.review_output)
     normalized_records = build_public_records(
         submissions,
         cache,
         overrides,
         references,
         imported_at,
-        previous_records=previous_public,
+        previous_records=previous_records,
     )
     public_records = select_public_records(normalized_records)
+    review_records = select_review_records(normalized_records)
 
     write_ndjson(args.raw_output, submissions)
     write_json(args.geocode_cache, cache)
     write_ndjson(args.output, public_records)
+    write_ndjson(args.review_output, review_records)
     print(
         f"Imported {len(submissions)} design-manhole submissions; "
         f"matched={sum(bool(row['canonical_ref']) for row in public_records)} "
         f"needs_review={sum(row['review_status'] == 'needs_review' for row in normalized_records)} "
-        f"published={len(public_records)}"
+        f"published={len(public_records)} "
+        f"review_queue={len(review_records)}"
     )
 
 

--- a/apps/scraper/import_design_manholes.py
+++ b/apps/scraper/import_design_manholes.py
@@ -258,6 +258,7 @@ def build_public_records(
             review_status = "needs_review"
         else:
             review_status = "pending"
+        default_status = "pending" if review_status == "needs_review" else "active"
 
         record = {
             "id": f"pokefuta-design:{source_id}",
@@ -279,7 +280,7 @@ def build_public_records(
             "review_status": review_status,
             "created_at": submission["created_at"],
             "last_updated": imported_at,
-            "status": override.get("status", "active"),
+            "status": override.get("status", default_status),
         }
         previous = previous_by_id.get(source_id)
         if previous:
@@ -291,6 +292,11 @@ def build_public_records(
                 record["last_updated"] = previous.get("last_updated", imported_at)
         records.append(record)
     return sorted(records, key=lambda record: (record["created_at"], record["source_id"]))
+
+
+def select_public_records(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Exclude nearby submissions until a human resolves their canonical match."""
+    return [record for record in records if record.get("review_status") != "needs_review"]
 
 
 def validate_snapshot_size(
@@ -352,7 +358,7 @@ def main() -> None:
     }
     imported_at = utc_now()
     previous_public = load_ndjson(args.output)
-    public_records = build_public_records(
+    normalized_records = build_public_records(
         submissions,
         cache,
         overrides,
@@ -360,6 +366,7 @@ def main() -> None:
         imported_at,
         previous_records=previous_public,
     )
+    public_records = select_public_records(normalized_records)
 
     write_ndjson(args.raw_output, submissions)
     write_json(args.geocode_cache, cache)
@@ -367,7 +374,8 @@ def main() -> None:
     print(
         f"Imported {len(submissions)} design-manhole submissions; "
         f"matched={sum(bool(row['canonical_ref']) for row in public_records)} "
-        f"needs_review={sum(row['review_status'] == 'needs_review' for row in public_records)}"
+        f"needs_review={sum(row['review_status'] == 'needs_review' for row in normalized_records)} "
+        f"published={len(public_records)}"
     )
 
 

--- a/apps/scraper/test_import_design_manholes.py
+++ b/apps/scraper/test_import_design_manholes.py
@@ -92,8 +92,36 @@ class ImportDesignManholesTests(unittest.TestCase):
 
         self.assertIsNone(records[0]["canonical_ref"])
         self.assertEqual(records[0]["review_status"], "needs_review")
+        self.assertEqual(records[0]["status"], "pending")
         self.assertEqual(records[0]["nearby_refs"][0]["ref"], "gundam:5")
         self.assertNotIn("submitter_name", records[0])
+        self.assertEqual(importer.select_public_records(records), [])
+
+    def test_official_pokefuta_candidate_is_not_published(self):
+        submission = {
+            **self.submission,
+            "latitude": 40.5379444444444,
+            "longitude": 141.558027777778,
+        }
+        references = {
+            "pokefuta": [
+                {
+                    "id": "157",
+                    "title": "青森県/八戸市",
+                    "lat": 40.537937,
+                    "lng": 141.558034,
+                }
+            ]
+        }
+
+        records = importer.build_public_records(
+            [submission], {}, {}, references, "2026-08-08T00:00:00Z"
+        )
+
+        self.assertEqual(records[0]["nearby_refs"][0]["ref"], "pokefuta:157")
+        self.assertEqual(records[0]["review_status"], "needs_review")
+        self.assertEqual(records[0]["status"], "pending")
+        self.assertEqual(importer.select_public_records(records), [])
 
     def test_source_url_links_to_individual_submission_page(self):
         records = importer.build_public_records(
@@ -120,6 +148,8 @@ class ImportDesignManholesTests(unittest.TestCase):
 
         self.assertEqual(records[0]["canonical_ref"], "gundam:5")
         self.assertEqual(records[0]["review_status"], "matched")
+        self.assertEqual(records[0]["status"], "active")
+        self.assertEqual(importer.select_public_records(records), records)
 
     def test_manual_review_status_can_clear_nearby_candidate(self):
         references = {
@@ -136,7 +166,9 @@ class ImportDesignManholesTests(unittest.TestCase):
         )
 
         self.assertEqual(records[0]["review_status"], "reviewed_distinct")
+        self.assertEqual(records[0]["status"], "active")
         self.assertEqual(records[0]["nearby_refs"][0]["ref"], "pokefuta:10")
+        self.assertEqual(importer.select_public_records(records), records)
 
     def test_unchanged_record_preserves_last_updated(self):
         initial = importer.build_public_records(
@@ -175,6 +207,16 @@ class ImportDesignManholesTests(unittest.TestCase):
         workflow = (ROOT / ".github/workflows/pages-deploy.yml").read_text(encoding="utf-8")
 
         self.assertIn("cp docs/design_manholes.ndjson dist/design_manholes.ndjson", workflow)
+
+    def test_update_workflow_runs_create_pr_even_when_diff_disappears(self):
+        workflow = (ROOT / ".github/workflows/update-design-manholes.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertNotIn("if: steps.diff.outputs.changed == 'true'", workflow)
+        self.assertIn("# Family B:", workflow)
+        self.assertIn("concurrency:", workflow)
+        self.assertIn("timeout-minutes:", workflow)
 
 
 if __name__ == "__main__":

--- a/apps/scraper/test_import_design_manholes.py
+++ b/apps/scraper/test_import_design_manholes.py
@@ -1,4 +1,5 @@
 import importlib.util
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -96,6 +97,7 @@ class ImportDesignManholesTests(unittest.TestCase):
         self.assertEqual(records[0]["nearby_refs"][0]["ref"], "gundam:5")
         self.assertNotIn("submitter_name", records[0])
         self.assertEqual(importer.select_public_records(records), [])
+        self.assertEqual(importer.select_review_records(records), records)
 
     def test_official_pokefuta_candidate_is_not_published(self):
         submission = {
@@ -119,9 +121,25 @@ class ImportDesignManholesTests(unittest.TestCase):
         )
 
         self.assertEqual(records[0]["nearby_refs"][0]["ref"], "pokefuta:157")
+        self.assertLessEqual(records[0]["nearby_refs"][0]["distance_m"], 1)
         self.assertEqual(records[0]["review_status"], "needs_review")
         self.assertEqual(records[0]["status"], "pending")
-        self.assertEqual(importer.select_public_records(records), [])
+        with tempfile.TemporaryDirectory() as directory:
+            public_path = Path(directory) / "public.ndjson"
+            review_path = Path(directory) / "review.ndjson"
+            importer.write_ndjson(public_path, importer.select_public_records(records))
+            importer.write_ndjson(review_path, importer.select_review_records(records))
+
+            self.assertEqual(importer.load_ndjson(public_path), [])
+            review_queue = importer.load_ndjson(review_path)
+            self.assertEqual(len(review_queue), 1)
+            self.assertEqual(review_queue[0]["source_id"], "submission-1")
+            self.assertEqual(review_queue[0]["nearby_refs"][0]["ref"], "pokefuta:157")
+            self.assertLessEqual(review_queue[0]["nearby_refs"][0]["distance_m"], 1)
+            self.assertEqual(
+                review_queue[0]["source_url"],
+                "https://pokefuta.com/design-manholes/submission-1",
+            )
 
     def test_source_url_links_to_individual_submission_page(self):
         records = importer.build_public_records(
@@ -170,6 +188,41 @@ class ImportDesignManholesTests(unittest.TestCase):
         self.assertEqual(records[0]["nearby_refs"][0]["ref"], "pokefuta:10")
         self.assertEqual(importer.select_public_records(records), records)
 
+    def test_public_selection_is_fail_closed(self):
+        base_record = {
+            "source_id": "submission-1",
+            "status": "active",
+            "review_status": "pending",
+        }
+        publishable = [
+            {**base_record, "source_id": "pending", "review_status": "pending"},
+            {**base_record, "source_id": "matched", "review_status": "matched"},
+            {
+                **base_record,
+                "source_id": "reviewed-distinct",
+                "review_status": "reviewed_distinct",
+            },
+        ]
+        quarantined = [
+            {**base_record, "source_id": "hidden", "status": "hidden"},
+            {**base_record, "source_id": "status-pending", "status": "pending"},
+            {
+                **base_record,
+                "source_id": "unknown-review",
+                "review_status": "future_state",
+            },
+            {
+                **base_record,
+                "source_id": "needs-review",
+                "review_status": "needs_review",
+            },
+        ]
+
+        records = publishable + quarantined
+
+        self.assertEqual(importer.select_public_records(records), publishable)
+        self.assertEqual(importer.select_review_records(records), quarantined)
+
     def test_unchanged_record_preserves_last_updated(self):
         initial = importer.build_public_records(
             [self.submission], {}, {}, {}, "2026-07-14T00:00:00Z"
@@ -217,6 +270,7 @@ class ImportDesignManholesTests(unittest.TestCase):
         self.assertIn("# Family B:", workflow)
         self.assertIn("concurrency:", workflow)
         self.assertIn("timeout-minutes:", workflow)
+        self.assertIn("dataset/design_manhole_review_queue.ndjson", workflow)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Treat unresolved nearby Pokéfuta candidates as `pending` and exclude them from the public design-manhole dataset.
- Add a regression test for the official Pokéfuta ID 157 coordinates that caused the accidental duplicate submission.
- Harden the scheduled review workflow with Family B documentation, timeout/concurrency settings, and unconditional create-pull-request execution so empty updates can close stale PRs.

## Root cause

The importer detected nearby official Pokéfuta candidates but still emitted them as active public records. The workflow also skipped `peter-evans/create-pull-request` when no dataset diff existed, preventing its branch/PR cleanup behavior.

## Verification

- `python3 -m unittest apps.scraper.test_import_design_manholes` (13 tests)
- `git diff --check`

## Follow-up

After this merges, the next daily data PR may remove five existing unresolved `needs_review` records. That generated-data change is intentionally kept separate for human review.
