### PR TITLE
feat: 図鑑のクロムを写真館と揃える（下タブ・サイトスイッチャー・認証UI）

### DIFF
--- a/apps/scraper/inject_site_header.py
+++ b/apps/scraper/inject_site_header.py
@@ -25,10 +25,14 @@ from pathlib import Path
 STYLESHEET_TEMPLATE = '<link rel="stylesheet" href="{asset_base}assets/site-header.css">'
 SESSION_BADGE_SCRIPT_TEMPLATE = '<script src="{asset_base}assets/session-badge.js" defer></script>'
 
-POKEFUTA_APP_URL = "https://pokefuta.com/"
+# pokefuta.com への導線には必ず `from=data` を付ける（AGENTS.md）。
+# 同一GA4プロパティ内の内部UTMは使わず、着地側の source_app=tracker /
+# p_data_referral と突き合わせて分析するため、これが唯一の流入元マーカーになる。
+POKEFUTA_APP_URL = "https://pokefuta.com/?from=data"
 POKEFUTA_LOGIN_URL = "https://pokefuta.com/login?from=data"
-POKEFUTA_PROFILE_URL = "https://pokefuta.com/profile"
-POKEFUTA_ABOUT_URL = "https://pokefuta.com/about"
+POKEFUTA_STAMP_URL = "https://pokefuta.com/visits?from=data"
+POKEFUTA_PROFILE_URL = "https://pokefuta.com/profile?from=data"
+POKEFUTA_ABOUT_URL = "https://pokefuta.com/about?from=data"
 X_ACCOUNT_URL = "https://x.com/pokemonmanhole"
 
 # lucide-react 0.294 系（写真館が使っているもの）と同じ字形を inline SVG で持つ。
@@ -188,7 +192,7 @@ BOTTOM_TABS_TEMPLATE = """<nav class="site-tabs" aria-label="{tabs_aria}">
   <a class="site-tab{active_map}" href="{page_base}map.html">{icon_map}<span>{nav_map}</span></a>
   <a class="site-tab{active_pokemon}" href="{page_base}pokemon/">{icon_pokemon}<span>{nav_pokemon}</span></a>
   <a class="site-tab{active_summary}" href="{page_base}summary/">{icon_summary}<span>{nav_summary}</span></a>
-  <a class="site-tab" data-login-link href="{login_url}">{icon_stamp}<span>{tab_stamp}</span></a>
+  <a class="site-tab" data-login-link data-stamp-page="{stamp_url}" href="{login_url}">{icon_stamp}<span>{tab_stamp}</span></a>
 </nav>"""
 
 
@@ -253,6 +257,7 @@ def inject(
         page_base=page_base,
         app_url=POKEFUTA_APP_URL,
         login_url=POKEFUTA_LOGIN_URL,
+        stamp_url=POKEFUTA_STAMP_URL,
         profile_url=POKEFUTA_PROFILE_URL,
         about_url=POKEFUTA_ABOUT_URL,
         x_url=X_ACCOUNT_URL,

--- a/apps/scraper/inject_site_header.py
+++ b/apps/scraper/inject_site_header.py
@@ -60,6 +60,7 @@ LABELS = {
     "ja": {
         "nav_aria": "メインナビゲーション",
         "tabs_aria": "サイト内タブ",
+        "footer_aria": "サイト内リンク",
         "switch_aria": "サイトを切り替える",
         "brand": "ポケふた",
         "site_dex": "図鑑",
@@ -79,6 +80,7 @@ LABELS = {
     "en": {
         "nav_aria": "Main navigation",
         "tabs_aria": "Site tabs",
+        "footer_aria": "Site links",
         "switch_aria": "Switch site",
         "brand": "Pokéfuta",
         "site_dex": "Directory",
@@ -98,6 +100,7 @@ LABELS = {
     "zh-TW": {
         "nav_aria": "主導覽",
         "tabs_aria": "網站分頁",
+        "footer_aria": "站內連結",
         "switch_aria": "切換網站",
         "brand": "寶可夢人孔蓋",
         "site_dex": "圖鑑",
@@ -117,6 +120,7 @@ LABELS = {
     "zh-CN": {
         "nav_aria": "主导航",
         "tabs_aria": "网站标签",
+        "footer_aria": "站内链接",
         "switch_aria": "切换网站",
         "brand": "宝可梦井盖",
         "site_dex": "图鉴",
@@ -136,6 +140,7 @@ LABELS = {
     "ko": {
         "nav_aria": "메인 내비게이션",
         "tabs_aria": "사이트 탭",
+        "footer_aria": "사이트 링크",
         "switch_aria": "사이트 전환",
         "brand": "포켓뚜껑",
         "site_dex": "도감",
@@ -206,11 +211,13 @@ BOTTOM_TABS_TEMPLATE = """<nav class="site-tabs" aria-label="{tabs_aria}">
 # 全画面地図ページ（map.html / gmanhole_map.html）は本文がビューポート固定で
 # フッターに到達できないため、同じ3つをスイッチャーのメニューにも常設している。
 # どちらか片方だけ消さないこと。
-FOOTER_TEMPLATE = """<footer class="site-footer">
+# ⚠️ <footer> にしないこと。既存ページが <footer role="contentinfo"> を持っており、
+# ラベルの無い contentinfo が2つになる。中身はリンク一覧なので nav が正しい。
+FOOTER_TEMPLATE = """<nav class="site-footer" aria-label="{footer_aria}">
   <a class="site-footer__link" href="{asset_base}character_manholes.html">{nav_character}</a>
   <a class="site-footer__link" href="{about_url}">{about}</a>
   <a class="site-footer__link" href="{x_url}" target="_blank" rel="noopener noreferrer"><b>X</b> @pokemonmanhole</a>
-</footer>"""
+</nav>"""
 
 
 LEGACY_HEADER_RE = re.compile(r'<header\s+class="top-app-bar"[^>]*>.*?</header>', flags=re.DOTALL)

--- a/apps/scraper/inject_site_header.py
+++ b/apps/scraper/inject_site_header.py
@@ -1,5 +1,18 @@
 #!/usr/bin/env python3
-"""Inject the shared navigation header into every generated site page."""
+"""Inject the shared navigation chrome (header + bottom tabs) into every page.
+
+pokefuta.com（写真館）と同じクロムを図鑑側にも出すための注入スクリプト。
+写真館側の実装は `nishiokya/pokefuta` の `src/components/SiteChrome.tsx`、
+色・寸法の正は同リポジトリの `src/app/site-chrome-tokens.css`。
+
+構成（2026-08-08 の統一方針にあわせて再構成）:
+  - PC (>=1024px): ベージュのバー1本。サイトスイッチャー + ナビ + Info/X + 認証
+  - SP (<1024px) : クリームの sticky バー（ロゴ・サイト名・認証の3要素のみ）
+                   ＋ 画面下のタブ。Info/X/キャラ蓋 は本文末尾のフッターへ
+
+以前は SP でもヘッダーに5項目を詰め込み、タップ領域を32px・文字11pxまで
+潰していた。ヘッダーに要素を足すときは下タブかフッターに逃がせないか先に考えること。
+"""
 
 from __future__ import annotations
 
@@ -10,46 +23,185 @@ from pathlib import Path
 
 
 STYLESHEET_TEMPLATE = '<link rel="stylesheet" href="{asset_base}assets/site-header.css">'
+SESSION_BADGE_SCRIPT_TEMPLATE = '<script src="{asset_base}assets/session-badge.js" defer></script>'
+
+POKEFUTA_APP_URL = "https://pokefuta.com/"
+POKEFUTA_LOGIN_URL = "https://pokefuta.com/login?from=data"
+POKEFUTA_PROFILE_URL = "https://pokefuta.com/profile"
+POKEFUTA_ABOUT_URL = "https://pokefuta.com/about"
+X_ACCOUNT_URL = "https://x.com/pokemonmanhole"
+
+# lucide-react 0.294 系（写真館が使っているもの）と同じ字形を inline SVG で持つ。
+# アイコンの言語を両サイトで揃えるため、勝手に別のアイコンへ差し替えないこと。
+ICONS = {
+    "map": '<polygon points="1 6 1 22 8 18 16 22 23 18 23 2 16 6 8 2 1 6"/><line x1="8" y1="2" x2="8" y2="18"/><line x1="16" y1="6" x2="16" y2="22"/>',
+    "pokemon": '<rect width="7" height="7" x="3" y="3" rx="1"/><rect width="7" height="7" x="14" y="3" rx="1"/><rect width="7" height="7" x="14" y="14" rx="1"/><rect width="7" height="7" x="3" y="14" rx="1"/>',
+    "summary": '<path d="M3 3v18h18"/><path d="M18 17V9"/><path d="M13 17V5"/><path d="M8 17v-3"/>',
+    # スタンプ帳は写真館の下タブと同じ CircleDot。両サイトで同じ意味に固定する
+    "stamp": '<circle cx="12" cy="12" r="10"/><circle cx="12" cy="12" r="1"/>',
+    "info": '<circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/>',
+}
+
+
+def _icon(name: str) -> str:
+    return (
+        '<svg class="site-tab__icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" '
+        f'stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">{ICONS[name]}</svg>'
+    )
+
+
+LABELS = {
+    "ja": {
+        "nav_aria": "メインナビゲーション",
+        "tabs_aria": "サイト内タブ",
+        "switch_aria": "サイトを切り替える",
+        "brand": "ポケふた",
+        "site_dex": "図鑑",
+        "site_dex_sub": "調べる・探す",
+        "site_album": "写真館",
+        "site_album_sub": "撮る・記録する",
+        "nav_map": "地図",
+        "nav_pokemon": "ポケモン",
+        "nav_summary": "集計",
+        "nav_character": "キャラ蓋",
+        "tab_stamp": "スタンプ帳",
+        "login": "ログイン",
+        "signup": "新規登録",
+        "profile": "プロフィール",
+        "about": "このサイトについて",
+    },
+    "en": {
+        "nav_aria": "Main navigation",
+        "tabs_aria": "Site tabs",
+        "switch_aria": "Switch site",
+        "brand": "Pokéfuta",
+        "site_dex": "Directory",
+        "site_dex_sub": "Look up & explore",
+        "site_album": "Album",
+        "site_album_sub": "Shoot & record",
+        "nav_map": "Map",
+        "nav_pokemon": "Pokémon",
+        "nav_summary": "Stats",
+        "nav_character": "Characters",
+        "tab_stamp": "Stamps",
+        "login": "Login",
+        "signup": "Sign up",
+        "profile": "Profile",
+        "about": "About this site",
+    },
+    "zh-TW": {
+        "nav_aria": "主導覽",
+        "tabs_aria": "網站分頁",
+        "switch_aria": "切換網站",
+        "brand": "寶可夢人孔蓋",
+        "site_dex": "圖鑑",
+        "site_dex_sub": "查詢與探索",
+        "site_album": "相館",
+        "site_album_sub": "拍攝與記錄",
+        "nav_map": "地圖",
+        "nav_pokemon": "神奇寶貝",
+        "nav_summary": "統計",
+        "nav_character": "角色蓋",
+        "tab_stamp": "集章冊",
+        "login": "登入",
+        "signup": "註冊",
+        "profile": "個人檔案",
+        "about": "關於本站",
+    },
+    "zh-CN": {
+        "nav_aria": "主导航",
+        "tabs_aria": "网站标签",
+        "switch_aria": "切换网站",
+        "brand": "宝可梦井盖",
+        "site_dex": "图鉴",
+        "site_dex_sub": "查询与探索",
+        "site_album": "相馆",
+        "site_album_sub": "拍摄与记录",
+        "nav_map": "地图",
+        "nav_pokemon": "宝可梦",
+        "nav_summary": "统计",
+        "nav_character": "角色盖",
+        "tab_stamp": "集章册",
+        "login": "登录",
+        "signup": "注册",
+        "profile": "个人资料",
+        "about": "关于本站",
+    },
+    "ko": {
+        "nav_aria": "메인 내비게이션",
+        "tabs_aria": "사이트 탭",
+        "switch_aria": "사이트 전환",
+        "brand": "포켓뚜껑",
+        "site_dex": "도감",
+        "site_dex_sub": "찾아보기",
+        "site_album": "사진관",
+        "site_album_sub": "찍고 기록하기",
+        "nav_map": "지도",
+        "nav_pokemon": "포켓몬",
+        "nav_summary": "통계",
+        "nav_character": "캐릭터 맨홀",
+        "tab_stamp": "스탬프북",
+        "login": "로그인",
+        "signup": "가입",
+        "profile": "프로필",
+        "about": "사이트 소개",
+    },
+}
+
+
 HEADER_TEMPLATE = """<header class="site-header">
   <div class="site-header__inner">
-    <a class="site-header__brand" href="{page_base}">
-      <span class="site-header__mark" aria-hidden="true"><span class="site-header__mark-core"></span></span>
-      <span class="site-header__brand-name">ポケふた図鑑</span>
-    </a>
+    <details class="site-switch">
+      <summary class="site-switch__trigger" aria-label="{switch_aria}">
+        <span class="site-header__mark" aria-hidden="true"><span class="site-header__mark-core"></span></span>
+        <span class="site-header__brand-name">{brand}<span class="site-header__brand-sep" aria-hidden="true">｜</span>{site_dex}</span>
+        <span class="site-switch__caret" aria-hidden="true"></span>
+      </summary>
+      <div class="site-switch__menu">
+        <a class="site-switch__item" href="{app_url}"><b>{site_album}</b><small>{site_album_sub}</small></a>
+        <a class="site-switch__item is-current" aria-current="page" href="{page_base}"><b>{site_dex}</b><small>{site_dex_sub}</small></a>
+      </div>
+    </details>
+
     <nav class="site-header__nav" aria-label="{nav_aria}">
-      <a class="site-header__link" href="{page_base}pokemon/">{nav_pokemon}</a>
-      <a class="site-header__link" href="{page_base}map.html"><span class="site-header__label--desktop">{nav_map}</span><span class="site-header__label--mobile">{nav_map_mobile}</span></a>
-      <a class="site-header__link" href="{page_base}summary/"><span class="site-header__label--desktop">{nav_summary}</span><span class="site-header__label--mobile">{nav_summary_mobile}</span></a>
-      <a class="site-header__link" href="{asset_base}character_manholes.html"><span class="site-header__label--desktop">{nav_character}</span><span class="site-header__label--mobile">{nav_character_mobile}</span></a>
-      <a class="site-header__link site-header__auth-link--desktop" data-login-link data-nav-target="login" data-stamp-page="https://pokefuta.com/" data-stamp-label="{nav_stamp}" href="https://pokefuta.com/login?from=data">{nav_login}</a>
-      <a class="site-header__link site-header__auth-link--mobile" data-login-link data-nav-target="login" data-stamp-page="https://pokefuta.com/" data-stamp-label="{nav_stamp_mobile}" href="https://pokefuta.com/login?from=data">{nav_login}</a>
+      <a class="site-header__link{active_map}" href="{page_base}map.html">{nav_map}</a>
+      <a class="site-header__link{active_pokemon}" href="{page_base}pokemon/">{nav_pokemon}</a>
+      <a class="site-header__link{active_summary}" href="{page_base}summary/">{nav_summary}</a>
+      <a class="site-header__link{active_character}" href="{asset_base}character_manholes.html">{nav_character}</a>
     </nav>
+
+    <a class="site-header__icon" href="{about_url}" title="{about}" aria-label="{about}">{icon_info}</a>
+    <a class="site-header__icon site-header__icon--x" href="{x_url}" target="_blank" rel="noopener noreferrer" title="X @pokemonmanhole" aria-label="X @pokemonmanhole">X</a>
+
+    <div class="site-auth" data-auth-guest>
+      <a class="site-auth__login" data-login-link href="{login_url}">{login}</a>
+      <a class="site-auth__signup" data-login-link href="{login_url}">{signup}</a>
+    </div>
+    <a class="site-auth__user" data-auth-user hidden href="{profile_url}" title="{profile}" aria-label="{profile}">
+      <span class="site-auth__avatar" aria-hidden="true">👤</span><span class="site-auth__name" data-auth-name></span>
+    </a>
   </div>
 </header>"""
-SESSION_BADGE_SCRIPT_TEMPLATE = (
-    '<script src="{asset_base}assets/session-badge.js" defer></script>'
-)
 
-NAV_LABELS = {
-    "ja": ("メインナビゲーション", "マップ", "サマリー", "ポケモン", "キャラマンホール", "スタンプ帳", "ログイン"),
-    "en": ("Main navigation", "Map", "Summary", "Pokémon", "Character Manholes", "Stamp Book", "Login"),
-    "zh-TW": ("主導覽", "地圖", "摘要", "神奇寶貝", "角色人孔蓋", "集章冊", "登入"),
-    "zh-CN": ("主导航", "地图", "摘要", "宝可梦", "角色井盖", "集章册", "登录"),
-    "ko": ("메인 내비게이션", "지도", "요약", "포켓몬", "캐릭터 맨홀", "스탬프북", "로그인"),
-}
 
-NAV_MOBILE_LABELS = {
-    "ja": ("地図", "集計", "キャラ", "スタンプ帳"),
-    "en": ("Map", "Stats", "Characters", "Stamps"),
-    "zh-TW": ("地圖", "統計", "角色", "集章"),
-    "zh-CN": ("地图", "统计", "角色", "集章"),
-    "ko": ("지도", "통계", "캐릭터", "스탬프"),
-}
+BOTTOM_TABS_TEMPLATE = """<nav class="site-tabs" aria-label="{tabs_aria}">
+  <a class="site-tab{active_map}" href="{page_base}map.html">{icon_map}<span>{nav_map}</span></a>
+  <a class="site-tab{active_pokemon}" href="{page_base}pokemon/">{icon_pokemon}<span>{nav_pokemon}</span></a>
+  <a class="site-tab{active_summary}" href="{page_base}summary/">{icon_summary}<span>{nav_summary}</span></a>
+  <a class="site-tab" data-login-link href="{login_url}">{icon_stamp}<span>{tab_stamp}</span></a>
+</nav>"""
 
-LEGACY_HEADER_RE = re.compile(
-    r'<header\s+class="top-app-bar"[^>]*>.*?</header>',
-    flags=re.DOTALL,
-)
+
+# SP ヘッダーから外した導線の受け皿。キャラ蓋はここに残す
+# （LP 新設直後で流入を落としたくないため、SP でも到達できる場所を確保する）
+FOOTER_TEMPLATE = """<footer class="site-footer">
+  <a class="site-footer__link" href="{asset_base}character_manholes.html">{nav_character}</a>
+  <a class="site-footer__link" href="{about_url}">{about}</a>
+  <a class="site-footer__link" href="{x_url}" target="_blank" rel="noopener noreferrer"><b>X</b> @pokemonmanhole</a>
+</footer>"""
+
+
+LEGACY_HEADER_RE = re.compile(r'<header\s+class="top-app-bar"[^>]*>.*?</header>', flags=re.DOTALL)
 
 
 def _prefix(target: Path, parent: Path) -> str:
@@ -59,40 +211,73 @@ def _prefix(target: Path, parent: Path) -> str:
 
 def _language(html: str) -> str:
     match = re.search(r'<html\b[^>]*\blang=["\']([^"\']+)', html, re.IGNORECASE)
-    return match.group(1) if match and match.group(1) in NAV_LABELS else "ja"
+    return match.group(1) if match and match.group(1) in LABELS else "ja"
 
 
-def inject(html: str, asset_base: str = "./", page_base: str | None = None) -> str:
-    """Return HTML with the shared header, or unchanged HTML when unsuitable."""
+def _active_tab(page_path: str | None) -> str | None:
+    """現在地のタブを返す。図鑑にはアクティブ表現が一切無かったので追加した。"""
+    if not page_path:
+        return None
+    normalized = page_path.lstrip("./")
+    if normalized.startswith("map.html"):
+        return "map"
+    if normalized.startswith("pokemon/") or normalized == "pokemon":
+        return "pokemon"
+    if normalized.startswith("summary/") or normalized == "summary":
+        return "summary"
+    if normalized.startswith("character_manholes.html"):
+        return "character"
+    return None
+
+
+def inject(
+    html: str,
+    asset_base: str = "./",
+    page_base: str | None = None,
+    page_path: str | None = None,
+) -> str:
+    """Return HTML with the shared chrome, or unchanged HTML when unsuitable."""
     lower = html.lower()
-    if "<body" not in lower or "http-equiv=\"refresh\"" in lower:
+    if "<body" not in lower or 'http-equiv="refresh"' in lower:
         return html
-    if "class=\"site-header\"" in html:
+    if 'class="site-header"' in html:
         return html
 
     page_base = page_base or asset_base
-    language = _language(html)
-    labels = NAV_LABELS[language]
-    mobile_labels = NAV_MOBILE_LABELS[language]
-    substitutions = dict(
-        zip(
-            ("nav_aria", "nav_map", "nav_summary", "nav_pokemon", "nav_character", "nav_stamp", "nav_login"),
-            labels,
-        )
-    )
-    substitutions.update(
-        zip(
-            ("nav_map_mobile", "nav_summary_mobile", "nav_character_mobile", "nav_stamp_mobile"),
-            mobile_labels,
-        )
-    )
-    stylesheet = STYLESHEET_TEMPLATE.format(asset_base=asset_base)
-    header = HEADER_TEMPLATE.format(asset_base=asset_base, page_base=page_base, **substitutions)
-    if "session-badge.js" not in html:
-        header += "\n" + SESSION_BADGE_SCRIPT_TEMPLATE.format(asset_base=asset_base)
+    labels = LABELS[_language(html)]
+    active = _active_tab(page_path)
 
+    fields = dict(labels)
+    fields.update(
+        asset_base=asset_base,
+        page_base=page_base,
+        app_url=POKEFUTA_APP_URL,
+        login_url=POKEFUTA_LOGIN_URL,
+        profile_url=POKEFUTA_PROFILE_URL,
+        about_url=POKEFUTA_ABOUT_URL,
+        x_url=X_ACCOUNT_URL,
+        icon_info=_icon("info"),
+        icon_map=_icon("map"),
+        icon_pokemon=_icon("pokemon"),
+        icon_summary=_icon("summary"),
+        icon_stamp=_icon("stamp"),
+        active_map=" is-active" if active == "map" else "",
+        active_pokemon=" is-active" if active == "pokemon" else "",
+        active_summary=" is-active" if active == "summary" else "",
+        active_character=" is-active" if active == "character" else "",
+    )
+
+    header = HEADER_TEMPLATE.format(**fields)
+    tabs = BOTTOM_TABS_TEMPLATE.format(**fields)
+    footer = FOOTER_TEMPLATE.format(**fields)
+
+    stylesheet = STYLESHEET_TEMPLATE.format(asset_base=asset_base)
     if stylesheet not in html:
         html = html.replace("</head>", f"  {stylesheet}\n</head>", 1)
+
+    script = ""
+    if "session-badge.js" not in html:
+        script = "\n" + SESSION_BADGE_SCRIPT_TEMPLATE.format(asset_base=asset_base)
 
     body_start = html.lower().find("<body")
     body_end = html.find(">", body_start)
@@ -102,6 +287,15 @@ def inject(html: str, asset_base: str = "./", page_base: str | None = None) -> s
     else:
         new_body_tag = body_tag[:-1] + ' class="has-site-header">'
     html = html[:body_start] + new_body_tag + html[body_end + 1 :]
+
+    # フッターと下タブは </body> の直前へ。下タブは position:fixed なので
+    # DOM 上の位置は見た目に影響しないが、読み上げ順は本文のあとにする
+    trailing = f"\n{footer}\n{tabs}{script}\n"
+    body_close = html.lower().rfind("</body>")
+    if body_close == -1:
+        html = html + trailing
+    else:
+        html = html[:body_close] + trailing + html[body_close:]
 
     if LEGACY_HEADER_RE.search(html):
         return LEGACY_HEADER_RE.sub(header, html, count=1)
@@ -122,7 +316,8 @@ def main() -> int:
         localized_root = args.root / language if language != "ja" else args.root
         asset_base = _prefix(args.root, path.parent)
         page_base = _prefix(localized_root, path.parent)
-        result = inject(original, asset_base=asset_base, page_base=page_base)
+        page_path = os.path.relpath(path, localized_root).replace(os.sep, "/")
+        result = inject(original, asset_base=asset_base, page_base=page_base, page_path=page_path)
         if result != original:
             path.write_text(result, encoding="utf-8")
             updated += 1

--- a/apps/scraper/inject_site_header.py
+++ b/apps/scraper/inject_site_header.py
@@ -165,7 +165,7 @@ HEADER_TEMPLATE = """<header class="site-header">
       </summary>
       <div class="site-switch__menu">
         <a class="site-switch__item" href="{app_url}"><b>{site_album}</b><small>{site_album_sub}</small></a>
-        <a class="site-switch__item is-current" aria-current="page" href="{page_base}"><b>{site_dex}</b><small>{site_dex_sub}</small></a>
+        <a class="site-switch__item is-current" aria-current="true" href="{page_base}"><b>{site_dex}</b><small>{site_dex_sub}</small></a>
         <hr class="site-switch__sep">
         <a class="site-switch__sub" href="{asset_base}character_manholes.html">{nav_character}</a>
         <a class="site-switch__sub" href="{about_url}">{about}</a>

--- a/apps/scraper/inject_site_header.py
+++ b/apps/scraper/inject_site_header.py
@@ -29,7 +29,9 @@ SESSION_BADGE_SCRIPT_TEMPLATE = '<script src="{asset_base}assets/session-badge.j
 # 同一GA4プロパティ内の内部UTMは使わず、着地側の source_app=tracker /
 # p_data_referral と突き合わせて分析するため、これが唯一の流入元マーカーになる。
 POKEFUTA_APP_URL = "https://pokefuta.com/?from=data"
-POKEFUTA_LOGIN_URL = "https://pokefuta.com/login?from=data"
+POKEFUTA_LOGIN_URL = "https://pokefuta.com/login?from=data&mode=login"
+# ラベルが「新規登録」なのにログインタブが開かないよう、初期タブを明示する
+POKEFUTA_SIGNUP_URL = "https://pokefuta.com/login?from=data&mode=signup"
 POKEFUTA_STAMP_URL = "https://pokefuta.com/visits?from=data"
 POKEFUTA_PROFILE_URL = "https://pokefuta.com/profile?from=data"
 POKEFUTA_ABOUT_URL = "https://pokefuta.com/about?from=data"
@@ -164,6 +166,10 @@ HEADER_TEMPLATE = """<header class="site-header">
       <div class="site-switch__menu">
         <a class="site-switch__item" href="{app_url}"><b>{site_album}</b><small>{site_album_sub}</small></a>
         <a class="site-switch__item is-current" aria-current="page" href="{page_base}"><b>{site_dex}</b><small>{site_dex_sub}</small></a>
+        <hr class="site-switch__sep">
+        <a class="site-switch__sub" href="{asset_base}character_manholes.html">{nav_character}</a>
+        <a class="site-switch__sub" href="{about_url}">{about}</a>
+        <a class="site-switch__sub" href="{x_url}" target="_blank" rel="noopener noreferrer">X @pokemonmanhole</a>
       </div>
     </details>
 
@@ -179,7 +185,7 @@ HEADER_TEMPLATE = """<header class="site-header">
 
     <div class="site-auth" data-auth-guest>
       <a class="site-auth__login" data-login-link href="{login_url}">{login}</a>
-      <a class="site-auth__signup" data-login-link href="{login_url}">{signup}</a>
+      <a class="site-auth__signup" data-login-link href="{signup_url}">{signup}</a>
     </div>
     <a class="site-auth__user" data-auth-user hidden href="{profile_url}" title="{profile}" aria-label="{profile}">
       <span class="site-auth__avatar" aria-hidden="true">👤</span><span class="site-auth__name" data-auth-name></span>
@@ -196,8 +202,10 @@ BOTTOM_TABS_TEMPLATE = """<nav class="site-tabs" aria-label="{tabs_aria}">
 </nav>"""
 
 
-# SP ヘッダーから外した導線の受け皿。キャラ蓋はここに残す
-# （LP 新設直後で流入を落としたくないため、SP でも到達できる場所を確保する）
+# SP ヘッダーから外した導線の受け皿。
+# 全画面地図ページ（map.html / gmanhole_map.html）は本文がビューポート固定で
+# フッターに到達できないため、同じ3つをスイッチャーのメニューにも常設している。
+# どちらか片方だけ消さないこと。
 FOOTER_TEMPLATE = """<footer class="site-footer">
   <a class="site-footer__link" href="{asset_base}character_manholes.html">{nav_character}</a>
   <a class="site-footer__link" href="{about_url}">{about}</a>
@@ -257,6 +265,7 @@ def inject(
         page_base=page_base,
         app_url=POKEFUTA_APP_URL,
         login_url=POKEFUTA_LOGIN_URL,
+        signup_url=POKEFUTA_SIGNUP_URL,
         stamp_url=POKEFUTA_STAMP_URL,
         profile_url=POKEFUTA_PROFILE_URL,
         about_url=POKEFUTA_ABOUT_URL,

--- a/apps/scraper/test_inject_site_header.py
+++ b/apps/scraper/test_inject_site_header.py
@@ -11,30 +11,87 @@ SPEC.loader.exec_module(header)
 
 inject = header.inject
 
+BARE = "<!doctype html><html><head></head><body><main></main></body></html>"
+
 
 class InjectSiteHeaderTest(unittest.TestCase):
-    def test_injects_header_stylesheet_and_body_class(self):
-        result = inject("<!doctype html><html><head></head><body><main></main></body></html>")
+    def test_injects_stylesheet_header_tabs_and_body_class(self):
+        result = inject(BARE)
         self.assertIn('href="./assets/site-header.css"', result)
         self.assertIn('class="site-header"', result)
+        self.assertIn('class="site-tabs"', result)
+        self.assertIn('class="site-footer"', result)
+        self.assertIn('<body class="has-site-header">', result)
+
         mark = re.search(r'<span[^>]*class="site-header__mark"[^>]*>', result)
         self.assertIsNotNone(mark)
         self.assertIn('aria-hidden="true"', mark.group(0))
-        self.assertIn('class="site-header__brand-name">ポケふた図鑑</span>', result)
         self.assertNotIn("DATABASE", result)
-        pokemon_pos = result.index('href="./pokemon/">ポケモン</a>')
-        map_pos = result.index('href="./map.html">')
-        summary_pos = result.index('href="./summary/">')
-        character_pos = result.index('href="./character_manholes.html">')
-        self.assertLess(pokemon_pos, map_pos)
-        self.assertLess(map_pos, summary_pos)
-        self.assertLess(summary_pos, character_pos)
-        self.assertIn('class="site-header__label--desktop">サマリー</span>', result)
-        self.assertIn('class="site-header__label--mobile">地図</span>', result)
-        self.assertIn('class="site-header__label--mobile">集計</span>', result)
-        self.assertIn('class="site-header__label--mobile">キャラ</span>', result)
-        self.assertIn('data-stamp-label="スタンプ帳"', result)
-        self.assertIn('<body class="has-site-header">', result)
+
+    def test_pc_nav_order(self):
+        result = inject(BARE)
+        positions = [
+            result.index('href="./map.html">地図</a>'),
+            result.index('href="./pokemon/">ポケモン</a>'),
+            result.index('href="./summary/">集計</a>'),
+            result.index('href="./character_manholes.html">キャラ蓋</a>'),
+        ]
+        self.assertEqual(positions, sorted(positions))
+
+    # ── サイトスイッチャー ────────────────────────────────
+
+    def test_brand_is_a_site_switcher(self):
+        result = inject(BARE)
+        self.assertIn('<details class="site-switch">', result)
+        self.assertIn('class="site-header__brand-name">ポケふた', result)
+        self.assertIn(">図鑑</span>", result)
+        # 写真館へ渡る導線が図鑑側にも必ずあること（従来は片方向だった）
+        self.assertIn('href="https://pokefuta.com/"><b>写真館</b>', result)
+        self.assertIn('aria-current="page"', result)
+
+    # ── 下タブ ───────────────────────────────────────────
+
+    def test_bottom_tabs_match_photo_site_roles(self):
+        """左2つが探す系、右端がサイトをまたぐ導線、という並びを写真館と揃える。"""
+        result = inject(BARE)
+        tabs = re.findall(r'<a class="site-tab[^"]*"[^>]*>.*?<span>([^<]+)</span>', result, re.DOTALL)
+        self.assertEqual(tabs, ["地図", "ポケモン", "集計", "スタンプ帳"])
+        self.assertIn('data-login-link href="https://pokefuta.com/login?from=data"', result)
+
+    def test_marks_active_tab_from_page_path(self):
+        """図鑑にはアクティブ表現が一切無かったので、現在地を出せることを固定する。"""
+        result = inject(BARE, page_path="summary/index.html")
+        self.assertIn('<a class="site-header__link is-active" href="./summary/">', result)
+        self.assertIn('<a class="site-tab is-active" href="./summary/">', result)
+        # 他のタブまで active にしない
+        self.assertEqual(result.count("is-active"), 2)
+
+    def test_no_active_marker_for_unknown_page(self):
+        result = inject(BARE, page_path="manholes/482/index.html")
+        self.assertNotIn("is-active", result)
+
+    # ── 認証 ─────────────────────────────────────────────
+
+    def test_auth_is_separate_from_navigation(self):
+        """認証ピルとナビ項目を分離したこと（ラベルが化けないこと）を固定する。"""
+        result = inject(BARE)
+        self.assertIn("data-auth-guest", result)
+        self.assertIn("data-auth-user", result)
+        self.assertIn("data-auth-name", result)
+        self.assertIn(">ログイン</a>", result)
+        self.assertIn(">新規登録</a>", result)
+        self.assertIn('href="https://pokefuta.com/profile"', result)
+        # 旧実装の「ログインボタンがスタンプ帳に化ける」属性は残さない
+        self.assertNotIn("data-stamp-label", result)
+        self.assertNotIn("data-stamp-page", result)
+        self.assertIn('<script src="./assets/session-badge.js" defer></script>', result)
+
+    def test_info_and_x_links(self):
+        result = inject(BARE)
+        self.assertIn('href="https://pokefuta.com/about"', result)
+        self.assertIn('href="https://x.com/pokemonmanhole"', result)
+
+    # ── 既存の振る舞い ───────────────────────────────────
 
     def test_preserves_existing_body_classes(self):
         result = inject('<html><head></head><body class="map-page"></body></html>')
@@ -55,47 +112,50 @@ class InjectSiteHeaderTest(unittest.TestCase):
 </body></html>"""
         result = inject(legacy)
         self.assertIn('href="./assets/site-header.css"', result)
-        self.assertIn('class="site-header"', result)
-        self.assertEqual(result.count('data-stamp-page="https://pokefuta.com/"'), 2)
-        self.assertNotIn('data-profile-page=', result)
-        self.assertIn('data-stamp-label="スタンプ帳"', result)
-        self.assertIn('data-nav-target="login"', result)
-        self.assertNotIn("https://pokefuta.com/visits", result)
-        self.assertNotIn("https://pokefuta.com/profile", result)
         self.assertIn('<body class="has-site-header top-page">', result)
         self.assertNotIn("top-app-bar", result)
         self.assertNotIn("ページ固有ヘッダー", result)
         self.assertEqual(result.count('class="site-header"'), 1)
+        self.assertEqual(result.count('class="site-tabs"'), 1)
         self.assertEqual(result.count("session-badge.js"), 1)
 
     def test_skips_redirect_documents(self):
         redirect = '<!doctype html><meta http-equiv="refresh" content="0; url=/">'
         self.assertEqual(inject(redirect), redirect)
 
+    def test_chrome_goes_before_body_close(self):
+        result = inject(BARE)
+        self.assertLess(result.index('class="site-footer"'), result.index("</body>"))
+        self.assertLess(result.index('class="site-tabs"'), result.index("</body>"))
+        self.assertLess(result.index("<main>"), result.index('class="site-tabs"'))
+
     def test_uses_relative_paths_for_nested_localized_page(self):
         html = '<html lang="en"><head></head><body></body></html>'
         result = inject(html, asset_base="../../../", page_base="../../")
         self.assertIn('href="../../../assets/site-header.css"', result)
-        self.assertIn('href="../../map.html"><span class="site-header__label--desktop">Map</span><span class="site-header__label--mobile">Map</span></a>', result)
-        self.assertIn('href="../../summary/"><span class="site-header__label--desktop">Summary</span><span class="site-header__label--mobile">Stats</span></a>', result)
+        self.assertIn('href="../../map.html">Map</a>', result)
+        self.assertIn('href="../../summary/">Stats</a>', result)
         self.assertIn('href="../../pokemon/">Pokémon</a>', result)
-        self.assertIn('href="../../../character_manholes.html"><span class="site-header__label--desktop">Character Manholes</span><span class="site-header__label--mobile">Characters</span></a>', result)
-        self.assertEqual(result.count('data-stamp-page="https://pokefuta.com/"'), 2)
-        self.assertNotIn('data-profile-page=', result)
-        self.assertIn('data-stamp-label="Stamp Book"', result)
-        self.assertIn('href="https://pokefuta.com/login?from=data">Login</a>', result)
+        self.assertIn('href="../../../character_manholes.html">Characters</a>', result)
         self.assertIn('src="../../../assets/session-badge.js"', result)
-        self.assertEqual(result.count('class="site-header__link"'), 4)
-        self.assertEqual(result.count('site-header__auth-link--desktop'), 1)
-        self.assertEqual(result.count('site-header__auth-link--mobile'), 1)
+        self.assertIn(">Login</a>", result)
+        self.assertIn(">Sign up</a>", result)
+        self.assertIn("<b>Album</b>", result)
+        self.assertEqual(result.count('class="site-header__link'), 4)
 
-    def test_injects_login_link_for_japanese_page(self):
-        result = inject("<!doctype html><html><head></head><body><main></main></body></html>")
-        self.assertEqual(result.count('data-stamp-page="https://pokefuta.com/"'), 2)
-        self.assertNotIn('data-profile-page=', result)
-        self.assertIn('href="https://pokefuta.com/login?from=data">ログイン</a>', result)
-        self.assertNotIn("https://pokefuta.com/visits", result)
-        self.assertIn('<script src="./assets/session-badge.js" defer></script>', result)
+    def test_every_language_has_the_same_label_keys(self):
+        """翻訳漏れがあると .format() が KeyError で落ちるので先に検知する。"""
+        expected = set(header.LABELS["ja"])
+        for language, labels in header.LABELS.items():
+            self.assertEqual(set(labels), expected, f"{language} のラベルが不足/余分")
+
+    def test_injects_for_every_supported_language(self):
+        for language in header.LABELS:
+            with self.subTest(language=language):
+                html = f'<html lang="{language}"><head></head><body></body></html>'
+                result = inject(html)
+                self.assertIn('class="site-header"', result)
+                self.assertIn('class="site-tabs"', result)
 
 
 if __name__ == "__main__":

--- a/apps/scraper/test_inject_site_header.py
+++ b/apps/scraper/test_inject_site_header.py
@@ -30,6 +30,9 @@ class InjectSiteHeaderTest(unittest.TestCase):
 
     def test_pc_nav_order(self):
         result = inject(BARE)
+        # スイッチャーのメニューにも同じ href が出るので、ナビの中だけを見る
+        nav = re.search(r'<nav class="site-header__nav".*?</nav>', result, re.DOTALL).group(0)
+        result = nav
         positions = [
             result.index('href="./map.html">地図</a>'),
             result.index('href="./pokemon/">ポケモン</a>'),
@@ -65,17 +68,36 @@ class InjectSiteHeaderTest(unittest.TestCase):
         # 内部UTMは使わない
         self.assertNotIn("utm_", result)
 
-    def test_logged_in_stamp_tab_targets_the_stamp_book(self):
-        """ログイン中にスタンプ帳タブがログイン画面へ飛ばないこと。"""
+    def test_stamp_tab_targets_the_stamp_book(self):
+        """スタンプ帳タブの行き先。
+
+        ログイン中は直接スタンプ帳へ。未ログインでも session-badge.js が
+        redirect にスタンプ帳を積むので、ログイン後にそのまま辿り着く
+        （現在の図鑑ページを積むと、もう一度タップさせることになる）。
+        """
         result = inject(BARE)
         self.assertIn('data-stamp-page="https://pokefuta.com/visits?from=data"', result)
+
+    def test_signup_opens_the_signup_tab(self):
+        """ラベルが「新規登録」なのにログインタブが開く、を防ぐ。"""
+        result = inject(BARE)
+        self.assertIn('href="https://pokefuta.com/login?from=data&mode=signup">新規登録</a>', result)
+        self.assertIn('href="https://pokefuta.com/login?from=data&mode=login">ログイン</a>', result)
+
+    def test_map_only_links_are_reachable_from_the_switcher(self):
+        """全画面地図ページはフッターに到達できないので、同じ導線をメニューにも常設する。"""
+        result = inject(BARE)
+        menu = result[result.index('site-switch__menu'):result.index("</details>")]
+        self.assertIn("キャラ蓋", menu)
+        self.assertIn("https://pokefuta.com/about?from=data", menu)
+        self.assertIn("https://x.com/pokemonmanhole", menu)
 
     def test_bottom_tabs_match_photo_site_roles(self):
         """左2つが探す系、右端がサイトをまたぐ導線、という並びを写真館と揃える。"""
         result = inject(BARE)
         tabs = re.findall(r'<a class="site-tab[^"]*"[^>]*>.*?<span>([^<]+)</span>', result, re.DOTALL)
         self.assertEqual(tabs, ["地図", "ポケモン", "集計", "スタンプ帳"])
-        self.assertIn('data-login-link href="https://pokefuta.com/login?from=data"', result)
+        self.assertIn('data-login-link data-stamp-page="https://pokefuta.com/visits?from=data"', result)
 
     def test_marks_active_tab_from_page_path(self):
         """図鑑にはアクティブ表現が一切無かったので、現在地を出せることを固定する。"""

--- a/apps/scraper/test_inject_site_header.py
+++ b/apps/scraper/test_inject_site_header.py
@@ -46,10 +46,29 @@ class InjectSiteHeaderTest(unittest.TestCase):
         self.assertIn('class="site-header__brand-name">ポケふた', result)
         self.assertIn(">図鑑</span>", result)
         # 写真館へ渡る導線が図鑑側にも必ずあること（従来は片方向だった）
-        self.assertIn('href="https://pokefuta.com/"><b>写真館</b>', result)
+        self.assertIn('href="https://pokefuta.com/?from=data"><b>写真館</b>', result)
         self.assertIn('aria-current="page"', result)
 
     # ── 下タブ ───────────────────────────────────────────
+
+    def test_all_app_links_carry_the_referral_marker(self):
+        """pokefuta.com への導線は必ず from=data を付ける（AGENTS.md）。
+
+        都道府県ページからの流入もこのクロム経由になるため、1つでも欠けると
+        着地側の source_app=tracker / p_data_referral と突き合わせられなくなる。
+        """
+        result = inject(BARE)
+        links = re.findall(r'href="(https://pokefuta\.com[^"]*)"', result)
+        self.assertTrue(links)
+        for link in links:
+            self.assertIn("from=data", link, f"from=data が無い: {link}")
+        # 内部UTMは使わない
+        self.assertNotIn("utm_", result)
+
+    def test_logged_in_stamp_tab_targets_the_stamp_book(self):
+        """ログイン中にスタンプ帳タブがログイン画面へ飛ばないこと。"""
+        result = inject(BARE)
+        self.assertIn('data-stamp-page="https://pokefuta.com/visits?from=data"', result)
 
     def test_bottom_tabs_match_photo_site_roles(self):
         """左2つが探す系、右端がサイトをまたぐ導線、という並びを写真館と揃える。"""
@@ -80,15 +99,18 @@ class InjectSiteHeaderTest(unittest.TestCase):
         self.assertIn("data-auth-name", result)
         self.assertIn(">ログイン</a>", result)
         self.assertIn(">新規登録</a>", result)
-        self.assertIn('href="https://pokefuta.com/profile"', result)
-        # 旧実装の「ログインボタンがスタンプ帳に化ける」属性は残さない
+        self.assertIn('href="https://pokefuta.com/profile?from=data"', result)
+        # 旧実装の「ログインボタンのラベルがスタンプ帳に化ける」は復活させない。
+        # data-stamp-page（遷移先の差し替え）はナビ項目に必要なので残るが、
+        # data-stamp-label（ラベルの差し替え）が戻ってきたらこのテストで落とす。
         self.assertNotIn("data-stamp-label", result)
-        self.assertNotIn("data-stamp-page", result)
+        # 認証ピル自体はラベル差し替えの対象にしない
+        self.assertNotIn("data-stamp-page", result[result.index('class="site-auth"'):result.index("</header>")])
         self.assertIn('<script src="./assets/session-badge.js" defer></script>', result)
 
     def test_info_and_x_links(self):
         result = inject(BARE)
-        self.assertIn('href="https://pokefuta.com/about"', result)
+        self.assertIn('href="https://pokefuta.com/about?from=data"', result)
         self.assertIn('href="https://x.com/pokemonmanhole"', result)
 
     # ── 既存の振る舞い ───────────────────────────────────

--- a/apps/scraper/test_inject_site_header.py
+++ b/apps/scraper/test_inject_site_header.py
@@ -50,7 +50,10 @@ class InjectSiteHeaderTest(unittest.TestCase):
         self.assertIn(">図鑑</span>", result)
         # 写真館へ渡る導線が図鑑側にも必ずあること（従来は片方向だった）
         self.assertIn('href="https://pokefuta.com/?from=data"><b>写真館</b>', result)
-        self.assertIn('aria-current="page"', result)
+        # 図鑑ホームへのリンクは「いま図鑑にいる」というサイト単位の現在地。
+        # 図鑑内のどのページでも付くので page は使わない
+        self.assertIn('aria-current="true"', result)
+        self.assertNotIn('aria-current="page"', result)
 
     # ── 下タブ ───────────────────────────────────────────
 

--- a/apps/scraper/test_inject_site_header.py
+++ b/apps/scraper/test_inject_site_header.py
@@ -133,6 +133,13 @@ class InjectSiteHeaderTest(unittest.TestCase):
         self.assertNotIn("data-stamp-page", result[result.index('class="site-auth"'):result.index("</header>")])
         self.assertIn('<script src="./assets/session-badge.js" defer></script>', result)
 
+    def test_footer_is_not_a_second_contentinfo(self):
+        """既存ページは <footer role="contentinfo"> を持つ。注入分を <footer> にすると
+        ラベルの無い contentinfo が2つになるので、中身に合わせて nav にする。"""
+        result = inject(BARE)
+        self.assertIn('<nav class="site-footer" aria-label="サイト内リンク">', result)
+        self.assertNotIn('<footer class="site-footer"', result)
+
     def test_info_and_x_links(self):
         result = inject(BARE)
         self.assertIn('href="https://pokefuta.com/about?from=data"', result)

--- a/apps/scraper/test_site_header_css.py
+++ b/apps/scraper/test_site_header_css.py
@@ -1,0 +1,107 @@
+"""site-header.css がトークンから外れていないかを検査する。
+
+色・寸法の正は写真館（nishiokya/pokefuta）の `src/app/site-chrome-tokens.css`。
+図鑑側はその値を `:root` にコピーして使う。
+
+以前は「写真館の実測px を site-header.css に書き写す」運用で、写真館側を
+変更するたびに図鑑側が黙って取り残されていた。リポジトリが別なのでビルド時に
+値を突き合わせることはできないが、**コピーした値を使わず生の hex / px を
+書き足す**という実際の壊れ方はここで検知できる。
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+CSS_PATH = Path(__file__).resolve().parents[1] / "web" / "assets" / "site-header.css"
+
+ROOT_BLOCK_RE = re.compile(r":root\s*\{(.*?)\}", re.DOTALL)
+DECLARATION_RE = re.compile(r"(--[\w-]+)\s*:\s*([^;]+);")
+HEX_RE = re.compile(r"#[0-9a-fA-F]{3,8}\b")
+PX_RE = re.compile(r"\b\d+(?:\.\d+)?px\b")
+
+# 寸法トークンのうち、値の偶然一致が起きにくく直書きを禁じたいもの
+SIZE_TOKENS = {"--chrome-height", "--chrome-tap-min", "--chrome-bottomnav-height"}
+
+
+def _css() -> str:
+    return CSS_PATH.read_text(encoding="utf-8")
+
+
+def _tokens(css: str) -> dict[str, str]:
+    tokens: dict[str, str] = {}
+    for block in ROOT_BLOCK_RE.findall(css):
+        for name, value in DECLARATION_RE.findall(block):
+            tokens[name] = value.strip()
+    return tokens
+
+
+def _css_without_root_blocks(css: str) -> str:
+    return ROOT_BLOCK_RE.sub("", css)
+
+
+class SiteHeaderTokenTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.css = _css()
+        self.tokens = _tokens(self.css)
+        self.rules = _css_without_root_blocks(self.css)
+
+    def test_token_block_exists(self):
+        self.assertIn("--chrome-height", self.tokens)
+        self.assertIn("--chrome-tap-min", self.tokens)
+        self.assertIn("--chrome-accent", self.tokens)
+
+    def test_no_raw_token_values_outside_root(self):
+        """トークンと同じ値を var() を使わず直書きしていないこと。
+
+        検査対象は「色」と「バーの寸法」だけに絞る。角丸や余白の px は
+        用途が違っても値が偶然一致する（例: padding 9px と角丸 9px）ので、
+        全 px を対象にすると誤検知でテストが信用されなくなる。
+        実際の壊れ方は #7b63a8 のような色の直書きなので、そこを固く見る。
+        """
+        checked = {
+            name: value
+            for name, value in self.tokens.items()
+            if HEX_RE.fullmatch(value) or name in SIZE_TOKENS
+        }
+        offenders = [
+            f"{value} は var({name}) を使うこと"
+            for name, value in checked.items()
+            if value != "0px" and re.search(rf"(?<![\w-]){re.escape(value)}(?![\w-])", self.rules)
+        ]
+        self.assertEqual(offenders, [], "トークン値の直書きがある: " + "; ".join(offenders))
+
+    def test_every_referenced_token_is_defined(self):
+        referenced = set(re.findall(r"var\((--chrome-[\w-]+)", self.css))
+        missing = sorted(referenced - set(self.tokens))
+        self.assertEqual(missing, [], f"未定義のトークンを参照している: {missing}")
+
+    def test_tap_targets_meet_the_minimum(self):
+        """SP のタップ領域は 44px 以上。以前は 32px / 文字11px まで潰していた。"""
+        self.assertEqual(self.tokens["--chrome-tap-min"], "44px")
+        for selector in (".site-switch__trigger", ".site-auth__login", ".site-auth__signup", ".site-tab", ".site-footer__link"):
+            block = re.search(rf"{re.escape(selector)}\s*(?:,[^{{]*)?\{{(.*?)\}}", self.css, re.DOTALL)
+            self.assertIsNotNone(block, f"{selector} が見つからない")
+            self.assertIn("var(--chrome-tap-min)", block.group(1), f"{selector} に最小タップ領域が無い")
+
+    def test_single_pc_breakpoint(self):
+        """ブレークポイントは 1024px の1本だけ。720px の段は写真館と食い違うので廃止した。"""
+        widths = set(re.findall(r"@media\s*\(\s*(?:min|max)-width:\s*(\d+px)\s*\)", self.css))
+        self.assertEqual(widths, {"1024px", "360px"}, f"想定外のブレークポイント: {sorted(widths)}")
+
+    def test_mark_is_not_hidden_on_mobile(self):
+        """SP でモンスターボールを消すとサイト帯のブランドが SP だけ無くなる。"""
+        for block in re.findall(r"\.site-header__mark\s*\{(.*?)\}", self.css, re.DOTALL):
+            self.assertNotIn("display: none", block)
+
+    def test_full_screen_map_reserves_room_for_both_bars(self):
+        block = re.search(r"\.map-stage[^{]*\{(.*?)\}", self.css, re.DOTALL)
+        self.assertIsNotNone(block)
+        self.assertIn("var(--chrome-height)", block.group(1))
+        self.assertIn("var(--chrome-bottomnav-height)", block.group(1))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/apps/scraper/test_site_header_css.py
+++ b/apps/scraper/test_site_header_css.py
@@ -96,6 +96,19 @@ class SiteHeaderTokenTest(unittest.TestCase):
         for block in re.findall(r"\.site-header__mark\s*\{(.*?)\}", self.css, re.DOTALL):
             self.assertNotIn("display: none", block)
 
+    def test_chrome_outranks_map_overlays(self):
+        """全画面地図のオーバーレイ（.map-hero-card 800 / #controls 1000）より
+        共通クロムを前面に出すこと。共通の z-index 50 のままだとサイトスイッチャーの
+        メニューがヒーローカードの下に潜って押せなくなる。"""
+        for selector in (".site-header", ".site-tabs"):
+            rule = re.search(
+                rf"body\.has-site-header\.pokefuta-map-page {re.escape(selector)}\s*\{{(.*?)\}}",
+                self.css, re.DOTALL)
+            self.assertIsNotNone(rule, f"{selector} の地図ページ用 z-index が無い")
+            z = re.search(r"z-index:\s*(\d+)", rule.group(1))
+            self.assertIsNotNone(z)
+            self.assertGreater(int(z.group(1)), 1000, f"{selector} が地図オーバーレイに負ける")
+
     def test_full_screen_map_reserves_room_for_both_bars(self):
         block = re.search(r"\.map-stage[^{]*\{(.*?)\}", self.css, re.DOTALL)
         self.assertIsNotNone(block)

--- a/apps/scraper/test_site_header_css.py
+++ b/apps/scraper/test_site_header_css.py
@@ -88,8 +88,15 @@ class SiteHeaderTokenTest(unittest.TestCase):
 
     def test_single_pc_breakpoint(self):
         """ブレークポイントは 1024px の1本だけ。720px の段は写真館と食い違うので廃止した。"""
-        widths = set(re.findall(r"@media\s*\(\s*(?:min|max)-width:\s*(\d+px)\s*\)", self.css))
-        self.assertEqual(widths, {"1024px", "360px"}, f"想定外のブレークポイント: {sorted(widths)}")
+        # コメント内にも他ファイルの @media を引用しているので、先に落とす
+        css = re.sub(r"/\*.*?\*/", "", self.css, flags=re.DOTALL)
+        widths = set(re.findall(r"@media\s*\(\s*(?:min|max)-width:\s*([\d.]+px)\s*\)", css))
+        # 759.98px はクロムのレイアウト用ではなく、pokefuta-map.css が
+        # @media (min-width: 760px) でボトムシートをフローティングパネルへ
+        # 切り替える境界に合わせたもの。ここを跨いで打ち消すとPCの地図が壊れる
+        self.assertEqual(
+            widths, {"1024px", "360px", "759.98px"}, f"想定外のブレークポイント: {sorted(widths)}"
+        )
 
     def test_mark_is_not_hidden_on_mobile(self):
         """SP でモンスターボールを消すとサイト帯のブランドが SP だけ無くなる。"""

--- a/apps/web/assets/session-badge.js
+++ b/apps/web/assets/session-badge.js
@@ -126,15 +126,22 @@
 
   function apply() {
     var user = currentUser();
+    var links = document.querySelectorAll('[data-login-link]');
 
-    // 未ログイン時だけ、戻り先を login の redirect パラメータに積む
-    if (!user) {
-      var links = document.querySelectorAll('[data-login-link]');
-      for (var i = 0; i < links.length; i++) {
+    for (var i = 0; i < links.length; i++) {
+      var link = links[i];
+      if (user) {
+        // ログイン中はログイン画面へ送らない。
+        // data-stamp-page を持つナビ項目（下タブのスタンプ帳）は本来の遷移先へ差し替える。
+        // ラベルは書き換えない（認証状態の表示とナビ項目は別物）。
+        var stampPage = link.getAttribute('data-stamp-page');
+        if (stampPage) link.href = stampPage;
+      } else {
+        // 未ログインはログイン後に戻ってこられるよう redirect を積む
         try {
-          var url = new URL(links[i].href);
+          var url = new URL(link.href);
           url.searchParams.set('redirect', location.href);
-          links[i].href = url.toString();
+          link.href = url.toString();
         } catch (_) {
           /* href が不正でも既定のリンク先のまま動く */
         }

--- a/apps/web/assets/session-badge.js
+++ b/apps/web/assets/session-badge.js
@@ -137,10 +137,13 @@
         var stampPage = link.getAttribute('data-stamp-page');
         if (stampPage) link.href = stampPage;
       } else {
-        // 未ログインはログイン後に戻ってこられるよう redirect を積む
+        // 未ログインはログイン後の行き先を redirect に積む。
+        // ナビ項目（data-stamp-page 付き）は「本来行きたかった場所」を積む。
+        // 現在ページを積むとログイン後に図鑑へ戻され、スタンプ帳へ行くのに
+        // もう一度タップさせることになる。
         try {
           var url = new URL(link.href);
-          url.searchParams.set('redirect', location.href);
+          url.searchParams.set('redirect', link.getAttribute('data-stamp-page') || location.href);
           link.href = url.toString();
         } catch (_) {
           /* href が不正でも既定のリンク先のまま動く */

--- a/apps/web/assets/session-badge.js
+++ b/apps/web/assets/session-badge.js
@@ -1,4 +1,4 @@
-// ヘッダーのログインリンクをログイン状態に応じて書き換える。
+// ヘッダーの認証表示をログイン状態に応じて切り替える。
 //
 // pokefuta.com と共有する Supabase セッションクッキー
 // (sb-<ref>-auth-token, Domain=.pokefuta.com) を document.cookie から
@@ -6,10 +6,16 @@
 // （「PV に比例して Supabase を読ませない」方針）。
 // あくまで表示用の判定で、本当の認証はアプリ側のサーバーが行う。
 //
-// 対象要素: <a data-login-link data-stamp-page="..." data-stamp-label="...">
-//  - 未ログイン: href に現在ページへの redirect パラメータを付与
+// 対象要素:
+//  - <div data-auth-guest>   未ログイン時に出す（ログイン / 新規登録）
+//  - <a data-auth-user>      ログイン時に出す（アバター＋表示名 → /profile）
+//    <span data-auth-name>   ここに表示名を入れる
+//  - <a data-login-link>     未ログイン時に href へ redirect パラメータを付ける
 //    （pokefuta.com/login がログイン後にこのページへ戻す）
-//  - ログイン中: 「スタンプ帳」に差し替え、pokefuta.com へリンク
+//
+// 以前は「ログインボタンのラベルをスタンプ帳に差し替える」実装だったが、
+// 認証状態の表示とナビ項目は別物なので分離した（2026-08-08 の統一方針）。
+// スタンプ帳は下タブの項目として常設し、認証ピルは認証だけを表す。
 //
 // cookie は data.pokefuta.com 側の @supabase/ssr object 形式と、
 // pokefuta.com 側の @supabase/auth-helpers-nextjs array 形式の両方を読む。
@@ -104,32 +110,70 @@
     }
   }
 
+  function displayName(user) {
+    if (!user) return '';
+    var meta = user.user_metadata || {};
+    if (meta.display_name) return meta.display_name;
+    if (user.email) return String(user.email).split('@')[0];
+    return 'トレーナー';
+  }
+
+  function setHidden(node, hidden) {
+    if (!node) return;
+    if (hidden) node.setAttribute('hidden', '');
+    else node.removeAttribute('hidden');
+  }
+
   function apply() {
-    var links = document.querySelectorAll('[data-login-link]');
-    if (!links.length) return;
     var user = currentUser();
-    for (var i = 0; i < links.length; i++) {
-      var link = links[i];
-      if (user) {
-        link.textContent = link.getAttribute('data-stamp-label') || 'スタンプ帳';
-        link.setAttribute('data-nav-target', 'stamp');
-        var stampPage = link.getAttribute('data-stamp-page');
-        if (stampPage) link.href = stampPage;
-      } else {
+
+    // 未ログイン時だけ、戻り先を login の redirect パラメータに積む
+    if (!user) {
+      var links = document.querySelectorAll('[data-login-link]');
+      for (var i = 0; i < links.length; i++) {
         try {
-          var url = new URL(link.href);
+          var url = new URL(links[i].href);
           url.searchParams.set('redirect', location.href);
-          link.href = url.toString();
+          links[i].href = url.toString();
         } catch (_) {
           /* href が不正でも既定のリンク先のまま動く */
         }
       }
     }
+
+    // 既定は未ログイン表示。ログインしている場合だけ差し替える
+    var guest = document.querySelector('[data-auth-guest]');
+    var authed = document.querySelector('[data-auth-user]');
+    var nameSlot = document.querySelector('[data-auth-name]');
+    if (nameSlot) nameSlot.textContent = displayName(user);
+    setHidden(guest, Boolean(user));
+    setHidden(authed, !user);
+  }
+
+  // <details> のサイトスイッチャーは外側クリックでは閉じないので面倒を見る。
+  // ここが全ページに載る唯一のスクリプトなので同居させている。
+  function closeSwitchOnOutsideClick() {
+    document.addEventListener('click', function (event) {
+      var open = document.querySelectorAll('details.site-switch[open]');
+      for (var i = 0; i < open.length; i++) {
+        if (!open[i].contains(event.target)) open[i].removeAttribute('open');
+      }
+    });
+    document.addEventListener('keydown', function (event) {
+      if (event.key !== 'Escape') return;
+      var open = document.querySelectorAll('details.site-switch[open]');
+      for (var i = 0; i < open.length; i++) open[i].removeAttribute('open');
+    });
+  }
+
+  function init() {
+    apply();
+    closeSwitchOnOutsideClick();
   }
 
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', apply);
+    document.addEventListener('DOMContentLoaded', init);
   } else {
-    apply();
+    init();
   }
 })();

--- a/apps/web/assets/session-badge.test.js
+++ b/apps/web/assets/session-badge.test.js
@@ -35,7 +35,10 @@ function chrome() {
   const authed = element({ hidden: '' });
   const name = element({});
   const loginLink = element({ 'data-login-link': '' });
-  const stampTab = element({ 'data-login-link': '' });
+  const stampTab = element({
+    'data-login-link': '',
+    'data-stamp-page': 'https://pokefuta.com/visits?from=data',
+  });
 
   const document = {
     cookie: '',
@@ -85,7 +88,10 @@ function run(document) {
   assert.equal(dom.guest.hidden, true, 'ログイン中はログイン/新規登録を隠す');
   // ログイン中はナビ項目のラベルを書き換えない（認証とナビを分離した）
   assert.equal(dom.stampTab.textContent, '');
-  assert.equal(dom.stampTab.href, LOGIN_URL);
+  // ただし遷移先はスタンプ帳へ。ログイン済みなのにログイン画面へ送らない
+  assert.equal(dom.stampTab.href, 'https://pokefuta.com/visits?from=data');
+  // data-stamp-page を持たないリンクはそのまま
+  assert.equal(dom.loginLink.href, LOGIN_URL);
 }
 
 // ── display_name が無ければメールのローカル部を使う ────────

--- a/apps/web/assets/session-badge.test.js
+++ b/apps/web/assets/session-badge.test.js
@@ -7,53 +7,108 @@ const source = fs.readFileSync(path.join(__dirname, 'session-badge.js'), 'utf8')
 // Keep the local browser location isolated from production URL expectations.
 const TEST_BROWSER_ORIGIN = ['http://', 'localhost:8000/'].join('');
 
-function link(attributes) {
+const LOGIN_URL = 'https://pokefuta.com/login?from=data';
+
+function element(attributes) {
   return {
     attributes: { ...attributes },
-    href: 'https://pokefuta.com/login?from=data',
-    textContent: 'ログイン',
+    href: LOGIN_URL,
+    textContent: '',
     getAttribute(name) {
       return this.attributes[name] ?? null;
     },
     setAttribute(name, value) {
       this.attributes[name] = value;
     },
+    removeAttribute(name) {
+      delete this.attributes[name];
+    },
+    get hidden() {
+      return 'hidden' in this.attributes;
+    },
   };
 }
 
-const desktop = link({
-  'data-stamp-page': 'https://pokefuta.com/',
-  'data-stamp-label': 'スタンプ帳',
-});
-const mobile = link({
-  'data-stamp-page': 'https://pokefuta.com/',
-  'data-stamp-label': 'スタンプ帳',
-});
-const session = {
-  user: {
-    id: 'user-1',
-    email: 'fallback@example.com',
-    user_metadata: { display_name: 'たこトレーナー' },
-  },
-};
-const cookie = `sb-kbwzwgsjqvflgfauzcpn-auth-token=${encodeURIComponent(JSON.stringify(session))}`;
+/** ヘッダーに注入される認証まわりの DOM を最小限で再現する */
+function chrome() {
+  const guest = element({});
+  const authed = element({ hidden: '' });
+  const name = element({});
+  const loginLink = element({ 'data-login-link': '' });
+  const stampTab = element({ 'data-login-link': '' });
 
-vm.runInNewContext(source, {
-  URL,
-  Uint8Array,
-  TextDecoder,
-  atob,
-  document: {
-    cookie,
+  const document = {
+    cookie: '',
     readyState: 'complete',
-    querySelectorAll: () => [desktop, mobile],
-  },
-  location: { href: TEST_BROWSER_ORIGIN },
-});
+    addEventListener() {},
+    querySelector(selector) {
+      if (selector === '[data-auth-guest]') return guest;
+      if (selector === '[data-auth-user]') return authed;
+      if (selector === '[data-auth-name]') return name;
+      return null;
+    },
+    querySelectorAll(selector) {
+      if (selector === '[data-login-link]') return [loginLink, stampTab];
+      return [];
+    },
+  };
 
-assert.equal(desktop.textContent, 'スタンプ帳');
-assert.equal(desktop.href, 'https://pokefuta.com/');
-assert.equal(desktop.attributes['data-nav-target'], 'stamp');
-assert.equal(mobile.textContent, 'スタンプ帳');
-assert.equal(mobile.href, 'https://pokefuta.com/');
-assert.equal(mobile.attributes['data-nav-target'], 'stamp');
+  return { guest, authed, name, loginLink, stampTab, document };
+}
+
+function run(document) {
+  vm.runInNewContext(source, {
+    URL,
+    Uint8Array,
+    TextDecoder,
+    atob,
+    document,
+    location: { href: TEST_BROWSER_ORIGIN },
+  });
+}
+
+// ── ログイン中: 表示名のピルに切り替わる ───────────────────
+{
+  const dom = chrome();
+  const session = {
+    user: {
+      id: 'user-1',
+      email: 'fallback@example.com',
+      user_metadata: { display_name: 'たこトレーナー' },
+    },
+  };
+  dom.document.cookie = `sb-kbwzwgsjqvflgfauzcpn-auth-token=${encodeURIComponent(JSON.stringify(session))}`;
+  run(dom.document);
+
+  assert.equal(dom.name.textContent, 'たこトレーナー');
+  assert.equal(dom.authed.hidden, false, 'ログイン中は認証ピルを出す');
+  assert.equal(dom.guest.hidden, true, 'ログイン中はログイン/新規登録を隠す');
+  // ログイン中はナビ項目のラベルを書き換えない（認証とナビを分離した）
+  assert.equal(dom.stampTab.textContent, '');
+  assert.equal(dom.stampTab.href, LOGIN_URL);
+}
+
+// ── display_name が無ければメールのローカル部を使う ────────
+{
+  const dom = chrome();
+  const session = { user: { id: 'user-2', email: 'takoyaki@example.com' } };
+  dom.document.cookie = `sb-kbwzwgsjqvflgfauzcpn-auth-token=${encodeURIComponent(JSON.stringify(session))}`;
+  run(dom.document);
+
+  assert.equal(dom.name.textContent, 'takoyaki');
+}
+
+// ── 未ログイン: 戻り先を redirect に積む ────────────────────
+{
+  const dom = chrome();
+  run(dom.document);
+
+  assert.equal(dom.guest.hidden, false, '未ログインはログイン/新規登録を出す');
+  assert.equal(dom.authed.hidden, true, '未ログインは認証ピルを隠す');
+  for (const link of [dom.loginLink, dom.stampTab]) {
+    const url = new URL(link.href);
+    assert.equal(url.searchParams.get('redirect'), TEST_BROWSER_ORIGIN);
+  }
+}
+
+console.log('session-badge: すべてのケースが通過');

--- a/apps/web/assets/session-badge.test.js
+++ b/apps/web/assets/session-badge.test.js
@@ -111,10 +111,14 @@ function run(document) {
 
   assert.equal(dom.guest.hidden, false, '未ログインはログイン/新規登録を出す');
   assert.equal(dom.authed.hidden, true, '未ログインは認証ピルを隠す');
-  for (const link of [dom.loginLink, dom.stampTab]) {
-    const url = new URL(link.href);
-    assert.equal(url.searchParams.get('redirect'), TEST_BROWSER_ORIGIN);
-  }
+  // 認証ボタンは現在ページへ戻す
+  assert.equal(new URL(dom.loginLink.href).searchParams.get('redirect'), TEST_BROWSER_ORIGIN);
+  // ナビ項目は「本来行きたかった場所」へ。現在ページを積むと
+  // ログイン後に図鑑へ戻され、スタンプ帳へ行くのにもう一度タップが要る
+  assert.equal(
+    new URL(dom.stampTab.href).searchParams.get('redirect'),
+    'https://pokefuta.com/visits?from=data'
+  );
 }
 
 console.log('session-badge: すべてのケースが通過');

--- a/apps/web/assets/site-header.css
+++ b/apps/web/assets/site-header.css
@@ -1,74 +1,189 @@
-/* Shared site header, injected into every built HTML page.
-   pokefuta.com のヘッダーと同じ見た目に揃える:
-   - <1024px : pokefuta の Header.tsx（クリーム #FFF8EB / 紫ボーダー / sticky）
-   - >=1024px: pokefuta の PCTopNav（ベージュ #f4ecda / 茶ボーダー / 非sticky・ナビ左寄せ）
-   数値は pokefuta 側（html 14px 基準の Tailwind / inline style）の実測pxに合わせている。 */
-@import url('https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@700&display=swap');
+/* 全ページに注入されるサイト共通クロム（ヘッダー・下タブ・フッター）。
+   マークアップは apps/scraper/inject_site_header.py が持つ。
 
-:root { --site-header-height: 56px; }
+   ⚠️ 色・寸法の正は写真館側の
+      nishiokya/pokefuta の src/app/site-chrome-tokens.css
+   ここはその値をコピーしている。生の hex / px を足すのではなく、
+   まず向こうのトークンを直してからここへ写すこと。
+   （以前は「写真館の実測pxを書き写す」運用で、向こうを変えるたびに
+     こちらが取り残されていた）
+
+   レイアウト:
+     <1024px  クリームの sticky ヘッダー（ロゴ・サイト名・認証の3要素）＋ 画面下タブ
+     >=1024px ベージュのバー1本（スイッチャー・ナビ・Info/X・認証）
+
+   ブレークポイントは 1024px の1本だけ。以前あった 720px の段は、
+   640〜720px で写真館と挙動が食い違う原因だったので廃止した。 */
+@import url('https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@600;700;800&display=swap');
+
+:root {
+  /* ── ここから site-chrome-tokens.css のコピー ── */
+  --chrome-height: 56px;
+  --chrome-tap-min: 44px;
+
+  --chrome-sp-bg: rgba(255, 248, 235, .95);
+  --chrome-sp-border: rgba(123, 99, 168, .2);
+
+  --chrome-pc-bg: #f4ecda;
+  --chrome-pc-border: #e9dfc7;
+  --chrome-pc-nav: #6f6657;
+  --chrome-pc-nav-active: #2c2a26;
+  --chrome-pc-nav-active-bg: #e9dfc7;
+
+  --chrome-ink: #2a2a2a;
+  --chrome-ink-pc: #38414f;
+
+  --chrome-accent: #7b63a8;
+  --chrome-accent-soft: rgba(123, 99, 168, .1);
+  --chrome-accent-border: #d7d0ef;
+
+  --chrome-ball-red: #e85046;
+
+  --chrome-radius-nav: 9px;
+  --chrome-radius-pill: 999px;
+
+  --chrome-z-header: 50;
+  --chrome-z-bottomnav: 40;
+  /* ── コピーここまで ── */
+
+  /* 図鑑側だけが持つ値（下タブは写真館では Tailwind 側にある） */
+  --chrome-bottomnav-height: 62px;
+
+  /* 全画面地図が参照する旧名。既存ページの互換のため残す */
+  --site-header-height: var(--chrome-height);
+}
 
 body.has-site-header {
-  padding-top: 0;
   overflow-x: hidden;
   overflow-x: clip;
+  /* 下タブぶんの余白。地図ページは別途 height を計算するので影響しない */
+  padding-bottom: calc(var(--chrome-bottomnav-height) + env(safe-area-inset-bottom));
 }
+
+/* 下タブは border-top 1px ぶん高さがずれると全画面地図の計算が合わなくなるので、
+   コンテナ自身も border-box にする */
+.site-header,
+.site-header *,
+.site-header *::before,
+.site-header *::after,
+.site-tabs,
+.site-tabs *,
+.site-footer,
+.site-footer * {
+  box-sizing: border-box;
+}
+
+/* ─────────────────────────────────────────
+   ヘッダー
+   ───────────────────────────────────────── */
 
 .site-header {
   position: sticky;
   top: 0;
-  z-index: 10000;
+  z-index: var(--chrome-z-header);
   width: 100vw;
   margin-inline: calc(50% - 50vw);
   flex: 0 0 auto;
-  background: rgba(255, 248, 235, .95);
+  background: var(--chrome-sp-bg);
   -webkit-backdrop-filter: blur(8px);
   backdrop-filter: blur(8px);
-  border-bottom: 1px solid rgba(123, 99, 168, .2);
-  color: #2a2a2a;
+  border-bottom: 1px solid var(--chrome-sp-border);
+  color: var(--chrome-ink);
   font-family: "M PLUS Rounded 1c", "Noto Sans JP", system-ui, -apple-system, sans-serif;
   -webkit-font-smoothing: antialiased;
 }
 
-.site-header,
-.site-header *,
-.site-header *::before,
-.site-header *::after {
-  box-sizing: border-box;
-}
-
-/* min-height は border-bottom 1px を引いた値にして、
-   実際の描画高さを --site-header-height と一致させる */
+/* border-bottom 1px を引いて、描画高さを --chrome-height に一致させる */
 .site-header__inner {
   width: min(1008px, 100%);
-  min-height: 55px;
+  min-height: calc(var(--chrome-height) - 1px);
   margin: 0 auto;
-  padding: 10px 14px;
+  padding: 4px 12px;
   display: flex;
   align-items: center;
   gap: 8px;
 }
 
-.site-header__brand {
+/* ─── サイトスイッチャー（写真館 ⇄ 図鑑） ───
+   同じモンスターボールなのに別サイト、という状態を解消するための導線。
+   <details> なので JS 無しで開閉できる（外側クリックで閉じるのは
+   session-badge.js が面倒を見る）。 */
+
+.site-switch {
+  position: relative;
+  flex: 0 0 auto;
+}
+
+.site-switch__trigger {
   display: flex;
   align-items: center;
   gap: 7px;
-  flex: 0 0 auto;
-  color: #2a2a2a;
+  min-height: var(--chrome-tap-min);
+  padding: 0 8px 0 4px;
+  border-radius: var(--chrome-radius-nav);
+  color: var(--chrome-ink);
   font-weight: 700;
-  text-decoration: none;
   white-space: nowrap;
+  cursor: pointer;
+  list-style: none;
 }
 
-/* pokefuta と同じ純CSSのモンスターボールマーク */
+.site-switch__trigger::-webkit-details-marker { display: none; }
+
+.site-switch__trigger:hover,
+.site-switch__trigger:focus-visible {
+  background: var(--chrome-accent-soft);
+}
+
+.site-switch__caret {
+  width: 0;
+  height: 0;
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 5px solid currentColor;
+  opacity: .55;
+}
+
+.site-switch[open] .site-switch__caret { transform: rotate(180deg); }
+
+.site-switch__menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  min-width: 220px;
+  padding: 6px;
+  border: 1px solid var(--chrome-accent-border);
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: 0 12px 30px rgba(60, 45, 25, .18);
+}
+
+.site-switch__item {
+  display: block;
+  padding: 9px 10px;
+  border-radius: 8px;
+  color: var(--chrome-ink);
+  text-decoration: none;
+}
+
+.site-switch__item b { display: block; font-size: 14px; font-weight: 700; }
+.site-switch__item small { display: block; font-size: 11px; color: var(--chrome-pc-nav); }
+
+.site-switch__item:hover,
+.site-switch__item:focus-visible { background: var(--chrome-accent-soft); }
+.site-switch__item.is-current { background: var(--chrome-pc-nav-active-bg); }
+
+/* 純CSSのモンスターボール。SP でも消さないこと
+   （消すとサイト帯のブランドが SP だけ無くなる） */
 .site-header__mark {
   position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 32px;
-  height: 32px;
+  width: 30px;
+  height: 30px;
   flex-shrink: 0;
-  border: 2px solid #2a2a2a;
+  border: 2px solid var(--chrome-ink);
   border-radius: 50%;
   background: #fff;
   overflow: hidden;
@@ -78,7 +193,7 @@ body.has-site-header {
   content: "";
   position: absolute;
   inset: 0 0 50% 0;
-  background: #e85046;
+  background: var(--chrome-ball-red);
 }
 
 .site-header__mark::after {
@@ -88,7 +203,7 @@ body.has-site-header {
   left: 0;
   right: 0;
   height: 2px;
-  background: #2a2a2a;
+  background: var(--chrome-ink);
   transform: translateY(-50%);
 }
 
@@ -97,41 +212,29 @@ body.has-site-header {
   z-index: 1;
   width: 12px;
   height: 12px;
-  border: 2px solid #2a2a2a;
+  border: 2px solid var(--chrome-ink);
   border-radius: 50%;
   background: #fff;
 }
 
-.site-header__brand-name {
-  font-size: 16px;
-}
+.site-header__brand-name { font-size: 15px; }
+.site-header__brand-sep { margin: 0 4px; opacity: .45; font-weight: 600; }
 
-/* 現状テンプレートは brand-name のみでこのサブは未出力。再有効化時に
-   pokefuta のパープルと揃うよう色トークンだけ合わせておく。 */
-.site-header__brand-sub {
-  color: rgba(123, 99, 168, .55);
-  font-family: "IBM Plex Mono", "Courier New", monospace;
-  font-size: 9px;
-  letter-spacing: .18em;
-}
+/* ─── ナビ・アイコン（PC のみ） ─── */
 
-.site-header__nav {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  margin-left: auto;
-  min-width: 0;
+.site-header__nav,
+.site-header__icon {
+  display: none;
 }
 
 .site-header__link {
   display: inline-flex;
   align-items: center;
-  height: 35px;
-  padding: 0 10px;
-  border-radius: 999px;
-  color: #2a2a2a;
-  font-size: 12px;
-  font-weight: 700;
+  padding: 7px 13px;
+  border-radius: var(--chrome-radius-nav);
+  color: var(--chrome-pc-nav);
+  font-size: 13.5px;
+  font-weight: 600;
   line-height: 1.2;
   text-decoration: none;
   white-space: nowrap;
@@ -139,217 +242,281 @@ body.has-site-header {
 }
 
 .site-header__link:hover,
-.site-header__link:focus-visible {
-  background: rgba(123, 99, 168, .1);
-  color: #2a2a2a;
+.site-header__link:focus-visible,
+.site-header__link.is-active {
+  background: var(--chrome-pc-nav-active-bg);
+  color: var(--chrome-pc-nav-active);
   text-decoration: none;
 }
 
-.site-header__label--mobile {
-  display: none;
+/* ─── 認証 ───
+   未ログイン: 枠線[ログイン] + 塗り[新規登録]
+   ログイン中: アバター＋表示名のピル → pokefuta.com/profile
+   以前は「ログインボタンのラベルがスタンプ帳に化ける」実装だったが、
+   認証状態の表示とナビ項目は別物なので分離した。 */
+
+.site-auth {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+  flex: 0 0 auto;
 }
 
-/* ログイン系リンクは pokefuta の Header と同じ紫の枠線ボタン */
-.site-header__auth-link--desktop,
-.site-header__auth-link--mobile {
-  height: auto;
-  padding: 7px 12px;
-  border: 1px solid #7b63a8;
-  border-radius: 8px;
-  color: #7b63a8;
+.site-auth[hidden],
+.site-auth__user[hidden] { display: none; }
+
+.site-auth__login,
+.site-auth__signup {
+  display: inline-flex;
+  align-items: center;
+  min-height: var(--chrome-tap-min);
+  padding: 0 13px;
+  border-radius: var(--chrome-radius-pill);
+  font-size: 13px;
+  font-weight: 700;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.site-auth__login {
+  border: 1px solid var(--chrome-accent-border);
+  color: var(--chrome-accent);
+}
+
+.site-auth__signup {
+  background: var(--chrome-accent);
+  color: #fff;
+  box-shadow: 0 2px 0 #5f55b8;
+}
+
+.site-auth__login:hover,
+.site-auth__login:focus-visible {
+  background: var(--chrome-accent-soft);
+  color: var(--chrome-accent);
+  text-decoration: none;
+}
+
+.site-auth__user {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 9rem;
+  min-height: var(--chrome-tap-min);
+  margin-left: auto;
+  padding: 0 12px 0 4px;
+  border-radius: var(--chrome-radius-pill);
+  color: var(--chrome-ink);
+  font-size: 13px;
+  font-weight: 700;
+  text-decoration: none;
+  flex: 0 0 auto;
+}
+
+.site-auth__user:hover,
+.site-auth__user:focus-visible { background: var(--chrome-accent-soft); }
+
+.site-auth__avatar {
+  display: grid;
+  place-items: center;
+  width: 26px;
+  height: 26px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  background: #dfe7f3;
+  font-size: 13px;
+}
+
+.site-auth__name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ─────────────────────────────────────────
+   下タブ（SP のみ）
+   写真館の BottomNav と位置・高さ・アイコン言語を揃えている
+   ───────────────────────────────────────── */
+
+.site-tabs {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: var(--chrome-z-bottomnav);
+  display: flex;
+  align-items: stretch;
+  justify-content: space-around;
+  height: calc(var(--chrome-bottomnav-height) + env(safe-area-inset-bottom));
+  padding-bottom: env(safe-area-inset-bottom);
+  background: rgba(255, 248, 235, .96);
+  -webkit-backdrop-filter: blur(6px);
+  backdrop-filter: blur(6px);
+  border-top: 1px solid rgba(123, 99, 168, .18);
+  font-family: "M PLUS Rounded 1c", "Noto Sans JP", system-ui, sans-serif;
+}
+
+.site-tab {
+  display: flex;
+  flex: 1 1 0;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  min-width: 0;
+  min-height: var(--chrome-tap-min);
+  padding: 6px 2px;
+  color: #6b6b6b;
+  font-size: 11px;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.site-tab span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 100%;
+}
+
+.site-tab__icon { width: 22px; height: 22px; }
+
+.site-tab:hover,
+.site-tab:focus-visible { color: var(--chrome-accent); text-decoration: none; }
+
+.site-tab.is-active {
+  color: var(--chrome-accent);
+  background: var(--chrome-accent-soft);
+  border-radius: var(--chrome-radius-nav);
+}
+
+/* ─────────────────────────────────────────
+   フッター（SP のみ）
+   SP ヘッダーから外した Info・X・キャラ蓋 の受け皿
+   ───────────────────────────────────────── */
+
+.site-footer {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 4px 14px;
+  padding: 16px 12px 20px;
+  border-top: 1px solid var(--chrome-sp-border);
+  font-family: "M PLUS Rounded 1c", "Noto Sans JP", system-ui, sans-serif;
+}
+
+.site-footer__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-height: var(--chrome-tap-min);
+  padding: 0 6px;
+  color: var(--chrome-pc-nav);
   font-size: 12px;
   font-weight: 700;
-}
-
-.site-header__auth-link--desktop:hover,
-.site-header__auth-link--desktop:focus-visible,
-.site-header__auth-link--mobile:hover,
-.site-header__auth-link--mobile:focus-visible {
-  background: rgba(123, 99, 168, .1);
-  color: #7b63a8;
   text-decoration: none;
 }
 
-.site-header__auth-link--mobile {
-  display: none;
-}
+.site-footer__link:hover,
+.site-footer__link:focus-visible { color: var(--chrome-accent); }
 
-@media (max-width: 720px) {
-  .site-header__inner {
-    padding: 10px 8px;
-    gap: 4px;
-  }
+/* ─────────────────────────────────────────
+   PC（>=1024px）: ベージュのバー1本にする
+   ───────────────────────────────────────── */
 
-  .site-header__brand {
-    flex: 0 0 auto;
-    gap: 0;
-  }
-
-  .site-header__mark {
-    display: none;
-  }
-
-  .site-header__brand-name {
-    font-size: 14px;
-    letter-spacing: -.03em;
-  }
-
-  .site-header__nav {
-    flex: 1 1 auto;
-    justify-content: flex-end;
-    gap: 1px;
-    min-width: 0;
-    margin-left: 0;
-  }
-
-  .site-header__link {
-    display: inline-flex;
-    height: 32px;
-    padding: 0 4px;
-    font-size: 11px;
-    line-height: 32px;
-    text-align: center;
-  }
-
-  .site-header__label--desktop {
-    display: none;
-  }
-
-  .site-header__label--mobile {
-    display: inline;
-  }
-
-  .site-header__auth-link--desktop {
-    display: none;
-  }
-
-  .site-header__auth-link--mobile {
-    display: inline-flex;
-    height: auto;
-    padding: 6px 8px;
-    border: 1px solid #7b63a8;
-    border-radius: 8px;
-    background: transparent;
-    color: #7b63a8;
-    font-size: 11px;
-    line-height: 1.4;
-    font-weight: 700;
-  }
-}
-
-@media (max-width: 360px) {
-  .site-header__inner {
-    padding-inline: 6px;
-    gap: 2px;
-  }
-
-  .site-header__brand-name {
-    font-size: 13px;
-    letter-spacing: -.05em;
-  }
-
-  .site-header__nav {
-    gap: 0;
-  }
-
-  .site-header__link {
-    padding-inline: 3px;
-    font-size: 10px;
-  }
-
-  .site-header__auth-link--mobile {
-    padding-inline: 7px;
-    font-size: 10px;
-  }
-}
-
-/* PC は pokefuta の PCTopNav と同じベージュのバーに切り替える */
 @media (min-width: 1024px) {
-  :root { --site-header-height: 57px; }
+  :root { --chrome-bottomnav-height: 0px; }
+
+  body.has-site-header { padding-bottom: 0; }
 
   .site-header {
     position: relative;
-    background: #f4ecda;
+    background: var(--chrome-pc-bg);
     -webkit-backdrop-filter: none;
     backdrop-filter: none;
-    border-bottom-color: #e9dfc7;
+    border-bottom-color: var(--chrome-pc-border);
   }
 
   .site-header__inner {
     width: 100%;
-    min-height: 56px;
-    padding: 14px 32px;
+    padding: 4px 32px;
     gap: 14px;
   }
 
-  .site-header__mark {
-    width: 28px;
-    height: 28px;
-  }
-
-  .site-header__mark-core {
-    width: 10px;
-    height: 10px;
-  }
-
-  .site-header__brand {
-    gap: 8px;
-    color: #38414f;
-  }
-
+  .site-switch__trigger { color: var(--chrome-ink-pc); }
   .site-header__brand-name { font-size: 18px; }
 
   .site-header__nav {
-    flex: 1 1 auto;
-    justify-content: flex-start;
+    display: flex;
+    align-items: center;
     gap: 4px;
-    margin-left: 18px;
+    margin-left: 4px;
+    min-width: 0;
   }
 
-  .site-header__link {
-    height: auto;
-    padding: 7px 13px;
-    border-radius: 9px;
-    color: #6f6657;
-    font-size: 13.5px;
-    font-weight: 600;
+  .site-header__icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    flex-shrink: 0;
+    border-radius: var(--chrome-radius-pill);
+    color: var(--chrome-pc-nav);
+    text-decoration: none;
   }
 
-  .site-header__link:hover,
-  .site-header__link:focus-visible {
-    background: #e9dfc7;
-    color: #2c2a26;
-  }
+  /* Info は nav とアイコン群のあいだで右に寄せる */
+  .site-header__icon:first-of-type { margin-left: auto; }
 
-  /* PC のログインは PCTopNav と同じ淡紫枠の丸ピルで右端に寄せる */
-  .site-header__auth-link--desktop {
-    margin-left: auto;
-    padding: 6px 14px;
-    border: 1px solid #d7d0ef;
-    border-radius: 999px;
-    color: #7b63a8;
-    font-size: 13px;
-    font-weight: 600;
-  }
+  .site-header__icon svg { width: 18px; height: 18px; }
+  .site-header__icon--x { font-size: 15px; font-weight: 900; }
 
-  .site-header__auth-link--desktop:hover,
-  .site-header__auth-link--desktop:focus-visible {
-    background: rgba(123, 99, 168, .1);
-    color: #7b63a8;
-  }
+  .site-header__icon:hover,
+  .site-header__icon:focus-visible { background: var(--chrome-pc-nav-active-bg); }
+
+  /* アイコンが margin-left:auto を持つので、認証側は詰めるだけでよい */
+  .site-auth,
+  .site-auth__user { margin-left: 0; }
+
+  .site-auth__user { color: var(--chrome-pc-nav); }
+
+  .site-tabs,
+  .site-footer { display: none; }
 }
 
-/* Full-screen maps must reserve room for the shared header. */
+/* 極小幅では文字を詰める。要素数が3つなので 360px でも破綻しない */
+@media (max-width: 360px) {
+  .site-header__inner { padding-inline: 8px; gap: 4px; }
+  .site-header__brand-name { font-size: 14px; }
+  .site-auth__login,
+  .site-auth__signup { padding-inline: 10px; font-size: 12px; }
+}
+
+/* ─────────────────────────────────────────
+   全画面地図はヘッダーと下タブのぶんを引く
+   ───────────────────────────────────────── */
+
 body.has-site-header.pokefuta-map-page .map-stage,
 body.has-site-header > #map {
-  height: calc(100dvh - var(--site-header-height, 56px));
-  min-height: calc(100dvh - var(--site-header-height, 56px));
+  height: calc(100dvh - var(--chrome-height) - var(--chrome-bottomnav-height) - env(safe-area-inset-bottom));
+  min-height: calc(100dvh - var(--chrome-height) - var(--chrome-bottomnav-height) - env(safe-area-inset-bottom));
 }
 
-@media (max-width: 720px) {
-  body.has-site-header.pokefuta-map-page .map-stage,
-  body.has-site-header > #map {
-    height: calc(100dvh - var(--site-header-height));
-    min-height: calc(100dvh - var(--site-header-height));
-  }
+/* 地図ページは本文がビューポート固定（overflow:hidden）なので、
+   下タブぶんの padding は不要。フッターも表示領域に出ないので隠す */
+body.has-site-header.pokefuta-map-page { padding-bottom: 0; }
+body.has-site-header.pokefuta-map-page .site-footer { display: none; }
+
+/* 地図ページのボトムシート `#controls` は position:fixed / z-index:1000 / bottom:0 で、
+   そのままだと下タブを覆い隠す。ページ側の CSS（pokefuta-map.css）は触らず、
+   共通クロム側にスコープして打ち消す。
+   - 下タブは必ずシートより上に出す（サイト共通の導線なので最前面）
+   - シートは下タブのぶんだけ底上げし、最大高もその分減らす */
+body.has-site-header.pokefuta-map-page .site-tabs { z-index: 1100; }
+
+body.has-site-header.pokefuta-map-page #controls {
+  bottom: calc(var(--chrome-bottomnav-height) + env(safe-area-inset-bottom));
+  max-height: calc(78vh - var(--chrome-bottomnav-height));
 }

--- a/apps/web/assets/site-header.css
+++ b/apps/web/assets/site-header.css
@@ -516,6 +516,11 @@ body.has-site-header.pokefuta-map-page .site-footer { display: none; }
    - シートは下タブのぶんだけ底上げし、最大高もその分減らす */
 body.has-site-header.pokefuta-map-page .site-tabs { z-index: 1100; }
 
+/* ヘッダーも同様。全画面地図には z-index 800〜1000 のオーバーレイ
+   （.map-hero-card / #controls）があり、共通の z-index 50 のままだと
+   サイトスイッチャーのメニューがヒーローカードの下に潜って押せなくなる。 */
+body.has-site-header.pokefuta-map-page .site-header { z-index: 1100; }
+
 body.has-site-header.pokefuta-map-page #controls {
   bottom: calc(var(--chrome-bottomnav-height) + env(safe-area-inset-bottom));
   max-height: calc(78vh - var(--chrome-bottomnav-height));

--- a/apps/web/assets/site-header.css
+++ b/apps/web/assets/site-header.css
@@ -173,6 +173,28 @@ body.has-site-header {
 .site-switch__item:focus-visible { background: var(--chrome-accent-soft); }
 .site-switch__item.is-current { background: var(--chrome-pc-nav-active-bg); }
 
+/* 全画面地図はフッターに到達できないので、フッターと同じ導線をここにも置く */
+.site-switch__sep {
+  margin: 6px 4px;
+  border: 0;
+  border-top: 1px solid var(--chrome-accent-border);
+}
+
+.site-switch__sub {
+  display: flex;
+  align-items: center;
+  min-height: var(--chrome-tap-min);
+  padding: 0 10px;
+  border-radius: 8px;
+  color: var(--chrome-pc-nav);
+  font-size: 13px;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.site-switch__sub:hover,
+.site-switch__sub:focus-visible { background: var(--chrome-accent-soft); text-decoration: none; }
+
 /* 純CSSのモンスターボール。SP でも消さないこと
    （消すとサイト帯のブランドが SP だけ無くなる） */
 .site-header__mark {
@@ -521,7 +543,19 @@ body.has-site-header.pokefuta-map-page .site-tabs { z-index: 1100; }
    サイトスイッチャーのメニューがヒーローカードの下に潜って押せなくなる。 */
 body.has-site-header.pokefuta-map-page .site-header { z-index: 1100; }
 
-body.has-site-header.pokefuta-map-page #controls {
-  bottom: calc(var(--chrome-bottomnav-height) + env(safe-area-inset-bottom));
-  max-height: calc(78vh - var(--chrome-bottomnav-height));
+/* ⚠️ 760px 未満に限定すること。
+   pokefuta-map.css は @media (min-width: 760px) でシートを画面右上の
+   フローティングパネル（bottom:auto / top:32px / max-height:calc(100dvh - 64px)）に
+   切り替える。無条件に打ち消すとPCでシートが画面下に固定され、最大高も 78vh に縮む。
+   ここは「シートが下端に張り付いている幅」だけを対象にする。 */
+@media (max-width: 759.98px) {
+  body.has-site-header.pokefuta-map-page #controls {
+    bottom: calc(var(--chrome-bottomnav-height) + env(safe-area-inset-bottom));
+    max-height: calc(78vh - var(--chrome-bottomnav-height));
+  }
+
+  /* 展開時は 88vh が正。上のルールのほうが詳細度が高いので個別に引き直す */
+  body.has-site-header.pokefuta-map-page.sheet-expanded #controls {
+    max-height: calc(88vh - var(--chrome-bottomnav-height));
+  }
 }


### PR DESCRIPTION
2026-08-08 の両サイトUX統一方針の **ステップ4〜7（図鑑側）**。写真館側は nishiokya/pokefuta#199。方針の全文は Obsidian「2026-08-08 pokefuta 両サイト共通ヘッダーUX統一方針」。

## 何を直したか

SP のヘッダーに5項目を詰め込み、**タップ領域を32px・文字11px（≤360pxで10px）まで潰していた**のを解体する。あわせて写真館との構造差（ブレークポイント・認証表現・アクティブ表現・相互リンクの非対称）を揃える。

## 変更点

- **SP ヘッダーを「ロゴ / サイト名 / 認証」の3要素に絞り、タップ領域を44px以上**に。ナビは画面下のタブへ、Info・X・キャラ蓋は本文末尾のフッターへ逃がした
- **SP でボールマークを消していたのをやめた**（SPだけサイト帯のブランドが無くなるため）
- **ブレークポイントを 1024px の1本に統一。** 720px の段は 640〜720px で写真館と挙動が食い違う原因だった
- **下タブを全ページに注入**（地図 / ポケモン / 集計 / スタンプ帳→写真館）。写真館の `BottomNav` と位置・高さ・アイコン言語（lucide 0.294系の字形を inline SVG で複製）を揃えた
- **サイトスイッチャー `ポケふた ｜ 図鑑 ▾` を追加。** 図鑑側に写真館への導線が無く相互リンクが片方向だったのを解消する。`<details>` なので JS 無しで開閉でき、外側クリック／Esc での閉じだけ `session-badge.js` が面倒を見る
- **現在地のアクティブ表現を追加**（これまで図鑑には一切無かった）
- **認証UIを写真館と同じに。** 未ログインは[ログイン][新規登録]、ログイン中はアバター＋表示名 → `/profile`。**「ログインボタンがスタンプ帳に化ける」実装を廃止**した（認証状態の表示とナビ項目は別物で、紫枠＝認証CTAの見た目のままナビ項目になっていた）。cookie 直読みでネットワークを叩かない方針はそのまま維持
- 色・寸法を `:root` のトークンに集約し、**直書きを検知する `test_site_header_css.py` を追加**（ブレークポイント・タップ領域・SPのボール表示・地図の高さ計算も固定）

## レビューで見てほしい点

**全画面地図のボトムシートとの重なり。** `pokefuta-map.css` の `#controls` は `position:fixed / z-index:1000 / bottom:0` で、そのままだと下タブを覆い隠します（実際に踏みました）。ページ側 CSS は触らず、`body.has-site-header.pokefuta-map-page` 配下にスコープして `site-header.css` から打ち消しています。この打ち消し方でよいか。

**下タブから外した「キャラ蓋」の置き場所。** 4枠が 地図/ポケモン/集計/スタンプ帳 で埋まるため、SP ではフッターに置きました。LP 新設（#362）直後なので流入を落とさない置き方か確認してほしいです。

## 確認したこと

- `test_inject_site_header.py`（16件に拡充）/ 新規 `test_site_header_css.py` / `session-badge.test.js` すべて通過
- `apps/scraper` 全体は 268件中 4 failures + 1 error。**いずれも `main` でも同じ**（`test_generate_summary_pages` の既知の失敗と `test_update_pokefuta` の import エラー）で、本PRで増えた16件はすべて通過
- ローカルで dist を作って注入し、SP(390px) / SP(360px) / PC(1440px) の実画面を確認。スイッチャーの開閉、アクティブ表現、地図ページの高さ計算、360px での横あふれ無しを確認済み

## ⚠️ このPRに入れられなかったもの

`.github/workflows/pages-deploy.yml` に**共通クロムのテスト実行ステップを足す変更**（CLAUDE.md のバッチ規約「ワークフローからスクリプトを呼ぶなら対応するテストも同じワークフローで走らせる」）を用意しましたが、**CLI の OAuth トークンに `workflow` スコープが無く push できません**でした。別途手で当てる必要があります。

```yaml
      # Install Japanese fonts の直後に追加
      - name: Test shared site chrome
        run: |
          python3 -m unittest apps.scraper.test_inject_site_header apps.scraper.test_site_header_css
          node apps/web/assets/session-badge.test.js
```

## 後続

写真館側のサイトスイッチャー（ステップ6の残り半分）は #199 マージ後に別PRで出します。`PcTopNav` に TODO コメントを置いてあります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)